### PR TITLE
✨ Add support for CRD singular name

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -32,6 +32,7 @@ spec:
     shortNames:
     - to
     - ty
+    singular: toy
   scope: Namespaced
   subresources:
     scale:

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -94,6 +94,7 @@ type ToyStatus struct {
 // +kubebuilder:printcolumn:name="abc",type="integer",JSONPath="status",description="descr2",format="int32",priority=1
 // +kubebuilder:printcolumn:name="service",type="string",JSONPath=".status.conditions.ready",description="descr3",format="byte",priority=2
 // +kubebuilder:resource:path=services,shortName=to;ty
+// +kubebuilder:singular=toy
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -86,6 +86,11 @@ func (b *APIs) parseCRDs() {
 						resource.Categories = categories
 					}
 
+					if hasSingular(resource.Type) {
+						singularName := getSingularName(resource.Type)
+						resource.CRD.Spec.Names.Singular = singularName
+					}
+
 					if hasStatusSubresource(resource.Type) {
 						if resource.CRD.Spec.Subresources == nil {
 							resource.CRD.Spec.Subresources = &v1beta1.CustomResourceSubresources{}

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -217,6 +217,20 @@ func HasDocAnnotation(t *types.Type) bool {
 	return false
 }
 
+// hasSingular returns true if t is an APIResource annotated with
+// +kubebuilder:singular
+func hasSingular(t *types.Type) bool {
+	if !IsAPIResource(t) {
+		return false
+	}
+	for _, c := range t.CommentLines{
+		if strings.Contains(c, "+kubebuilder:singular"){
+			return true
+		}
+	}
+	return false
+}
+
 // IsUnversioned returns true if t is in given group, and not in versioned path.
 func IsUnversioned(t *types.Type, group string) bool {
 	return IsApisDir(filepath.Base(filepath.Dir(t.Name.Package))) && GetGroup(t) == group
@@ -309,6 +323,16 @@ func getCategoriesTag(c *types.Type) string {
 		panic(errors.Errorf("Must specify +kubebuilder:categories comment for type %v", c.Name))
 	}
 	return resource
+}
+
+// getSingularName returns the value of the +kubebuilder:singular tag
+func getSingularName(c *types.Type) string {
+	comments := Comments(c.CommentLines)
+	singular := comments.getTag("kubebuilder:singular", "=")
+	if len(singular) == 0 {
+		panic(errors.Errorf("Must specify a value to use with +kubebuilder:singular comment for type %v", c.Name))
+	}
+	return singular
 }
 
 // getDocAnnotation parse annotations of "+kubebuilder:doc:" with tags of "warning" or "doc" for control generating doc config.


### PR DESCRIPTION
This adds a `+kubebuilder:singular=foo` tag to specify singular names for CRDs if desired
