### PR TITLE
added rbac manifests generation pkg and CLI

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package main
 
 import (
@@ -26,6 +25,35 @@ import (
 )
 
 func main() {
+
+	rootCmd := &cobra.Command{
+		Use:   "controller-gen",
+		Short: "A reference implementation generation tool for Kubernetes APIs.",
+		Long:  `A reference implementation generation tool for Kubernetes APIs.`,
+		Example: `	# Generate RBAC manifests for a project
+	controller-gen rbac
+	
+	# Generate CRD manifests for a project
+	controller-gen crd 
+
+	# Run all the generators for a given project
+	controller-gen all
+`,
+	}
+
+	// add RBAC manifests generator as subcommand
+	rootCmd.AddCommand(
+		newRBACCmd(),
+		newAllSubCmd(),
+	)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func newRBACCmd() *cobra.Command {
 	o := &rbac.ManifestOptions{}
 	cmd := &cobra.Command{
 		Use:   "rbac",
@@ -42,17 +70,25 @@ Usage:
 		},
 	}
 
-	registerFlags(cmd, o)
-
-	if err := cmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
-func registerFlags(cmd *cobra.Command, o *rbac.ManifestOptions) {
 	f := cmd.Flags()
 	f.StringVar(&o.Name, "name", "manager", "Name to be used as prefix in identifier for manifests")
 	f.StringVar(&o.InputDir, "input-dir", "./pkg", "input directory pointing to Go source files")
 	f.StringVar(&o.OutputDir, "output-dir", "./config", "output directory where generated manifests will be saved.")
+
+	return cmd
+}
+
+func newAllSubCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "all",
+		Short: "runs all generators for a project",
+		Long: `Run all available generators for a given project
+Usage:
+# controller-gen all
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO(droot): fill in all the generators
+		},
+	}
+	return cmd
 }

--- a/cmd/rbac/main.go
+++ b/cmd/rbac/main.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-tools/pkg/generate/rbac"
+)
+
+func main() {
+	o := &rbac.ManifestOptions{}
+	cmd := &cobra.Command{
+		Use:   "rbac",
+		Short: "Generates RBAC manifests",
+		Long: `Generate RBAC manifests from the RBAC annotations in Go source files.
+Usage:
+# rbac generate [--name manager] [--input-dir input_dir] [--output-dir output_dir]
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := rbac.Generate(o); err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("RBAC manifests generated under '%s' directory\n", o.OutputDir)
+		},
+	}
+
+	registerFlags(cmd, o)
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func registerFlags(cmd *cobra.Command, o *rbac.ManifestOptions) {
+	f := cmd.Flags()
+	f.StringVar(&o.Name, "name", "manager", "Name to be used as prefix in identifier for manifests")
+	f.StringVar(&o.InputDir, "input-dir", "./pkg", "input directory pointing to Go source files")
+	f.StringVar(&o.OutputDir, "output-dir", "./config", "output directory where generated manifests will be saved.")
+}

--- a/pkg/generate/rbac/manifests.go
+++ b/pkg/generate/rbac/manifests.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ManifestOptions represent options for generating the RBAC manifests.
+type ManifestOptions struct {
+	InputDir  string
+	OutputDir string
+	Name      string
+	Labels    map[string]string
+}
+
+// Validate validates the input options.
+func (o *ManifestOptions) Validate() error {
+	if _, err := os.Stat(o.InputDir); err != nil {
+		return fmt.Errorf("invalid input directory '%s' %v", o.InputDir, err)
+	}
+	if _, err := os.Stat(o.OutputDir); err != nil {
+		return fmt.Errorf("invalid output directory '%s' %v", o.OutputDir, err)
+	}
+	return nil
+}
+
+// Generate generates RBAC manifests by parsing the RBAC annotations in Go source
+// files specified in the input directory.
+func Generate(o *ManifestOptions) error {
+	if err := o.Validate(); err != nil {
+		return err
+	}
+
+	rules, err := ParseDir(o.InputDir)
+	if err != nil {
+		return fmt.Errorf("failed to parse the input dir %v", err)
+	}
+	if len(rules) == 0 {
+		return nil
+	}
+	roleManifest, err := getClusterRoleManifest(rules, o)
+	if err != nil {
+		return fmt.Errorf("failed to generate role manifest %v", err)
+	}
+
+	roleBindingManifest, err := getClusterRoleBindingManifest(o)
+	if err != nil {
+		return fmt.Errorf("failed to generate role binding manifests %v", err)
+	}
+
+	roleManifestFile := filepath.Join(o.OutputDir, "rbac_role.yaml")
+	if err := ioutil.WriteFile(roleManifestFile, roleManifest, 0666); err != nil {
+		return fmt.Errorf("failed to write role manifest YAML file %v", err)
+	}
+
+	roleBindingManifestFile := filepath.Join(o.OutputDir, "rbac_role_binding.yaml")
+	if err := ioutil.WriteFile(roleBindingManifestFile, roleBindingManifest, 0666); err != nil {
+		return fmt.Errorf("failed to write role manifest YAML file %v", err)
+	}
+	return nil
+}
+
+func getClusterRoleManifest(rules []rbacv1.PolicyRule, o *ManifestOptions) ([]byte, error) {
+	role := rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterRole",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   o.Name + "-role",
+			Labels: o.Labels,
+		},
+		Rules: rules,
+	}
+	return yaml.Marshal(role)
+}
+
+func getClusterRoleBindingManifest(o *ManifestOptions) ([]byte, error) {
+	rolebinding := &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s-rolebinding", o.Name),
+			Labels: o.Labels,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Name:      "default",
+				Namespace: fmt.Sprintf("%v-system", o.Name),
+				Kind:      "ServiceAccount",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name:     fmt.Sprintf("%v-role", o.Name),
+			Kind:     "ClusterRole",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+	return yaml.Marshal(rolebinding)
+}

--- a/pkg/generate/rbac/parser.go
+++ b/pkg/generate/rbac/parser.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rbac contain libraries for generating RBAC manifests from RBAC
+// annotations in Go source files.
+package rbac
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// ParseDir parses the Go files under given directory and parses the RBAC
+// annotations in to RBAC rules.
+// TODO(droot): extend it to multiple dirs
+func ParseDir(dir string) ([]rbacv1.PolicyRule, error) {
+	var rbacRules []rbacv1.PolicyRule
+	fset := token.NewFileSet()
+
+	err := filepath.Walk(dir,
+		func(path string, info os.FileInfo, err error) error {
+			if !isGoFile(info) {
+				// TODO(droot): enable this output based on verbose flag
+				// fmt.Println("skipping non-go file", path)
+				return nil
+			}
+			rules, err := parseFile(fset, path, nil)
+			if err == nil {
+				rbacRules = append(rbacRules, rules...)
+			}
+			return err
+		})
+	return rbacRules, err
+}
+
+// filter function to ignore files from parsing.
+func isGoFile(f os.FileInfo) bool {
+	// ignore non-Go or Go test files
+	name := f.Name()
+	return !f.IsDir() &&
+		!strings.HasPrefix(name, ".") &&
+		!strings.HasSuffix(name, "_test.go") &&
+		strings.HasSuffix(name, ".go")
+}
+
+// parseFile parses given filename or content src and parses RBAC annotations
+// into RBAC rules.
+func parseFile(fset *token.FileSet, filename string, src interface{}) ([]rbacv1.PolicyRule, error) {
+	var rules []rbacv1.PolicyRule
+
+	f, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	// using commentMaps here because it sanitizes the comment text by removing
+	// comment markers, compresses newlines etc.
+	cmap := ast.NewCommentMap(fset, f, f.Comments)
+
+	for _, commentGroup := range cmap.Comments() {
+		for _, comment := range strings.Split(commentGroup.Text(), "\n") {
+			comment := strings.TrimSpace(comment)
+			if strings.HasPrefix(comment, "+rbac") {
+				if ann := getAnnotation(comment, "rbac"); ann != "" {
+					rules = append(rules, parseRBACTag(ann))
+				}
+			}
+			if strings.HasPrefix(comment, "+kubebuilder:rbac") {
+				if ann := getAnnotation(comment, "kubebuilder:rbac"); ann != "" {
+					rules = append(rules, parseRBACTag(ann))
+				}
+			}
+		}
+	}
+	return rules, nil
+}
+
+// getAnnotation extracts the RBAC annotation from comment text. It will return
+// "foo" for comment "+rbac:foo" .
+func getAnnotation(c, name string) string {
+	prefix := fmt.Sprintf("+%s:", name)
+	if strings.HasPrefix(c, prefix) {
+		return strings.TrimPrefix(c, prefix)
+	}
+	return ""
+}
+
+// parseRBACTag parses the given RBAC annotation in to an RBAC PolicyRule.
+// This is copied from Kubebuilder code.
+func parseRBACTag(tag string) rbacv1.PolicyRule {
+	result := rbacv1.PolicyRule{}
+	for _, elem := range strings.Split(tag, ",") {
+		key, value, err := parseKV(elem)
+		if err != nil {
+			log.Fatalf("// +kubebuilder:rbac: tags must be key value pairs.  Expected "+
+				"keys [groups=<group1;group2>,resources=<resource1;resource2>,verbs=<verb1;verb2>] "+
+				"Got string: [%s]", tag)
+		}
+		values := strings.Split(value, ";")
+		switch key {
+		case "groups":
+			normalized := []string{}
+			for _, v := range values {
+				if v == "core" {
+					normalized = append(normalized, "")
+				} else {
+					normalized = append(normalized, v)
+				}
+			}
+			result.APIGroups = normalized
+		case "resources":
+			result.Resources = values
+		case "verbs":
+			result.Verbs = values
+		case "urls":
+			result.NonResourceURLs = values
+		}
+	}
+	return result
+}
+
+func parseKV(s string) (key, value string, err error) {
+	kv := strings.Split(s, "=")
+	if len(kv) != 2 {
+		err = fmt.Errorf("invalid key value pair")
+		return key, value, err
+	}
+	key, value = kv[0], kv[1]
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		value = value[1 : len(value)-1]
+	}
+	return key, value, err
+}

--- a/pkg/generate/rbac/parser_test.go
+++ b/pkg/generate/rbac/parser_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"go/token"
+	"reflect"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestParseFile(t *testing.T) {
+	tests := []struct {
+		content string
+		exp     []rbacv1.PolicyRule
+	}{
+		{
+			content: `package foo
+	import (
+		"fmt"
+		"time"
+	)
+
+	// RBAC annotation with kubebuilder prefix
+	// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;delete
+	// bar function
+	func bar() {
+		fmt.Println(time.Now())
+	}`,
+			exp: []rbacv1.PolicyRule{{
+				Verbs:     []string{"get", "list", "watch", "delete"},
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+			}},
+		},
+		{
+			content: `package foo
+	import (
+		"fmt"
+		"time"
+	)
+
+	// RBAC annotation without kuebuilder prefix
+	// +rbac:groups=apps,resources=deployments,verbs=get;list;watch;delete
+	// bar function
+	func bar() {
+		fmt.Println(time.Now())
+	}`,
+			exp: []rbacv1.PolicyRule{{
+				Verbs:     []string{"get", "list", "watch", "delete"},
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+			}},
+		},
+		{
+			content: `package foo
+	import (
+		"fmt"
+		"time"
+	)
+
+	// RBAC annotation with kubebuilder prefix
+	// +kubebuilder:rbac:groups=,resources=pods,verbs=get;list;watch;delete
+	// bar function
+	func bar() {
+		fmt.Println(time.Now())
+	}`,
+			exp: []rbacv1.PolicyRule{{
+				Verbs:     []string{"get", "list", "watch", "delete"},
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+			}},
+		},
+		{
+			content: `package foo
+	import (
+		"fmt"
+		"time"
+	)
+
+	// RBAC annotation with kubebuilder prefix
+	// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
+	// bar function
+	func bar() {
+		fmt.Println(time.Now())
+	}`,
+			exp: []rbacv1.PolicyRule{{
+				Verbs:     []string{"get", "list", "watch", "delete"},
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		fset := token.NewFileSet()
+		got, err := parseFile(fset, "test.go", test.content)
+		if err != nil {
+			t.Errorf("processFile should have succeeded, but got error: %v", err)
+		}
+		if !reflect.DeepEqual(got, test.exp) {
+			t.Errorf("RBAC rules should have matched, expected %v and got %v", test.exp, got)
+		}
+	}
+}


### PR DESCRIPTION
Note: need feedback specifically about the pkg and command's location. 

Added `rbac` new commandline tool and `rbac` pkg under `pkg/generate/rbac` for generating RBAC manifests.  It scans the Go source files under given input-dir and parses the RBAC annotations and generates the RBAC manifests. The annotations could be anywhere in the Go files not necessarily tied to a Type or Function (Thats one reason `gengo` wasn't useful). Parser uses `Go` standard packages (ast, parser) instead of `gengo` because requirements were very simple. 

Realized that we will have to generate RBAC annotations while scaffolding the resources so that this tool can generate RBAC manifests. 

