### PR TITLE
Include description in the OpenAPI schema under fields property

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -41,8 +41,14 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -86,9 +92,12 @@ spec:
               format: int64
               type: integer
             replicas:
+              description: This is a dummy comment. Just checking if the multi-line
+                comments are working or not.
               format: int32
               type: integer
             rook:
+              description: This is a newly added field. Using this for testing purpose.
               oneOf:
               - type: string
               - type: integer
@@ -105,6 +114,7 @@ spec:
         status:
           properties:
             replicas:
+              description: It tracks the number of replicas.
               format: int32
               type: integer
           required:

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -50,9 +50,12 @@ type ToySpec struct {
 
 	Template v1.PodTemplateSpec       `json:"template"`
 	Claim    v1.PersistentVolumeClaim `json:"claim,omitempty"`
-
+	//This is a dummy comment.
+	// Just checking if the multi-line comments are working or not.
 	Replicas *int32 `json:"replicas"`
 
+	// This is a newly added field.
+	// Using this for testing purpose.
 	Rook *intstr.IntOrString `json:"rook"`
 }
 
@@ -60,6 +63,8 @@ type ToySpec struct {
 type ToyStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+
+	// It tracks the number of replicas.
 	Replicas int32 `json:"replicas"`
 }
 

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -334,6 +334,18 @@ func parseByteValue(b []byte) string {
 	return elem
 }
 
+// parseDescription parse comments above each field in the type definition.
+func parseDescription(res []string) string {
+	var temp, data string
+	for _, comment := range res {
+		if !(strings.Contains(comment, "+kubebuilder") || strings.Contains(comment, "+optional")) {
+			temp += comment + " "
+			data = strings.TrimRight(temp, " ")
+		}
+	}
+	return data
+}
+
 // parseEnumToString returns a representive validated go format string from JSONSchemaProps schema
 func parseEnumToString(value []v1beta1.JSON) string {
 	res := "[]v1beta1.JSON{"


### PR DESCRIPTION
Fix #102 
List of assumptions while creating this PR.

1.  Not including `+kubebuilder` and `+optional` comments in the description.
2.  The `description` field will not be created if there are no comments above the field in the type definition.
