### PR TITLE
Feature: support scale sub resource by tag in controller-tools

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -11,6 +11,11 @@ spec:
     kind: Toy
     plural: toys
   scope: Namespaced
+  subresources:
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -59,6 +64,9 @@ spec:
               - 3
               format: int64
               type: integer
+            replicas:
+              format: int32
+              type: integer
             template:
               type: object
             winner:
@@ -66,8 +74,15 @@ spec:
           required:
           - rank
           - template
+          - replicas
           type: object
         status:
+          properties:
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - replicas
           type: object
       type: object
   version: v1alpha1

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -49,12 +49,15 @@ type ToySpec struct {
 
 	Template v1.PodTemplateSpec       `json:"template"`
 	Claim    v1.PersistentVolumeClaim `json:"claim,omitempty"`
+
+	Replicas *int32 `json:"replicas"`
 }
 
 // ToyStatus defines the observed state of Toy
 type ToyStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	Replicas int32 `json:"replicas"`
 }
 
 // +genclient
@@ -62,6 +65,8 @@ type ToyStatus struct {
 
 // Toy is the Schema for the toys API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/internal/codegen/parse/util_test.go
+++ b/pkg/internal/codegen/parse/util_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parse
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"k8s.io/gengo/types"
+)
+
+func TestParseScaleParams(t *testing.T) {
+	testCases := []struct {
+		name     string
+		tag      string
+		expected map[string]string
+		parseErr error
+	}{
+		{
+			name: "test ok",
+			tag:  "+kubebuilder:subresource:scale:specpath=.spec.replica,statuspath=.status.replica,selectorpath=.spec.Label",
+			expected: map[string]string{
+				specReplicasPath:   ".spec.replica",
+				statusReplicasPath: ".status.replica",
+				labelSelectorPath:  ".spec.Label",
+			},
+			parseErr: nil,
+		},
+		{
+			name: "test ok without selectorpath",
+			tag:  "+kubebuilder:subresource:scale:specpath=.spec.replica,statuspath=.status.replica",
+			expected: map[string]string{
+				specReplicasPath:   ".spec.replica",
+				statusReplicasPath: ".status.replica",
+			},
+			parseErr: nil,
+		},
+		{
+			name: "test ok selectorpath has empty value",
+			tag:  "+kubebuilder:subresource:scale:specpath=.spec.replica,statuspath=.status.replica,selectorpath=",
+			expected: map[string]string{
+				specReplicasPath:   ".spec.replica",
+				statusReplicasPath: ".status.replica",
+				labelSelectorPath:  "",
+			},
+			parseErr: nil,
+		},
+		{
+			name:     "test no jsonpath",
+			tag:      "+kubebuilder:subresource:scale",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+		{
+			name:     "test no specpath",
+			tag:      "+kubebuilder:subresource:scale:statuspath=.status.replica,selectorpath=.jsonpath",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+		{
+			name:     "test no statuspath",
+			tag:      "+kubebuilder:subresource:scale:specpath=.spec.replica,selectorpath=.jsonpath",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+		{
+			name:     "test statuspath is empty string",
+			tag:      "+kubebuilder:subresource:scale:statuspath=,selectorpath=.jsonpath",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+		{
+			name:     "test scale jsonpath has incorrect separator",
+			tag:      "+kubebuilder:subresource:scale,specpath=.spec.replica,statuspath=.jsonpath,selectorpath=.jsonpath",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+		{
+			name:     "test scale jsonpath has extra separator",
+			tag:      "+kubebuilder:subresource:scale:specpath=.spec.replica,statuspath=.status.replicas,selectorpath=.jsonpath,",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+		{
+			name:     "test scale jsonpath has incorrect separator in-between key value pairs",
+			tag:      "+kubebuilder:subresource:scale:specpath=.spec.replica;statuspath=.jsonpath;selectorpath=.jsonpath",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+		{
+			name:     "test unsupported key value pairs",
+			tag:      "+kubebuilder:subresource:scale:name=test,specpath=.spec.replica,statuspath=.status.replicas,selectorpath=.jsonpath",
+			expected: nil,
+			parseErr: fmt.Errorf(jsonPathError),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		r := &types.Type{}
+		r.CommentLines = []string{tc.tag}
+		res, err := parseScaleParams(r)
+		if !reflect.DeepEqual(err, tc.parseErr) {
+			t.Errorf("test [%s] failed. error is (%v),\n but expected (%v)", tc.name, err, tc.parseErr)
+		}
+		if !reflect.DeepEqual(res, tc.expected) {
+			t.Errorf("test [%s] failed. result is (%v),\n but expected (%v)", tc.name, res, tc.expected)
+		}
+	}
+}

--- a/pkg/internal/codegen/types.go
+++ b/pkg/internal/codegen/types.go
@@ -171,8 +171,6 @@ type APIResource struct {
 	ValidationComments string
 	// DocAnnotation is a map of annotations by name for doc. e.g. warning, notes message
 	DocAnnotation map[string]string
-	// HasStatusSubresource indicates that the resource has a status subresource
-	HasStatusSubresource bool
 	// Categories is a list of categories the resource is part of.
 	Categories []string
 }


### PR DESCRIPTION
- Add Scale Subresource tag validation for parsing CRD.
- Usage to enable scale subresource in CRD:
   1) add tag close above Resource struct, like:
```golang
      // +kubebuilder:subresource:scale:specpath=.spec.replica,statuspath=.status.replica,selectorpath=.jsonpath
```

`specpath`, `statuspath`, `selectorpath` key values, represents for JSONPath of **SpecReplicasPath**,  **StatusReplicasPath**,  **LabelSelectorPath** separately.
`specpath` and `statuspath` must be provided. `selectorpath` is optional

   2) Modify corresponding Spec and Status struct in types.
   3) Modify types_test.go files accordingly.

https://github.com/kubernetes-sigs/kubebuilder/issues/303