### PR TITLE
Add support for the date type in +printcolumn

### DIFF
--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -453,7 +453,7 @@ func helperPrintColumn(parts string, comment string) (v1beta1.CustomResourceColu
 		case printColumnName:
 			config.Name = value
 		case printColumnType:
-			if value == "integer" || value == "number" || value == "string" || value == "boolean" {
+			if value == "integer" || value == "number" || value == "string" || value == "boolean" || value == "date" {
 				config.Type = value
 			} else {
 				return v1beta1.CustomResourceColumnDefinition{}, fmt.Errorf("invalid value for %s printcolumn", printColumnType)

--- a/pkg/internal/codegen/parse/util_test.go
+++ b/pkg/internal/codegen/parse/util_test.go
@@ -147,6 +147,18 @@ func TestParsePrintColumnParams(t *testing.T) {
 			parseErr: nil,
 		},
 		{
+			name: "age as date",
+			tag:  "+kubebuilder:printcolumn:name=age,type=date,JSONPath=.metadata.creationTimestamp",
+			expected: []v1beta1.CustomResourceColumnDefinition{
+				{
+					Name:     "age",
+					Type:     "date",
+					JSONPath: ".metadata.creationTimestamp",
+				},
+			},
+			parseErr: nil,
+		},
+		{
 			name: "Minimum Three parameters",
 			tag:  "+kubebuilder:printcolumn:name=toy,type=string,JSONPath=.status.conditions[?(@.type==\"Ready\")].status",
 			expected: []v1beta1.CustomResourceColumnDefinition{


### PR DESCRIPTION
While not part of the OpenAPI spec, "date" is the type used by the
defaulted field "age" to present a relative value (e.g 4h ago).

The full list of allowable types exists at https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go#L38