### PR TITLE
Generate versioned crd runtime object

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -98,7 +98,7 @@ Usage:
 			if err := g.Do(); err != nil {
 				log.Fatal(err)
 			}
-			fmt.Printf("CRD files generated, files can be found under path %s.\n", g.OutputDir)
+			fmt.Printf("CRD files generated, files can be found under path %s\n", g.OutputDir)
 		},
 	}
 

--- a/pkg/crd/generator/crd.go
+++ b/pkg/crd/generator/crd.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"io"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"k8s.io/gengo/generator"
+	"k8s.io/gengo/types"
+	"sigs.k8s.io/controller-tools/pkg/internal/codegen"
+)
+
+type crdGenerator struct {
+	generator.DefaultGen
+	apiversion *codegen.APIVersion
+	apigroup   *codegen.APIGroup
+}
+
+var _ generator.Generator = &crdGenerator{}
+
+func (d *crdGenerator) Imports(c *generator.Context) []string {
+	imports := []string{
+		"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+		"metav1 \"k8s.io/apimachinery/pkg/apis/meta/v1\"",
+		"k8s.io/apimachinery/pkg/runtime",
+		"k8s.io/apimachinery/pkg/runtime/schema",
+	}
+	if d.apigroup.Pkg != nil {
+		imports = append(imports, d.apigroup.Pkg.Path)
+	}
+	return imports
+}
+
+func (d *crdGenerator) Finalize(context *generator.Context, w io.Writer) error {
+	temp := template.Must(template.New("crd-template").Parse(crdTemplate))
+	return temp.Execute(w, d.apiversion)
+}
+
+// generatorToPackage creates a new package from a generator and package name
+func generatorToPackage(pkg string, gen generator.Generator) generator.Package {
+	name := strings.Split(filepath.Base(pkg), ".")[0]
+	return &generator.DefaultPackage{
+		PackageName: name,
+		PackagePath: pkg,
+		HeaderText:  append(generatedGoHeader(), []byte("\n\n")...),
+		GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
+			return []generator.Generator{gen}
+		},
+		FilterFunc: func(c *generator.Context, t *types.Type) bool {
+			// Generators only see Types in the same package as the generator
+			return t.Name.Package == pkg
+		},
+	}
+}
+
+// generatedGoHeader returns the header to preprend to generated go files
+func generatedGoHeader() []byte {
+	cr, err := ioutil.ReadFile(filepath.Join("hack", "boilerplate.go.txt"))
+	if err != nil {
+		return []byte{}
+	}
+	return cr
+}
+
+// packages wraps a collection of generator.Packages
+type packages struct {
+	value generator.Packages
+}
+
+// add creates a new generator.Package from gen and adds it to the collection
+func (g *packages) add(pkg string, gen generator.Generator) {
+	g.value = append(g.value, generatorToPackage(pkg, gen))
+}
+
+var crdTemplate = `
+// CRD Generation
+func getFloat(f float64) *float64 {
+    return &f
+}
+
+func getInt(i int64) *int64 {
+    return &i
+}
+
+var (
+    {{ range $api := .Resources -}}
+    // {{.Kind}}CRD resource
+    {{.Kind}}CRD = v1beta1.CustomResourceDefinition{
+        ObjectMeta: metav1.ObjectMeta{
+            Name: "{{.Resource}}.{{.Group}}.{{.Domain}}",
+        },
+        Spec: v1beta1.CustomResourceDefinitionSpec {
+            Group: "{{.Group}}.{{.Domain}}",
+            Version: "{{.Version}}",
+            Names: v1beta1.CustomResourceDefinitionNames{
+                Kind: "{{.Kind}}",
+                Plural: "{{.Resource}}",
+                {{ if .ShortName -}}
+                ShortNames: []string{"{{.ShortName}}"},
+                {{ end -}}
+                {{ if .Categories -}}
+                Categories: []string{
+                {{ range .Categories -}}
+                    "{{ . }}",
+                {{ end -}}
+                },
+                {{ end -}}
+            },
+            {{ if .NonNamespaced -}}
+            Scope: "Cluster",
+            {{ else -}}
+            Scope: "Namespaced",
+            {{ end -}}
+            Validation: &v1beta1.CustomResourceValidation{
+                OpenAPIV3Schema: &{{.Validation}},
+            },
+            Subresources: &v1beta1.CustomResourceSubresources{
+                {{ if .HasStatusSubresource -}}
+                Status: &v1beta1.CustomResourceSubresourceStatus{},
+                {{ end -}}
+                {{ if .HasScaleSubresource -}}
+                Scale: &v1beta1.CustomResourceSubresourceScale{
+                    SpecReplicasPath: "{{ .CRD.Spec.Subresources.Scale.SpecReplicasPath }}",
+                    StatusReplicasPath: "{{ .CRD.Spec.Subresources.Scale.StatusReplicasPath }}",
+                    {{ if .CRD.Spec.Subresources.Scale.LabelSelectorPath -}}
+                    LabelSelectorPath: {{ .CRD.Spec.Subresources.Scale.LabelSelectorPath }},
+                    {{ end -}}
+                },
+                {{ end -}}
+            },
+        },
+    }
+    {{ end -}}
+)
+`

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -66,7 +66,7 @@ type ToyStatus struct {
 // Toy is the Schema for the toys API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/zz_generated_crd.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/zz_generated_crd.go
@@ -1,0 +1,143 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CRD Generation
+func getFloat(f float64) *float64 {
+	return &f
+}
+
+func getInt(i int64) *int64 {
+	return &i
+}
+
+var (
+	// ToyCRD resource
+	ToyCRD = v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "toys.fun.myk8s.io",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group:   "fun.myk8s.io",
+			Version: "v1alpha1",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Kind:   "Toy",
+				Plural: "toys",
+			},
+			Scope: "Namespaced",
+			Validation: &v1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"apiVersion": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"kind": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"metadata": v1beta1.JSONSchemaProps{
+							Type: "object",
+						},
+						"spec": v1beta1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{
+								"alias": v1beta1.JSONSchemaProps{
+									Type: "string",
+									Enum: []v1beta1.JSON{v1beta1.JSON{Raw: []byte{34, 76, 105, 111, 110, 34}}, v1beta1.JSON{Raw: []byte{34, 87, 111, 108, 102, 34}}, v1beta1.JSON{Raw: []byte{34, 68, 114, 97, 103, 111, 110, 34}}},
+								},
+								"bricks": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int32",
+								},
+								"claim": v1beta1.JSONSchemaProps{
+									Type:       "object",
+									Properties: map[string]v1beta1.JSONSchemaProps{},
+								},
+								"comment": v1beta1.JSONSchemaProps{
+									Type:   "string",
+									Format: "byte",
+								},
+								"knights": v1beta1.JSONSchemaProps{
+									Type:     "array",
+									MaxItems: getInt(500),
+									MinItems: getInt(1),
+									Items: &v1beta1.JSONSchemaPropsOrArray{
+										Schema: &v1beta1.JSONSchemaProps{
+											Type: "string",
+										},
+									},
+								},
+								"name": v1beta1.JSONSchemaProps{
+									Type:      "string",
+									MaxLength: getInt(15),
+									MinLength: getInt(1),
+								},
+								"power": v1beta1.JSONSchemaProps{
+									Maximum:          getFloat(100),
+									Minimum:          getFloat(1),
+									ExclusiveMinimum: true,
+									Type:             "number",
+									Format:           "float",
+								},
+								"rank": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int64",
+									Enum:   []v1beta1.JSON{v1beta1.JSON{Raw: []byte{49}}, v1beta1.JSON{Raw: []byte{50}}, v1beta1.JSON{Raw: []byte{51}}},
+								},
+								"replicas": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int32",
+								},
+								"template": v1beta1.JSONSchemaProps{
+									Type:       "object",
+									Properties: map[string]v1beta1.JSONSchemaProps{},
+								},
+								"winner": v1beta1.JSONSchemaProps{
+									Type: "boolean",
+								},
+							},
+							Required: []string{
+								"rank",
+								"template",
+								"replicas",
+							}},
+						"status": v1beta1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{
+								"replicas": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int32",
+								},
+							},
+							Required: []string{
+								"replicas",
+							}},
+					},
+				},
+			},
+			Subresources: &v1beta1.CustomResourceSubresources{
+				Status: &v1beta1.CustomResourceSubresourceStatus{},
+				Scale: &v1beta1.CustomResourceSubresourceScale{
+					SpecReplicasPath:   ".spec.replicas",
+					StatusReplicasPath: ".status.replicas",
+				},
+			},
+		},
+	}
+)

--- a/pkg/crd/generator/testData/test/zz_generated_crd.go
+++ b/pkg/crd/generator/testData/test/zz_generated_crd.go
@@ -1,0 +1,143 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CRD Generation
+func getFloat(f float64) *float64 {
+	return &f
+}
+
+func getInt(i int64) *int64 {
+	return &i
+}
+
+var (
+	// ToyCRD resource
+	ToyCRD = v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "toys.fun.myk8s.io",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group:   "fun.myk8s.io",
+			Version: "v1alpha1",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Kind:   "Toy",
+				Plural: "toys",
+			},
+			Scope: "Namespaced",
+			Validation: &v1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"apiVersion": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"kind": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"metadata": v1beta1.JSONSchemaProps{
+							Type: "object",
+						},
+						"spec": v1beta1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{
+								"alias": v1beta1.JSONSchemaProps{
+									Type: "string",
+									Enum: []v1beta1.JSON{v1beta1.JSON{Raw: []byte{34, 76, 105, 111, 110, 34}}, v1beta1.JSON{Raw: []byte{34, 87, 111, 108, 102, 34}}, v1beta1.JSON{Raw: []byte{34, 68, 114, 97, 103, 111, 110, 34}}},
+								},
+								"bricks": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int32",
+								},
+								"claim": v1beta1.JSONSchemaProps{
+									Type:       "object",
+									Properties: map[string]v1beta1.JSONSchemaProps{},
+								},
+								"comment": v1beta1.JSONSchemaProps{
+									Type:   "string",
+									Format: "byte",
+								},
+								"knights": v1beta1.JSONSchemaProps{
+									Type:     "array",
+									MaxItems: getInt(500),
+									MinItems: getInt(1),
+									Items: &v1beta1.JSONSchemaPropsOrArray{
+										Schema: &v1beta1.JSONSchemaProps{
+											Type: "string",
+										},
+									},
+								},
+								"name": v1beta1.JSONSchemaProps{
+									Type:      "string",
+									MaxLength: getInt(15),
+									MinLength: getInt(1),
+								},
+								"power": v1beta1.JSONSchemaProps{
+									Maximum:          getFloat(100),
+									Minimum:          getFloat(1),
+									ExclusiveMinimum: true,
+									Type:             "number",
+									Format:           "float",
+								},
+								"rank": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int64",
+									Enum:   []v1beta1.JSON{v1beta1.JSON{Raw: []byte{49}}, v1beta1.JSON{Raw: []byte{50}}, v1beta1.JSON{Raw: []byte{51}}},
+								},
+								"replicas": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int32",
+								},
+								"template": v1beta1.JSONSchemaProps{
+									Type:       "object",
+									Properties: map[string]v1beta1.JSONSchemaProps{},
+								},
+								"winner": v1beta1.JSONSchemaProps{
+									Type: "boolean",
+								},
+							},
+							Required: []string{
+								"rank",
+								"template",
+								"replicas",
+							}},
+						"status": v1beta1.JSONSchemaProps{
+							Type: "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{
+								"replicas": v1beta1.JSONSchemaProps{
+									Type:   "integer",
+									Format: "int32",
+								},
+							},
+							Required: []string{
+								"replicas",
+							}},
+					},
+				},
+			},
+			Subresources: &v1beta1.CustomResourceSubresources{
+				Status: &v1beta1.CustomResourceSubresourceStatus{},
+				Scale: &v1beta1.CustomResourceSubresourceScale{
+					SpecReplicasPath:   ".spec.replicas",
+					StatusReplicasPath: ".status.replicas",
+				},
+			},
+		},
+	}
+)

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -91,6 +91,7 @@ func (b *APIs) parseCRDs() {
 							resource.CRD.Spec.Subresources = &v1beta1.CustomResourceSubresources{}
 						}
 						resource.CRD.Spec.Subresources.Status = &v1beta1.CustomResourceSubresourceStatus{}
+						resource.HasStatusSubresource = true
 					}
 
 					resource.CRD.Status.Conditions = []v1beta1.CustomResourceDefinitionCondition{}
@@ -112,6 +113,7 @@ func (b *APIs) parseCRDs() {
 						if ok && labelSelctor != "" {
 							resource.CRD.Spec.Subresources.Scale.LabelSelectorPath = &labelSelctor
 						}
+						resource.HasScaleSubresource = true
 					}
 
 					if len(resource.ShortName) > 0 {

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -321,7 +321,7 @@ func parseByteValue(b []byte) string {
 // parseEnumToString returns a representive validated go format string from JSONSchemaProps schema
 func parseEnumToString(value []v1beta1.JSON) string {
 	res := "[]v1beta1.JSON{"
-	prefix := "v1beta1.JSON{[]byte{"
+	prefix := "v1beta1.JSON{Raw:[]byte{"
 	for _, v := range value {
 		res = res + prefix + parseByteValue(v.Raw) + "}},"
 	}
@@ -369,9 +369,6 @@ func parseScaleParams(t *types.Type) (map[string]string, error) {
 			path := strings.Split(paths, ",")
 			if len(path) < 2 {
 				return nil, fmt.Errorf(jsonPathError)
-			}
-			for _, s := range path {
-				fmt.Printf("\n[debug] %s", s)
 			}
 			for _, s := range path {
 				kv := strings.Split(s, "=")

--- a/pkg/internal/codegen/types.go
+++ b/pkg/internal/codegen/types.go
@@ -161,9 +161,10 @@ type APIResource struct {
 	// Strategy is name of the struct to use for the strategy
 	StatusStrategy string
 	// NonNamespaced indicates that the resource kind is non namespaced
-	NonNamespaced bool
-
-	ShortName string
+	NonNamespaced        bool
+	HasStatusSubresource bool
+	HasScaleSubresource  bool
+	ShortName            string
 
 	JSONSchemaProps    v1beta1.JSONSchemaProps
 	CRD                v1beta1.CustomResourceDefinition

--- a/test/pkg/apis/creatures/v2alpha1/zz_generated_crd.go
+++ b/test/pkg/apis/creatures/v2alpha1/zz_generated_crd.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2alpha1
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CRD Generation
+// func getFloat(f float64) *float64 {
+// 	return &f
+// }
+
+// func getInt(i int64) *int64 {
+// 	return &i
+// }
+
+var (
+	// KrakenCRD resource
+	KrakenCRD = v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "krakens.creatures.testproject.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group:   "creatures.testproject.org",
+			Version: "v2alpha1",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Kind:   "Kraken",
+				Plural: "krakens",
+			},
+			Scope: "Cluster",
+			Validation: &v1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"apiVersion": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"kind": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"metadata": v1beta1.JSONSchemaProps{
+							Type: "object",
+						},
+						"spec": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+						"status": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+					},
+				},
+			},
+			Subresources: &v1beta1.CustomResourceSubresources{},
+		},
+	}
+)

--- a/test/pkg/apis/crew/v1/zz_generated_crd.go
+++ b/test/pkg/apis/crew/v1/zz_generated_crd.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CRD Generation
+// func getFloat(f float64) *float64 {
+// 	return &f
+// }
+
+// func getInt(i int64) *int64 {
+// 	return &i
+// }
+
+var (
+	// FirstMateCRD resource
+	FirstMateCRD = v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "firstmates.crew.testproject.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group:   "crew.testproject.org",
+			Version: "v1",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Kind:   "FirstMate",
+				Plural: "firstmates",
+			},
+			Scope: "Namespaced",
+			Validation: &v1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"apiVersion": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"kind": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"metadata": v1beta1.JSONSchemaProps{
+							Type: "object",
+						},
+						"spec": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+						"status": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+					},
+				},
+			},
+			Subresources: &v1beta1.CustomResourceSubresources{},
+		},
+	}
+)

--- a/test/pkg/apis/policy/v1beta1/zz_generated_crd.go
+++ b/test/pkg/apis/policy/v1beta1/zz_generated_crd.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CRD Generation
+// func getFloat(f float64) *float64 {
+// 	return &f
+// }
+
+// func getInt(i int64) *int64 {
+// 	return &i
+// }
+
+var (
+	// HealthCheckPolicyCRD resource
+	HealthCheckPolicyCRD = v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "healthcheckpolicies.policy.testproject.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group:   "policy.testproject.org",
+			Version: "v1beta1",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Kind:   "HealthCheckPolicy",
+				Plural: "healthcheckpolicies",
+			},
+			Scope: "Cluster",
+			Validation: &v1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"apiVersion": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"kind": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"metadata": v1beta1.JSONSchemaProps{
+							Type: "object",
+						},
+						"spec": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+						"status": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+					},
+				},
+			},
+			Subresources: &v1beta1.CustomResourceSubresources{},
+		},
+	}
+)

--- a/test/pkg/apis/ship/v1beta1/zz_generated_crd.go
+++ b/test/pkg/apis/ship/v1beta1/zz_generated_crd.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CRD Generation
+// func getFloat(f float64) *float64 {
+// 	return &f
+// }
+
+// func getInt(i int64) *int64 {
+// 	return &i
+// }
+
+var (
+	// FrigateCRD resource
+	FrigateCRD = v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "frigates.ship.testproject.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group:   "ship.testproject.org",
+			Version: "v1beta1",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Kind:   "Frigate",
+				Plural: "frigates",
+			},
+			Scope: "Namespaced",
+			Validation: &v1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+					Properties: map[string]v1beta1.JSONSchemaProps{
+						"apiVersion": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"kind": v1beta1.JSONSchemaProps{
+							Type: "string",
+						},
+						"metadata": v1beta1.JSONSchemaProps{
+							Type: "object",
+						},
+						"spec": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+						"status": v1beta1.JSONSchemaProps{
+							Type:       "object",
+							Properties: map[string]v1beta1.JSONSchemaProps{},
+						},
+					},
+				},
+			},
+			Subresources: &v1beta1.CustomResourceSubresources{},
+		},
+	}
+)


### PR DESCRIPTION
This PR is for https://github.com/kubernetes-sigs/kubebuilder/issues/369

Adding an effort to `getCrds()` for generating a crd runtime object in  `zz_generated_crd.go` files in the same path of types.  This generation is default behavior. The auto generated crd runtime object can be exported and referred as external crd for controller.

Currently, support validation and sub resource.

Open to discussions 
