### PR TITLE
Handle "intstr.IntOrString" use case for the generated openAPI validation

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -88,6 +88,10 @@ spec:
             replicas:
               format: int32
               type: integer
+            rook:
+              oneOf:
+              - type: string
+              - type: integer
             template:
               type: object
             winner:
@@ -96,6 +100,7 @@ spec:
           - rank
           - template
           - replicas
+          - rook
           type: object
         status:
           properties:

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -51,6 +52,8 @@ type ToySpec struct {
 	Claim    v1.PersistentVolumeClaim `json:"claim,omitempty"`
 
 	Replicas *int32 `json:"replicas"`
+
+	Rook *intstr.IntOrString `json:"rook"`
 }
 
 // ToyStatus defines the observed state of Toy

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -149,6 +149,7 @@ func (b *APIs) typeToJSONSchemaProps(t *types.Type, found sets.String, comments 
 	time := types.Name{Name: "Time", Package: "k8s.io/apimachinery/pkg/apis/meta/v1"}
 	meta := types.Name{Name: "ObjectMeta", Package: "k8s.io/apimachinery/pkg/apis/meta/v1"}
 	unstructured := types.Name{Name: "Unstructured", Package: "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"}
+	intOrString := types.Name{Name: "IntOrString", Package: "k8s.io/apimachinery/pkg/util/intstr"}
 	switch t.Name {
 	case time:
 		return v1beta1.JSONSchemaProps{
@@ -162,6 +163,17 @@ func (b *APIs) typeToJSONSchemaProps(t *types.Type, found sets.String, comments 
 	case unstructured:
 		return v1beta1.JSONSchemaProps{
 			Type: "object",
+		}, b.objSchema()
+	case intOrString:
+		return v1beta1.JSONSchemaProps{
+			OneOf: []v1beta1.JSONSchemaProps{
+				{
+					Type: "string",
+				},
+				{
+					Type: "integer",
+				},
+			},
 		}, b.objSchema()
 	}
 


### PR DESCRIPTION
Fix https://github.com/kubernetes-sigs/kubebuilder/issues/442