### PR TITLE
✨add shortnames annotation

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -30,6 +30,7 @@ spec:
     kind: Toy
     plural: services
     shortNames:
+    - to
     - ty
   scope: Namespaced
   subresources:

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -93,7 +93,7 @@ type ToyStatus struct {
 // +kubebuilder:printcolumn:name="toy",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="descr1",format="date",priority=3
 // +kubebuilder:printcolumn:name="abc",type="integer",JSONPath="status",description="descr2",format="int32",priority=1
 // +kubebuilder:printcolumn:name="service",type="string",JSONPath=".status.conditions.ready",description="descr3",format="byte",priority=2
-// +kubebuilder:resource:path=services,shortName=ty
+// +kubebuilder:resource:path=services,shortName=to;ty
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -121,7 +121,7 @@ func (b *APIs) parseCRDs() {
 						resource.CRD.Spec.AdditionalPrinterColumns = result
 					}
 					if len(resource.ShortName) > 0 {
-						resource.CRD.Spec.Names.ShortNames = []string{resource.ShortName}
+						resource.CRD.Spec.Names.ShortNames = strings.Split(resource.ShortName, ";")
 					}
 				}
 			}


### PR DESCRIPTION
fix https://github.com/kubernetes-sigs/kubebuilder/issues/404

current implement  only supports single shortname, however, in CRD, `shortName` is an array.  this pr create a new annotation to help generating shortnames. 

Signed-off-by: magicsong <magicsong@yunify.com>

