### PR TITLE
Add KubebuilderVersion to gopkg.toml template

### DIFF
--- a/pkg/scaffold/project/gopkg.go
+++ b/pkg/scaffold/project/gopkg.go
@@ -43,6 +43,9 @@ type GopkgToml struct {
 
 	// Stanzas are additional managed stanzas to add after the ManagedHeader
 	Stanzas []Stanza
+
+	// KubebuilderVersion is the kubebuilder version
+	KubebuilderVersion string
 }
 
 // Stanza is a single Gopkg.toml entry
@@ -146,11 +149,11 @@ name="{{ .Name }}"
 
 [[constraint]]
   name="sigs.k8s.io/controller-runtime"
-  version="v0.1.1"
+  version="{{ .KubebuilderVersion }}"
 
 [[constraint]]
   name="sigs.k8s.io/controller-tools"
-  version="v0.1.1"
+  version="{{ .KubebuilderVersion }}"
 
 # For dependency below: Refer to issue https://github.com/golang/dep/issues/1799
 [[override]]

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -24,11 +24,11 @@ required = [
 
 [[constraint]]
   name="sigs.k8s.io/controller-runtime"
-  version="v0.1.1"
+  version=""
 
 [[constraint]]
   name="sigs.k8s.io/controller-tools"
-  version="v0.1.1"
+  version=""
 
 # For dependency below: Refer to issue https://github.com/golang/dep/issues/1799
 [[override]]


### PR DESCRIPTION
First step to make the controller-runtime/controller-tools version softcoded.

Kubebuilder issue: kubernetes-sigs/kubebuilder/issues/419