### PR TITLE
Revert "crd: add finalizers support in CRD generation"

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -2,9 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  finalizers:
-  - f1.example.com
-  - f2.example.com
   labels:
     controller-tools.k8s.io: "1.0"
   name: toys.fun.myk8s.io

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -67,7 +67,6 @@ type ToyStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=
-// +kubebuilder:finalizers=f1.example.com, f2.example.com
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -80,15 +80,10 @@ func (b *APIs) parseCRDs() {
 					}
 
 					if hasCategories(resource.Type) {
-						categories := splitNTrim(getCategoriesTag(resource.Type), ",")
+						categoriesTag := getCategoriesTag(resource.Type)
+						categories := strings.Split(categoriesTag, ",")
 						resource.CRD.Spec.Names.Categories = categories
 						resource.Categories = categories
-					}
-
-					finalizers := splitNTrim(getFinalizersTag(resource.Type), ",")
-					if len(finalizers) > 0 {
-						resource.CRD.ObjectMeta.Finalizers = finalizers
-						resource.Finalizers = finalizers
 					}
 
 					if hasStatusSubresource(resource.Type) {
@@ -574,17 +569,4 @@ func (b *APIs) getMembers(t *types.Type, found sets.String) (map[string]v1beta1.
 
 	defer found.Delete(t.Name.String())
 	return members, result, required
-}
-
-// splitNTrim slices given string s in to all substrings separated by sep and
-// returns a slice of substrings by trimming space and removing empty substrings.
-func splitNTrim(s, sep string) (result []string) {
-	l := strings.Split(s, sep)
-	for _, elem := range l {
-		elem = strings.TrimSpace(elem)
-		if len(elem) > 0 {
-			result = append(result, elem)
-		}
-	}
-	return
 }

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -295,12 +295,6 @@ func getCategoriesTag(c *types.Type) string {
 	return resource
 }
 
-// getFinalizersTag returns the value of the +kubebuilder:finalizers tags
-func getFinalizersTag(c *types.Type) string {
-	comments := Comments(c.CommentLines)
-	return comments.getTag("kubebuilder:finalizers", "=")
-}
-
 // getDocAnnotation parse annotations of "+kubebuilder:doc:" with tags of "warning" or "doc" for control generating doc config.
 // E.g. +kubebuilder:doc:warning=foo  +kubebuilder:doc:note=bar
 func getDocAnnotation(t *types.Type, tags ...string) map[string]string {
@@ -375,6 +369,9 @@ func parseScaleParams(t *types.Type) (map[string]string, error) {
 			path := strings.Split(paths, ",")
 			if len(path) < 2 {
 				return nil, fmt.Errorf(jsonPathError)
+			}
+			for _, s := range path {
+				fmt.Printf("\n[debug] %s", s)
 			}
 			for _, s := range path {
 				kv := strings.Split(s, "=")

--- a/pkg/internal/codegen/types.go
+++ b/pkg/internal/codegen/types.go
@@ -173,10 +173,6 @@ type APIResource struct {
 	DocAnnotation map[string]string
 	// Categories is a list of categories the resource is part of.
 	Categories []string
-
-	// Finalizers is a list of finalizers (pre-delete hooks) to be added to the
-	// resource
-	Finalizers []string
 }
 
 // APISubresource contains information of an API subresource.


### PR DESCRIPTION
Reverts kubernetes-sigs/controller-tools#82

I missread the docs at https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#finalizers thinking finalizers in the CR definitions are added to all the instances of that CR. While testing I figured out that isn't the case, so reverting this PR.

So each CR object needs to be initialized with set of finalizers (if required) in the controller or one can implement an admission webhook for the same. We will add the details in the kubebuilder book.