### PR TITLE
:bug: Fix description generation to work for all types of fields

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -69,11 +69,17 @@ spec:
               format: byte
               type: string
             knights:
+              description: This is a comment on an array field.
               items:
                 type: string
               maxItems: 500
               minItems: 1
               type: array
+            location:
+              additionalProperties:
+                type: string
+              description: This is a comment on a map field.
+              type: object
             name:
               maxLength: 15
               minLength: 1
@@ -102,14 +108,17 @@ spec:
               - type: string
               - type: integer
             template:
+              description: This is a comment on an object field.
               type: object
             winner:
+              description: This is a comment on a boolean field.
               type: boolean
           required:
           - rank
           - template
           - replicas
           - rook
+          - location
           type: object
         status:
           properties:

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -32,24 +32,36 @@ type ToySpec struct {
 	// +kubebuilder:validation:Maximum=100
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:ExclusiveMinimum=true
-	Power  float32 `json:"power,omitempty"`
-	Bricks int32   `json:"bricks,omitempty"`
+	Power float32 `json:"power,omitempty"`
+
+	Bricks int32 `json:"bricks,omitempty"`
+
 	// +kubebuilder:validation:MaxLength=15
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name,omitempty"`
+
+	// This is a comment on an array field.
 	// +kubebuilder:validation:MaxItems=500
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:UniqueItems=false
 	Knights []string `json:"knights,omitempty"`
-	Winner  bool     `json:"winner,omitempty"`
+
+	// This is a comment on a boolean field.
+	Winner bool `json:"winner,omitempty"`
+
 	// +kubebuilder:validation:Enum=Lion,Wolf,Dragon
 	Alias string `json:"alias,omitempty"`
+
 	// +kubebuilder:validation:Enum=1,2,3
-	Rank    int    `json:"rank"`
+	Rank int `json:"rank"`
+
 	Comment []byte `json:"comment,omitempty"`
 
-	Template v1.PodTemplateSpec       `json:"template"`
-	Claim    v1.PersistentVolumeClaim `json:"claim,omitempty"`
+	// This is a comment on an object field.
+	Template v1.PodTemplateSpec `json:"template"`
+
+	Claim v1.PersistentVolumeClaim `json:"claim,omitempty"`
+
 	//This is a dummy comment.
 	// Just checking if the multi-line comments are working or not.
 	Replicas *int32 `json:"replicas"`
@@ -57,6 +69,9 @@ type ToySpec struct {
 	// This is a newly added field.
 	// Using this for testing purpose.
 	Rook *intstr.IntOrString `json:"rook"`
+
+	// This is a comment on a map field.
+	Location map[string]string `json:"location"`
 }
 
 // ToyStatus defines the observed state of Toy

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -336,14 +336,16 @@ func parseByteValue(b []byte) string {
 
 // parseDescription parse comments above each field in the type definition.
 func parseDescription(res []string) string {
-	var temp, data string
+	var temp strings.Builder
+	var desc string
 	for _, comment := range res {
 		if !(strings.Contains(comment, "+kubebuilder") || strings.Contains(comment, "+optional")) {
-			temp += comment + " "
-			data = strings.TrimRight(temp, " ")
+			temp.WriteString(comment)
+			temp.WriteString(" ")
+			desc = strings.TrimRight(temp.String(), " ")
 		}
 	}
-	return data
+	return desc
 }
 
 // parseEnumToString returns a representive validated go format string from JSONSchemaProps schema


### PR DESCRIPTION
-  What does this do, and why do we need it?
This PR fix the description field generation for all types of fields under `Openschema API`.
For more details, please go through this issue #116