### PR TITLE
Improve CRD Group handling in codegen

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -105,6 +105,7 @@ Usage:
 	f := cmd.Flags()
 	f.StringVar(&g.RootPath, "root-path", "", "working dir, must have PROJECT file under the path or parent path if domain not set")
 	f.StringVar(&g.OutputDir, "output-dir", "", "output directory, default to 'config/crds' under root path")
+	f.BoolVar(&g.NestedOutput, "nested", false, "nested output layout: group/version/kind.yaml")
 	f.StringVar(&g.Domain, "domain", "", "domain of the resources, will try to fetch it from PROJECT file if not specified")
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as cluster scoped if not set")
 	f.BoolVar(&g.SkipMapValidation, "skip-map-validation", true, "if set to true, skip generating OpenAPI validation schema for map type in CRD.")

--- a/cmd/crd/cmd/generate.go
+++ b/cmd/crd/cmd/generate.go
@@ -62,6 +62,7 @@ func GeneratorForFlags(f *flag.FlagSet) *crdgenerator.Generator {
 	g := &crdgenerator.Generator{}
 	f.StringVar(&g.RootPath, "root-path", "", "working dir, must have PROJECT file under the path or parent path if domain not set")
 	f.StringVar(&g.OutputDir, "output-dir", "", "output directory, default to 'config/crds' under root path")
+	f.BoolVar(&g.NestedOutput, "nested", false, "nested output layout: group/version/kind.yaml")
 	f.StringVar(&g.Domain, "domain", "", "domain of the resources, will try to fetch it from PROJECT file if not specified")
 	// TODO: Do we need this? Is there a possibility that a crd is namespace scoped?
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as root scoped if not set")


### PR DESCRIPTION
### Overview
This PR contains a few improvements to CRD group handling.

### Changes
#### Output Layout
Add support for nested output layout via command line `-nested` boolean flag, which allows emitting CRD files in a nested `group/version/kind.yaml` layout, vs default flat `group_version_kind.yaml`
- Tracking #94

#### Annotated Group Name
Currently, CRD group name is retrieved using `parent` directory to the versioned type, i.e. 
`./pkg/apis/foo/v1alpha1/bar.go` - results in the `groupName=foo`.

The main limitation of this approach, it is not allowing for more complicated group structure as reported in #81. For example: `./pkg/apis/foo/buz/v1alpha1/bar.go` - is not supported, and generate reports an error

To address this functionality issue, there are two changes:
- Add support for using comment type annotation for group name: `// +groupName=foo.bar`.
If the annotated group value is not provided - default to the original `parent` dir model.
- Allow nested groups under `apis` directory 

**Note***: both of these changes are additive and all original behavior is preserved and is a default functionality.

