### PR TITLE
:bug: Removes extraneous "format" key from array objects

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -60,6 +60,12 @@ spec:
               description: This is an IPv4 address.
               format: ipv4
               type: string
+            addresses:
+              description: This is a list of IPv4 addresses.
+              items:
+                format: ipv4
+                type: string
+              type: array
             alias:
               enum:
               - Lion
@@ -130,6 +136,7 @@ spec:
           - rook
           - location
           - address
+          - addresses
           type: object
         status:
           properties:

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -79,6 +79,10 @@ type ToySpec struct {
 	// This is an IPv4 address.
 	// +kubebuilder:validation:Format=ipv4
 	Address string `json:"address"`
+
+	// This is a list of IPv4 addresses.
+	// +kubebuilder:validation:Format=ipv4
+	Addresses []string `json:"addresses"`
 }
 
 // ToyStatus defines the observed state of Toy

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -395,6 +395,11 @@ func (b *APIs) parseArrayValidation(t *types.Type, found sets.String, comments [
 	for _, l := range comments {
 		getValidation(l, &props)
 	}
+	if t.Name.Name != "[]byte" {
+		// Except for the byte array special case above, the "format" property
+		// should be applied to the array items and not the array itself.
+		props.Format = ""
+	}
 	buff := &bytes.Buffer{}
 	if err := arrayTemplate.Execute(buff, arrayTemplateArgs{props, result}); err != nil {
 		log.Fatalf("%v", err)


### PR DESCRIPTION
This commit removes the "format" key from array objects since any format annotations on arrays are assumed to be applicable to the array items rather than to the array itself.  Byte arrays are handled as a special case since they are represented as byte strings in the CRD YAML rather than actual arrays.

Closes #141

I wasn't sure how long it would take to get PR #140 merged so I went ahead and created this PR on top of the fix for PR #140 since there was some overlap in the test data.   When PR #140 merges I will gladly rebase this PR to exclude the other commit.  

