### PR TITLE
Use compatible sed

### DIFF
--- a/pkg/scaffold/project/makefile.go
+++ b/pkg/scaffold/project/makefile.go
@@ -95,7 +95,7 @@ generate:
 docker-build: test
 	docker build . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
-	sed -i 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
+	sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
 
 # Push the docker image
 docker-push:

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,7 +45,7 @@ generate:
 docker-build: test
 	docker build . -t ${IMG}
 	@echo "updating kustomize image patch file for manager resource"
-	sed -i 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
+	sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
 
 # Push the docker image
 docker-push:


### PR DESCRIPTION
because `sed -i <script>` doesn't work on OS X.

see https://github.com/kubernetes-sigs/kubebuilder/issues/348