### PR TITLE
:bug: Fixes missing format validation key

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -55,6 +55,10 @@ spec:
           type: object
         spec:
           properties:
+            address:
+              description: This is an IPv4 address.
+              format: ipv4
+              type: string
             alias:
               enum:
               - Lion
@@ -68,6 +72,9 @@ spec:
               type: object
             comment:
               format: byte
+              type: string
+            description:
+              description: This is a simple string without validation.
               type: string
             knights:
               description: This is a comment on an array field.
@@ -116,10 +123,12 @@ spec:
               type: boolean
           required:
           - rank
+          - description
           - template
           - replicas
           - rook
           - location
+          - address
           type: object
         status:
           properties:

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -57,6 +57,9 @@ type ToySpec struct {
 
 	Comment []byte `json:"comment,omitempty"`
 
+	// This is a simple string without validation.
+	Description string `json:"description"`
+
 	// This is a comment on an object field.
 	Template v1.PodTemplateSpec `json:"template"`
 
@@ -72,6 +75,10 @@ type ToySpec struct {
 
 	// This is a comment on a map field.
 	Location map[string]string `json:"location"`
+
+	// This is an IPv4 address.
+	// +kubebuilder:validation:Format=ipv4
+	Address string `json:"address"`
 }
 
 // ToyStatus defines the observed state of Toy

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -289,6 +289,7 @@ func (b *APIs) parsePrimitiveValidation(t *types.Type, found sets.String, commen
 		n = "boolean"
 	case "string":
 		n = "string"
+		f = props.Format
 	default:
 		n = t.Name.Name
 	}


### PR DESCRIPTION
Adds the "format" validation key to the generated schema whenever it is
added explicitely to a type by an annonation.

Closes #123
