### PR TITLE
controller-gen: added rbac generation

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -25,7 +25,6 @@ import (
 )
 
 func main() {
-
 	rootCmd := &cobra.Command{
 		Use:   "controller-gen",
 		Short: "A reference implementation generation tool for Kubernetes APIs.",
@@ -55,6 +54,8 @@ func main() {
 
 func newRBACCmd() *cobra.Command {
 	o := &rbac.ManifestOptions{}
+	o.SetDefaults()
+
 	cmd := &cobra.Command{
 		Use:   "rbac",
 		Short: "Generates RBAC manifests",
@@ -71,9 +72,9 @@ Usage:
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&o.Name, "name", "manager", "Name to be used as prefix in identifier for manifests")
-	f.StringVar(&o.InputDir, "input-dir", "./pkg", "input directory pointing to Go source files")
-	f.StringVar(&o.OutputDir, "output-dir", "./config", "output directory where generated manifests will be saved.")
+	f.StringVar(&o.Name, "name", o.Name, "Name to be used as prefix in identifier for manifests")
+	f.StringVar(&o.InputDir, "input-dir", o.InputDir, "input directory pointing to Go source files")
+	f.StringVar(&o.OutputDir, "output-dir", o.OutputDir, "output directory where generated manifests will be saved.")
 
 	return cmd
 }
@@ -87,8 +88,40 @@ Usage:
 # controller-gen all
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			// TODO(droot): fill in all the generators
+			// load default project for populating generator options
+			// TODO: uncomment the following while enabling CRD
+			// projectFile, err := loadProjectFile()
+			// if err != nil {
+			// 	log.Fatal(err)
+			// }
+
+			// RBAC generation
+			rbacOptions := &rbac.ManifestOptions{}
+			rbacOptions.SetDefaults()
+			if err := rbac.Generate(rbacOptions); err != nil {
+				log.Fatal(err)
+			}
+			fmt.Printf("RBAC manifests generated under '%s' directory\n", rbacOptions.OutputDir)
+
+			// Plug-in CRD generation
 		},
 	}
 	return cmd
 }
+
+// func loadProjectFile() (*input.ProjectFile, error) {
+// 	// Load the PROJECT file for default options
+// 	if _, err := os.Stat("PROJECT"); os.IsNotExist(err) {
+// 		return nil, fmt.Errorf("%s file missing", "PROJECT")
+// 	}
+// 	content, err := ioutil.ReadFile("PROJECT")
+// 	if err != nil {
+// 		return nil, fmt.Errorf("Error reading '%s' file %v", "PROJECT", err)
+// 	}
+// 	projectFile := input.ProjectFile{}
+// 	err = yaml.Unmarshal(content, &projectFile)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("Error loading '%s' file %v", "PROJECT", err)
+// 	}
+// 	return &projectFile, nil
+// }

--- a/pkg/generate/rbac/manifests.go
+++ b/pkg/generate/rbac/manifests.go
@@ -35,13 +35,17 @@ type ManifestOptions struct {
 	Labels    map[string]string
 }
 
+// SetDefaults sets up the default options for RBAC Manifest generator.
+func (o *ManifestOptions) SetDefaults() {
+	o.Name = "manager"
+	o.InputDir = filepath.Join(".", "pkg")
+	o.OutputDir = filepath.Join(".", "config", "rbac")
+}
+
 // Validate validates the input options.
 func (o *ManifestOptions) Validate() error {
 	if _, err := os.Stat(o.InputDir); err != nil {
 		return fmt.Errorf("invalid input directory '%s' %v", o.InputDir, err)
-	}
-	if _, err := os.Stat(o.OutputDir); err != nil {
-		return fmt.Errorf("invalid output directory '%s' %v", o.OutputDir, err)
 	}
 	return nil
 }
@@ -70,6 +74,10 @@ func Generate(o *ManifestOptions) error {
 		return fmt.Errorf("failed to generate role binding manifests %v", err)
 	}
 
+	err = os.MkdirAll(o.OutputDir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create output dir %v", err)
+	}
 	roleManifestFile := filepath.Join(o.OutputDir, "rbac_role.yaml")
 	if err := ioutil.WriteFile(roleManifestFile, roleManifest, 0666); err != nil {
 		return fmt.Errorf("failed to write role manifest YAML file %v", err)


### PR DESCRIPTION
enabled `rbac` generation in `controller-gen all` run. 

Will be using this command to generate rbac/crd manifests using `go generate` directive in the generated project.