### PR TITLE
gas linter has been renamed to gosec

### DIFF
--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -86,7 +86,7 @@ func (s *Scaffold) setFieldsAndValidate(t input.File) error {
 
 // GetProject reads the project file and deserializes it into a Project
 func getProject(path string) (input.ProjectFile, error) {
-	in, err := ioutil.ReadFile(path)
+	in, err := ioutil.ReadFile(path) // nolint: gosec
 	if err != nil {
 		return input.ProjectFile{}, err
 	}
@@ -100,7 +100,7 @@ func getProject(path string) (input.ProjectFile, error) {
 
 // GetBoilerplate reads the boilerplate file
 func getBoilerplate(path string) (string, error) {
-	b, err := ioutil.ReadFile(path)
+	b, err := ioutil.ReadFile(path) // nolint: gosec
 	return string(b), err
 }
 

--- a/test.sh
+++ b/test.sh
@@ -128,7 +128,7 @@ gometalinter.v2 --disable-all \
     --enable=errcheck \
     --enable=varcheck \
     --enable=goconst \
-    --enable=gas \
+    --enable=gosec \
     --enable=unparam \
     --enable=ineffassign \
     --enable=nakedret \


### PR DESCRIPTION
This PR is doing the same thing as https://github.com/kubernetes-sigs/controller-runtime/pull/126