### PR TITLE
fixed api-group and resource field in RBAC annotation

### DIFF
--- a/test/config/rbac/rbac_role.yaml
+++ b/test/config/rbac/rbac_role.yaml
@@ -17,7 +17,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - crew
+  - crew.k8s.io
   resources:
   - firstmates
   verbs:
@@ -29,7 +29,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - ship
+  - ship.k8s.io
   resources:
   - frigates
   verbs:
@@ -41,7 +41,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - creatures
+  - creatures.k8s.io
   resources:
   - krakens
   verbs:

--- a/test/pkg/controller/firstmate/firstmate_controller.go
+++ b/test/pkg/controller/firstmate/firstmate_controller.go
@@ -94,8 +94,8 @@ type ReconcileFirstMate struct {
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=crew,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=crew.k8s.io,resources=firstmates,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileFirstMate) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the FirstMate instance
 	instance := &crewv1.FirstMate{}

--- a/test/pkg/controller/frigate/frigate_controller.go
+++ b/test/pkg/controller/frigate/frigate_controller.go
@@ -87,7 +87,7 @@ type ReconcileFrigate struct {
 // and what is in the Frigate.Spec
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
-// +kubebuilder:rbac:groups=ship,resources=frigates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ship.k8s.io,resources=frigates,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileFrigate) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Frigate instance
 	instance := &shipv1beta1.Frigate{}

--- a/test/pkg/controller/kraken/kraken_controller.go
+++ b/test/pkg/controller/kraken/kraken_controller.go
@@ -87,7 +87,7 @@ type ReconcileKraken struct {
 // and what is in the Kraken.Spec
 // TODO(user): Modify this Reconcile function to implement your Controller logic.  The scaffolding writes
 // a Deployment as an example
-// +kubebuilder:rbac:groups=creatures,resources=krakens,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=creatures.k8s.io,resources=krakens,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileKraken) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Kraken instance
 	instance := &creaturesv2alpha1.Kraken{}


### PR DESCRIPTION
Found this bug during testing today where RBAC manifests for CRD types didn't include fully qualified api-group-name (with domain suffix etc.) and also discovered `resources` were not being pluralized properly.