### PR TITLE
Configuration options

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -78,6 +78,7 @@ Usage:
 	f := cmd.Flags()
 	f.StringVar(&o.Name, "name", o.Name, "name to be used as prefix in identifier for manifests")
 	f.StringVar(&o.ServiceAccount, "service-account", o.ServiceAccount, "service account to bind the role to")
+	f.StringVar(&o.Namespace, "service-account-namespace", o.Namespace, "namespace of the service account to bind the role to")
 	f.StringVar(&o.InputDir, "input-dir", o.InputDir, "input directory pointing to Go source files")
 	f.StringVar(&o.OutputDir, "output-dir", o.OutputDir, "output directory where generated manifests will be saved")
 	f.StringVar(&o.RoleFile, "role-file", o.RoleFile, "output file for the role manifest")

--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -77,6 +77,7 @@ Usage:
 
 	f := cmd.Flags()
 	f.StringVar(&o.Name, "name", o.Name, "name to be used as prefix in identifier for manifests")
+	f.StringVar(&o.ServiceAccount, "service-account", o.ServiceAccount, "service account to bind the role to")
 	f.StringVar(&o.InputDir, "input-dir", o.InputDir, "input directory pointing to Go source files")
 	f.StringVar(&o.OutputDir, "output-dir", o.OutputDir, "output directory where generated manifests will be saved")
 	f.StringVar(&o.RoleFile, "role-file", o.RoleFile, "output file for the role manifest")

--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -76,9 +76,11 @@ Usage:
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&o.Name, "name", o.Name, "Name to be used as prefix in identifier for manifests")
+	f.StringVar(&o.Name, "name", o.Name, "name to be used as prefix in identifier for manifests")
 	f.StringVar(&o.InputDir, "input-dir", o.InputDir, "input directory pointing to Go source files")
-	f.StringVar(&o.OutputDir, "output-dir", o.OutputDir, "output directory where generated manifests will be saved.")
+	f.StringVar(&o.OutputDir, "output-dir", o.OutputDir, "output directory where generated manifests will be saved")
+	f.StringVar(&o.RoleFile, "role-file", o.RoleFile, "output file for the role manifest")
+	f.StringVar(&o.BindingFile, "binding-file", o.BindingFile, "output file for the role binding manifest")
 
 	return cmd
 }

--- a/pkg/rbac/manifests.go
+++ b/pkg/rbac/manifests.go
@@ -30,12 +30,13 @@ import (
 
 // ManifestOptions represent options for generating the RBAC manifests.
 type ManifestOptions struct {
-	InputDir    string
-	OutputDir   string
-	RoleFile    string
-	BindingFile string
-	Name        string
-	Labels      map[string]string
+	InputDir       string
+	OutputDir      string
+	RoleFile       string
+	BindingFile    string
+	Name           string
+	ServiceAccount string
+	Labels         map[string]string
 }
 
 // SetDefaults sets up the default options for RBAC Manifest generator.
@@ -43,6 +44,7 @@ func (o *ManifestOptions) SetDefaults() {
 	o.Name = "manager"
 	o.InputDir = filepath.Join(".", "pkg")
 	o.OutputDir = filepath.Join(".", "config", "rbac")
+	o.ServiceAccount = "default"
 }
 
 // RoleName returns the RBAC role name to be used in the manifests.
@@ -157,7 +159,7 @@ func getClusterRoleBindingManifest(o *ManifestOptions) ([]byte, error) {
 		},
 		Subjects: []rbacv1.Subject{
 			{
-				Name:      "default",
+				Name:      o.ServiceAccount,
 				Namespace: o.Namespace(),
 				Kind:      "ServiceAccount",
 			},

--- a/pkg/rbac/manifests.go
+++ b/pkg/rbac/manifests.go
@@ -30,10 +30,12 @@ import (
 
 // ManifestOptions represent options for generating the RBAC manifests.
 type ManifestOptions struct {
-	InputDir  string
-	OutputDir string
-	Name      string
-	Labels    map[string]string
+	InputDir    string
+	OutputDir   string
+	RoleFile    string
+	BindingFile string
+	Name        string
+	Labels      map[string]string
 }
 
 // SetDefaults sets up the default options for RBAC Manifest generator.
@@ -48,9 +50,27 @@ func (o *ManifestOptions) RoleName() string {
 	return o.Name + "-role"
 }
 
+// RoleFileName returns the name of the manifest file to use for the role.
+func (o *ManifestOptions) RoleFileName() string {
+	if len(o.RoleFile) == 0 {
+		return o.Name + "_role.yaml"
+	}
+	// TODO: validate file name
+	return o.RoleFile
+}
+
 // RoleBindingName returns the RBAC role binding name to be used in the manifests.
 func (o *ManifestOptions) RoleBindingName() string {
 	return o.Name + "-rolebinding"
+}
+
+// RoleBindingFileName returns the name of the manifest file to use for the role binding.
+func (o *ManifestOptions) RoleBindingFileName() string {
+	if len(o.BindingFile) == 0 {
+		return o.Name + "_role_binding.yaml"
+	}
+	// TODO: validate file name
+	return o.BindingFile
 }
 
 // Namespace returns the namespace to be used in the RBAC manifests.
@@ -98,12 +118,12 @@ func Generate(o *ManifestOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to create output dir %v", err)
 	}
-	roleManifestFile := filepath.Join(o.OutputDir, "rbac_role.yaml")
+	roleManifestFile := filepath.Join(o.OutputDir, o.RoleFileName())
 	if err := ioutil.WriteFile(roleManifestFile, roleManifest, 0666); err != nil {
 		return fmt.Errorf("failed to write role manifest YAML file %v", err)
 	}
 
-	roleBindingManifestFile := filepath.Join(o.OutputDir, "rbac_role_binding.yaml")
+	roleBindingManifestFile := filepath.Join(o.OutputDir, o.RoleBindingFileName())
 	if err := ioutil.WriteFile(roleBindingManifestFile, roleBindingManifest, 0666); err != nil {
 		return fmt.Errorf("failed to write role manifest YAML file %v", err)
 	}

--- a/pkg/rbac/manifests.go
+++ b/pkg/rbac/manifests.go
@@ -46,7 +46,6 @@ func (o *ManifestOptions) SetDefaults() {
 	o.InputDir = filepath.Join(".", "pkg")
 	o.OutputDir = filepath.Join(".", "config", "rbac")
 	o.ServiceAccount = "default"
-	// TODO(droot): define Namespace as a const and share it with scaffold pkg.
 	o.Namespace = "system"
 }
 

--- a/pkg/rbac/manifests.go
+++ b/pkg/rbac/manifests.go
@@ -36,6 +36,7 @@ type ManifestOptions struct {
 	BindingFile    string
 	Name           string
 	ServiceAccount string
+	Namespace      string
 	Labels         map[string]string
 }
 
@@ -45,6 +46,8 @@ func (o *ManifestOptions) SetDefaults() {
 	o.InputDir = filepath.Join(".", "pkg")
 	o.OutputDir = filepath.Join(".", "config", "rbac")
 	o.ServiceAccount = "default"
+	// TODO(droot): define Namespace as a const and share it with scaffold pkg.
+	o.Namespace = "system"
 }
 
 // RoleName returns the RBAC role name to be used in the manifests.
@@ -73,12 +76,6 @@ func (o *ManifestOptions) RoleBindingFileName() string {
 	}
 	// TODO: validate file name
 	return o.BindingFile
-}
-
-// Namespace returns the namespace to be used in the RBAC manifests.
-func (o *ManifestOptions) Namespace() string {
-	// TODO(droot): define this as a constant and share it with scaffold pkg.
-	return "system"
 }
 
 // Validate validates the input options.
@@ -160,7 +157,7 @@ func getClusterRoleBindingManifest(o *ManifestOptions) ([]byte, error) {
 		Subjects: []rbacv1.Subject{
 			{
 				Name:      o.ServiceAccount,
-				Namespace: o.Namespace(),
+				Namespace: o.Namespace,
 				Kind:      "ServiceAccount",
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig api-machinery
/priority important-longterm

**What this PR does / why we need it**:
Introduces some configuration options for RBAC generation that allows to bind cluster roles to custom service accounts instead of `"default"` in `"system"` and also allows to specify the name of the output files.

**Which issue(s) this PR fixes**:
Fixes #145 
Fixes #146

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The default output files have been changed from "rbac_role.yaml" and "rback_role_binding.yaml" to "manager_role.yaml" and "manager_role_binding.yaml".
```