### PR TITLE
Fix format of OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,8 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
 
 aliases:
-  - controller-tools-admins:
+  controller-tools-admins:
     - directxman12
     - droot
     - pwittrock
-  - controller-tools-maintainers:
+  controller-tools-maintainers:


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/controller-tools/issues/59

/assign pwittrock 