### PR TITLE
add support for resource fields to accept name with underscore and hyphen

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -52,7 +52,7 @@ spec:
               - Wolf
               - Dragon
               type: string
-            bricks:
+            bricks-test:
               format: int32
               type: integer
             claim:
@@ -70,7 +70,7 @@ spec:
               maxLength: 15
               minLength: 1
               type: string
-            power:
+            power_test:
               exclusiveMinimum: true
               format: float
               maximum: 100

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -31,8 +31,8 @@ type ToySpec struct {
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:ExclusiveMinimum=true
-	Power  float32 `json:"power,omitempty"`
-	Bricks int32   `json:"bricks,omitempty"`
+	Power  float32 `json:"power_test,omitempty"`
+	Bricks int32   `json:"bricks-test,omitempty"`
 	// +kubebuilder:validation:MaxLength=15
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name,omitempty"`

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -189,7 +189,7 @@ func (b *APIs) typeToJSONSchemaProps(t *types.Type, found sets.String, comments 
 	return v, s
 }
 
-var jsonRegex = regexp.MustCompile("json:\"([a-zA-Z,]+)\"")
+var jsonRegex = regexp.MustCompile("json:\"([a-zA-Z,_-]+)\"")
 
 type primitiveTemplateArgs struct {
 	v1beta1.JSONSchemaProps


### PR DESCRIPTION
Fix for this issue listed in the kubebuilder repo: https://github.com/kubernetes-sigs/kubebuilder/issues/490
I have also added support for `-` in case someone wants to specify it in the resource fields.