### PR TITLE
✨ Add support for `nested` output flag and functionality

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -107,6 +107,7 @@ Usage:
 	f := cmd.Flags()
 	f.StringVar(&g.RootPath, "root-path", "", "working dir, must have PROJECT file under the path or parent path if domain not set")
 	f.StringVar(&g.OutputDir, "output-dir", "", "output directory, default to 'config/crds' under root path")
+	f.BoolVar(&g.NestedOutput, "nested", false, "nested output layout: group/version/kind.yaml")
 	f.StringVar(&g.Domain, "domain", "", "domain of the resources, will try to fetch it from PROJECT file if not specified")
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as cluster scoped if not set")
 	f.BoolVar(&g.SkipMapValidation, "skip-map-validation", true, "if set to true, skip generating OpenAPI validation schema for map type in CRD.")

--- a/cmd/crd/cmd/generate.go
+++ b/cmd/crd/cmd/generate.go
@@ -62,6 +62,7 @@ func GeneratorForFlags(f *flag.FlagSet) *crdgenerator.Generator {
 	g := &crdgenerator.Generator{}
 	f.StringVar(&g.RootPath, "root-path", "", "working dir, must have PROJECT file under the path or parent path if domain not set")
 	f.StringVar(&g.OutputDir, "output-dir", "", "output directory, default to 'config/crds' under root path")
+	f.BoolVar(&g.NestedOutput, "nested", false, "nested output layout: group/version/kind.yaml")
 	f.StringVar(&g.Domain, "domain", "", "domain of the resources, will try to fetch it from PROJECT file if not specified")
 	// TODO: Do we need this? Is there a possibility that a crd is namespace scoped?
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as root scoped if not set")

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -38,6 +38,7 @@ import (
 type Generator struct {
 	RootPath          string
 	OutputDir         string
+	NestedOutput      bool
 	Domain            string
 	Namespace         string
 	SkipMapValidation bool
@@ -135,6 +136,10 @@ func (c *Generator) writeCRDs(crds map[string][]byte) error {
 
 	for file, crd := range crds {
 		outFile := path.Join(c.OutputDir, file)
+		// If nested output selected: construct nested path 'group/version/kind'
+		if c.NestedOutput {
+			outFile = path.Join(append([]string{c.OutputDir}, strings.Split(file, "_")...)...)
+		}
 		if err := (&util.FileWriter{Fs: c.OutFs}).WriteFile(outFile, crd); err != nil {
 			return err
 		}


### PR DESCRIPTION
Add functionality to support nested output format for generated CRD files.

`go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all`
result:
```
config/crds/
└── ships_v1beta1_sloop.yaml
```

go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all --nested`
result:
```
config/crds/
└── ships
    └── v1beta1
        └── sloop.yaml
```

Tracking: #94