### PR TITLE
🐛support alphanum json field in json validation

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -122,6 +122,13 @@ spec:
               oneOf:
               - type: string
               - type: integer
+            s3Log:
+              description: Used this for testing fieldNames with number.
+              properties:
+                bucket:
+                  minLength: 1
+                  type: string
+              type: object
             template:
               description: This is a comment on an object field.
               type: object
@@ -134,6 +141,7 @@ spec:
           - template
           - replicas
           - rook
+          - s3Log
           - location
           - address
           - addresses

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -24,6 +24,12 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// ToyS3LogConfig defines logs configs using S3 backend
+type ToyS3LogConfig struct {
+	// +kubebuilder:validation:MinLength=1
+	Bucket string `json:"bucket,omitempty"`
+}
+
 // ToySpec defines the desired state of Toy
 type ToySpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
@@ -72,6 +78,9 @@ type ToySpec struct {
 	// This is a newly added field.
 	// Using this for testing purpose.
 	Rook *intstr.IntOrString `json:"rook"`
+
+	// Used this for testing fieldNames with number.
+	S3Log ToyS3LogConfig `json:"s3Log"`
 
 	// This is a comment on a map field.
 	Location map[string]string `json:"location"`

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -222,7 +222,7 @@ func (b *APIs) typeToJSONSchemaProps(t *types.Type, found sets.String, comments 
 	return v, s
 }
 
-var jsonRegex = regexp.MustCompile("json:\"([a-zA-Z,]+)\"")
+var jsonRegex = regexp.MustCompile("json:\"([a-zA-Z0-9,]+)\"")
 
 type primitiveTemplateArgs struct {
 	v1beta1.JSONSchemaProps


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->
<!-- What does this do, and why do we need it? -->
Support json fields that have numbers. E.g. `S3`. 
Fix #150 


Tests done:
1. using alphanum as json field names, and attach `+kubebuilder:validation` validation to the field elements.
e.g. 
> S3 LoadBalancerAccessLogsS3Attributes `json:"s3,omitempty"`
1. The generated openAPIV3Schema in CRD contains the expected s3 field, and the validation exists.
1. Install the CRD into an k8s v1.11.5 cluster, and tested the validation works by creating success/fail CRs.