### PR TITLE
✨ Add support for nested groups.

### DIFF
--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -144,8 +144,20 @@ func (c *Generator) writeCRDs(crds map[string][]byte) error {
 	return nil
 }
 
+func getGroupElements(group string) []string {
+	ss := strings.Split(group, ".")
+	if len(ss) > 1 {
+		// reverse slice
+		for i := len(ss)/2 - 1; i >= 0; i-- {
+			opp := len(ss) - 1 - i
+			ss[i], ss[opp] = ss[opp], ss[i]
+		}
+	}
+	return ss
+}
+
 func getCRDFileName(resource *codegen.APIResource) string {
-	elems := []string{resource.Group, resource.Version, strings.ToLower(resource.Kind)}
+	elems := append(getGroupElements(resource.Group), resource.Version, strings.ToLower(resource.Kind))
 	return strings.Join(elems, "_") + ".yaml"
 }
 

--- a/pkg/internal/codegen/parse/util_test.go
+++ b/pkg/internal/codegen/parse/util_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/gengo/types"
 )
@@ -213,4 +214,39 @@ func TestParsePrintColumnParams(t *testing.T) {
 			t.Errorf("test [%s] failed. result is (%v),\n but expected (%v)", tc.name, res, tc.expected)
 		}
 	}
+}
+
+func TestIsUnderApiDir(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(IsUnderApisDir("pkg/apis")).Should(BeTrue())
+	g.Expect(IsUnderApisDir("pkg/apis/foo")).Should(BeTrue())
+	g.Expect(IsUnderApisDir("pkg/apis/foo/bar")).Should(BeTrue())
+
+	g.Expect(IsUnderApisDir("pkg/api")).Should(BeTrue())
+	g.Expect(IsUnderApisDir("pkg/api/foo")).Should(BeTrue())
+	g.Expect(IsUnderApisDir("pkg/api/foo/bar")).Should(BeTrue())
+
+	g.Expect(IsUnderApisDir("pkg")).Should(BeFalse())
+	g.Expect(IsUnderApisDir("pkg/foo")).Should(BeFalse())
+	g.Expect(IsUnderApisDir("pkg/foo/bar")).Should(BeFalse())
+}
+
+func TestGetGroupNames(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(GetGroupNames("")).Should(BeEmpty())
+	g.Expect(GetGroupNames("pkg")).Should(BeEmpty())
+	g.Expect(GetGroupNames("foo")).Should(BeEmpty())
+
+	g.Expect(GetGroupNames("pkg/apis")).Should(BeEmpty())
+	g.Expect(GetGroupNames("pkg/apis/foo")).Should(Equal([]string{"foo"}))
+	g.Expect(GetGroupNames("pkg/apis/foo/bar")).Should(Equal([]string{"bar", "foo"}))
+	g.Expect(GetGroupNames("pkg/apis/foo/bar/baz")).Should(Equal([]string{"baz", "bar", "foo"}))
+
+	g.Expect(GetGroupNames("pkg/api")).Should(BeEmpty())
+	g.Expect(GetGroupNames("pkg/api/foo")).Should(Equal([]string{"foo"}))
+	g.Expect(GetGroupNames("pkg/api/foo/bar")).Should(Equal([]string{"bar", "foo"}))
+	g.Expect(GetGroupNames("pkg/api/foo/bar/baz")).Should(Equal([]string{"baz", "bar", "foo"}))
+
 }


### PR DESCRIPTION
Add support for project with nested groups:
```
pkg/apis
├── addtoscheme_foo_v1alpha1.go
├── apis.go
└── foo
    ├── buz
    │   ├── group.go
    │   └── v1alpha1
    │       ├── bar_types.go
    │       ├── bar_types_test.go
    │       ├── doc.go
    │       ├── register.go
    │       ├── v1alpha1_suite_test.go
    │       └── zz_generated.deepcopy.go
    └── group.go
```

Tracking: #81