### PR TITLE
✨Add flags to customize API path and contexts

### DIFF
--- a/cmd/crd/cmd/generate.go
+++ b/cmd/crd/cmd/generate.go
@@ -66,5 +66,7 @@ func GeneratorForFlags(f *flag.FlagSet) *crdgenerator.Generator {
 	// TODO: Do we need this? Is there a possibility that a crd is namespace scoped?
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as root scoped if not set")
 	f.BoolVar(&g.SkipMapValidation, "skip-map-validation", true, "if set to true, skip generating validation schema for map type in CRD.")
+	f.StringVar(&g.APIsPath, "apis-path", "pkg/apis", "the path to search for apis relative to the current directory")
+	f.StringVar(&g.APIsPkg, "apis-pkg", "", "package to consider as the project api package")
 	return g
 }

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -42,6 +42,10 @@ type Generator struct {
 	Namespace         string
 	SkipMapValidation bool
 
+	// APIsPath and APIsPkg allow customized generation for Go types existing under directories other than pkg/apis
+	APIsPath string
+	APIsPkg  string
+
 	// OutFs is filesystem to be used for writing out the result
 	OutFs afero.Fs
 
@@ -80,13 +84,7 @@ func (c *Generator) ValidateAndInitFields() error {
 		c.Domain = crdutil.GetDomainFromProject(c.RootPath)
 	}
 
-	// Validate apis directory exists under working path
-	apisPath := path.Join(c.RootPath, "pkg/apis")
-	if _, err := os.Stat(apisPath); err != nil {
-		return fmt.Errorf("error validating apis path %s: %v", apisPath, err)
-	}
-
-	c.apisPkg, err = crdutil.DirToGoPkg(apisPath)
+	err = c.setAPIsPkg()
 	if err != nil {
 		return err
 	}
@@ -112,7 +110,7 @@ func (c *Generator) Do() error {
 		return fmt.Errorf("failed switching working dir: %v", err)
 	}
 
-	if err := b.AddDirRecursive("./pkg/apis"); err != nil {
+	if err := b.AddDirRecursive("./" + c.APIsPath); err != nil {
 		return fmt.Errorf("failed making a parser: %v", err)
 	}
 	ctx, err := parse.NewContext(b)
@@ -184,4 +182,22 @@ func (c *Generator) getCrds(p *parse.APIs) map[string][]byte {
 // current project.
 func (c *Generator) belongsToAPIsPkg(t *types.Type) bool {
 	return strings.HasPrefix(t.Name.Package, c.apisPkg)
+}
+
+func (c *Generator) setAPIsPkg() error {
+	var err error
+	c.apisPkg = c.APIsPkg
+	if c.apisPkg == "" {
+		// Validate apis directory exists under working path
+		apisPath := path.Join(c.RootPath, c.APIsPath)
+		if _, err := os.Stat(apisPath); err != nil {
+			return fmt.Errorf("error validating apis path %s: %v", apisPath, err)
+		}
+
+		c.apisPkg, err = crdutil.DirToGoPkg(apisPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
We have some use cases where API types are defined in a different package or location than the default `pkg/apis` currently hardcoded. For example, we have vendored types in an API library that correspond to CRDs in multiple different repos; this would allow us to establish a workflow such as 

1. Update API types in library
2. Bump that library in specific CRD repos
3. Generate new CRDs in those repos (wherein those types exist under, eg, `vendor/org/library/some-api/v1/`)

By specifying a known directory and context, we can still use this tool with only minor changes (the optional flags added in this PR) and this gives us more ability to customize it to our use cases.

I'm aware that we could accomplish something similar with `--output-dir`, by going in the opposite direction and running this tool from our API library while specifying the output as those specific repos. But I think controlling the CRD updates from each repo itself couples the CRD update with the corresponding, necessary dependency bump well.
