### PR TITLE
Apply Modularized Annotation Pattern for kubebuilder (POC)

### DIFF
--- a/pkg/internal/annotation/doc.go
+++ b/pkg/internal/annotation/doc.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package annotation represents annotation module of controller-tool and kubebuilder.
+// It serves as a mechanism for parsing kubebuilder style annotations (e.g. starting with // +kubuilder)
+// and handling coresponding process.
+//
+// K8s
+// +k8s:deepcopy-gen=<VALUE>
+// +k8s:defaulter-gen=<VALUE>
+// +k8s:conversion-gen=<CONVERSION_TARGET_DIR>
+// +k8s:openapi-gen=true
+// +k8s:openapi-gen=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+//
+// Kubebuilder Annotation Examples:
+//
+// +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+// +kubebuilder:subresource:scale:specpath=<jsonpath>,statuspath=<jsonpath>,selectorpath=<jsonpath>
+// +kubebuilder:webhook:admission:groups=apps,resources=deployments,verbs=CREATE;UPDATE,name=bar-webhook,path=/bar,type=mutating,failure-policy=Fail
+// +kubebuilder:webhook:serveroption:port=7890,cert-dir=/tmp/test-cert,service=test-system|webhook-service,selector=app|webhook-server,secret=test-system|webhook-secret,mutating-webhook-config-name=test-mutating-webhook-cfg,validating-webhook-config-name=test-validating-webhook-cfg
+//
+// Annoation schema:
+// <header> : <module> : <parameter key values>
+// Generic Annotation Spec <https://github.com/kubernetes-sigs/kubebuilder/issues/554>
+package annotation

--- a/pkg/internal/annotation/parser.go
+++ b/pkg/internal/annotation/parser.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var (
+	ann  Annotation
+	once sync.Once
+)
+
+// GetAnnotation returns singleton of annotaiton
+func GetAnnotation() Annotation {
+	once.Do(func() {
+		ann = Build()
+		ann.Header("kubebuilder")
+	})
+	return ann
+}
+
+// ParseAnnotationByDir parses the Go files under given directory and parses the annotation by
+// invoking the Parse function on each comment group (multi-lines comments).
+func ParseAnnotationByDir(dir string, ann Annotation) error {
+	fset := token.NewFileSet()
+
+	err := filepath.Walk(dir,
+		func(path string, info os.FileInfo, err error) error {
+			if !isGoFile(info) {
+				return nil
+			}
+			return ParseAnnotationByFile(fset, path, nil, ann)
+		})
+	return err
+}
+
+// ParseAnnotationByFile parses given filename or content src and parses annotations by
+// invoking the parseFn function on each comment group (multi-lines comments).
+func ParseAnnotationByFile(fset *token.FileSet, path string, src interface{}, ann Annotation) error {
+	f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		fmt.Printf("error from parse.ParseFile: %v", err)
+		return err
+	}
+
+	// using commentMaps here because it sanitizes the comment text by removing
+	// comment markers, compresses newlines etc.
+	cmap := ast.NewCommentMap(fset, f, f.Comments)
+	for _, commentGroup := range cmap.Comments() {
+		err = ann.Parse(commentGroup.Text())
+		if err != nil {
+			fmt.Print("error when parsing annotation")
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/internal/annotation/types.go
+++ b/pkg/internal/annotation/types.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotation
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Annotation defines a generic spec of annotations
+// The schema is [header]:[module]:[submodule]:[key-value elements], submodule could be optional and multiple
+type Annotation interface {
+	Header(string)
+	Module(*Module)
+	HasModule(string) bool
+	GetModule(string) *Module
+	Parse(string) error
+}
+
+type defaultAnnotation struct {
+	Headers   sets.String
+	Modules   sets.String
+	ModuleMap map[string]*Module
+}
+
+func (a *defaultAnnotation) Header(header string) {
+	a.Headers.Insert(header)
+}
+
+func (a *defaultAnnotation) Module(m *Module) {
+	a.Modules.Insert(m.Name)
+	a.ModuleMap[m.Name] = m
+}
+
+func (a *defaultAnnotation) HasModule(name string) bool {
+	return a.Modules.Has(name)
+}
+
+func (a *defaultAnnotation) GetModule(name string) *Module {
+	for _, m := range a.ModuleMap {
+		if m.Name == name {
+			return m
+		}
+	}
+	return nil
+}
+
+// Parse takes single line comment and validates each token.
+func (a *defaultAnnotation) Parse(comments string) error {
+	for _, comment := range strings.Split(comments, "\n") {
+		comment = strings.TrimSpace(comment)
+		for k := range a.Headers.Union(a.Modules) {
+			if !strings.HasPrefix(comment, prefixName(k)) {
+				continue
+			}
+			// parsing sigle whole line of comment into tokens split by comma (1st level delimiter)
+			// This requires all key-values of same module/submodule should reside in the same comment line
+			tokens := strings.Split(strings.TrimPrefix(comment, "+"), ":")
+			if err := a.parseTokens(tokens); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Complete process annotaion string into Tokens
+func (a *defaultAnnotation) parseTokens(tokens []string) error {
+	if a.Headers.Has(tokens[0]) {
+		// competitable for annotations without header starting with "+[module]"
+		tokens = tokens[1:]
+	}
+	if a.Modules.Has(tokens[0]) {
+		return a.GetModule(tokens[0]).parseModule(tokens)
+	}
+	return fmt.Errorf("annotation %+v format error", tokens)
+}
+
+// Module defines functional feature for annotation. Header may contain multiple modules,
+// single module may contain submodules. Do() function defines what this module can do
+type Module struct {
+	Name       string
+	Meta       interface{}
+	SubModules map[string]*Module
+	Do         func(string) error
+}
+
+// HasSubModule verify if given token string is a valid subresource
+func (m *Module) HasSubModule(name string) bool {
+	for _, v := range m.SubModules {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Module) parseModule(tokens []string) error {
+	if len(tokens) == 1 {
+		return m.Do(tokens[0])
+	}
+	// [module]:[submodule]:[element-values]
+	if len(tokens) > 2 {
+		s := tokens[1]
+		if !m.HasSubModule(s) {
+			return fmt.Errorf("annotation (%s) format error, has incorrect submodule %s", tokens, s)
+		}
+		return m.SubModules[s].parseModule(tokens[1:])
+	}
+	return m.Do(tokens[1])
+}
+
+// Build returns initialized default annotation
+func Build() Annotation {
+	return &defaultAnnotation{
+		Headers:   sets.NewString(),
+		Modules:   sets.NewString(),
+		ModuleMap: map[string]*Module{},
+	}
+}

--- a/pkg/internal/annotation/utils.go
+++ b/pkg/internal/annotation/utils.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotation
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func prefixName(name string) string {
+	return "+" + name
+}
+
+// isGoFile filters files from parsing.
+func isGoFile(f os.FileInfo) bool {
+	// ignore non-Go or Go test files
+	name := f.Name()
+	return !f.IsDir() &&
+		!strings.HasPrefix(name, ".") &&
+		!strings.HasSuffix(name, "_test.go") &&
+		strings.HasSuffix(name, ".go")
+}
+
+// ParseKV parses key-value string formatted as "foo=bar" and returns key and value.
+func ParseKV(s string) (key, value string, err error) {
+	kv := strings.SplitN(s, "=", 2)
+	if len(kv) != 2 {
+		err = fmt.Errorf("invalid key value pair")
+		return key, value, err
+	}
+	key, value = kv[0], kv[1]
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		value = value[1 : len(value)-1]
+	}
+	return key, value, err
+}

--- a/pkg/rbac/manifests.go
+++ b/pkg/rbac/manifests.go
@@ -25,7 +25,8 @@ import (
 	"github.com/ghodss/yaml"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-tools/pkg/internal/general"
+
+	"sigs.k8s.io/controller-tools/pkg/internal/annotation"
 )
 
 // ManifestOptions represent options for generating the RBAC manifests.
@@ -77,7 +78,8 @@ func Generate(o *ManifestOptions) error {
 	ops := parserOptions{
 		rules: []rbacv1.PolicyRule{},
 	}
-	err := general.ParseDir(o.InputDir, ops.parseAnnotation)
+	// parse rbac annotation by generic annotation approach
+	err := annotation.ParseAnnotationByDir(o.InputDir, ops.AddToAnnotation(annotation.GetAnnotation()))
 	if err != nil {
 		return fmt.Errorf("failed to parse the input dir %v", err)
 	}

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package rbac contain libraries for generating RBAC manifests from RBAC
-// annotations in Go source files.
 package rbac
 
 import (
@@ -23,37 +21,27 @@ import (
 	"strings"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	"sigs.k8s.io/controller-tools/pkg/internal/general"
+	"sigs.k8s.io/controller-tools/pkg/internal/annotation"
 )
 
 type parserOptions struct {
 	rules []rbacv1.PolicyRule
 }
 
-// parseAnnotation parses RBAC annotations
-func (o *parserOptions) parseAnnotation(commentText string) error {
-	for _, comment := range strings.Split(commentText, "\n") {
-		comment := strings.TrimSpace(comment)
-		if strings.HasPrefix(comment, "+rbac") {
-			if ann := general.GetAnnotation(comment, "rbac"); ann != "" {
-				o.rules = append(o.rules, parseRBACTag(ann))
-			}
-		}
-		if strings.HasPrefix(comment, "+kubebuilder:rbac") {
-			if ann := general.GetAnnotation(comment, "kubebuilder:rbac"); ann != "" {
-				o.rules = append(o.rules, parseRBACTag(ann))
-			}
-		}
-	}
-	return nil
+func (o *parserOptions) AddToAnnotation(a annotation.Annotation) annotation.Annotation {
+	a.Module(&annotation.Module{
+		Name: "rbac",
+		Do:   o.parseRBAC,
+	})
+	return a
 }
 
-// parseRBACTag parses the given RBAC annotation in to an RBAC PolicyRule.
-// This is copied from Kubebuilder code.
-func parseRBACTag(tag string) rbacv1.PolicyRule {
+// parseRBAC parses the given RBAC annotation in to an RBAC PolicyRule.
+// Functional implementation is copied from Kubebuilder code.
+func (o *parserOptions) parseRBAC(tag string) error {
 	result := rbacv1.PolicyRule{}
 	for _, elem := range strings.Split(tag, ",") {
-		key, value, err := general.ParseKV(elem)
+		key, value, err := annotation.ParseKV(elem)
 		if err != nil {
 			log.Fatalf("// +kubebuilder:rbac: tags must be key value pairs.  Expected "+
 				"keys [groups=<group1;group2>,resources=<resource1;resource2>,verbs=<verb1;verb2>] "+
@@ -79,5 +67,6 @@ func parseRBACTag(tag string) rbacv1.PolicyRule {
 			result.NonResourceURLs = values
 		}
 	}
-	return result
+	o.rules = append(o.rules, result)
+	return nil
 }

--- a/pkg/rbac/parser_test.go
+++ b/pkg/rbac/parser_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	rbacv1 "k8s.io/api/rbac/v1"
-	"sigs.k8s.io/controller-tools/pkg/internal/general"
+	"sigs.k8s.io/controller-tools/pkg/internal/annotation"
 )
 
 func TestParseFile(t *testing.T) {
@@ -113,7 +113,7 @@ func TestParseFile(t *testing.T) {
 		ops := parserOptions{
 			rules: []rbacv1.PolicyRule{},
 		}
-		err := general.ParseFile(fset, "test.go", test.content, ops.parseAnnotation)
+		err := annotation.ParseAnnotationByFile(fset, "test.go", test.content, ops.AddToAnnotation(annotation.GetAnnotation()))
 		if err != nil {
 			t.Errorf("processFile should have succeeded, but got error: %v", err)
 		}


### PR DESCRIPTION
This PR is draft sample about `Modularized Annotation Pattern`. For more information,  please visit [Go Annotation](https://github.com/fanzhangio/go-annotation)
RE: [Generic Annotation in kubebuilder KEP](https://github.com/kubernetes-sigs/kubebuilder/issues/554)

- Implement of generic annotation spec reside in `./pkg/internal/annotation package`
- Sample codes about RBAC and Webhook. Minimum refactor, leverage existing codes.

⚠ 
