### PR TITLE
WIP: crd-gen: don't apply array+map comments to elements

### DIFF
--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -328,7 +328,7 @@ var mapTemplate = template.Must(template.New("map-template").Parse(
 // parseMapValidation returns a JSONSchemaProps object and its serialization in
 // Go that describe the validations for the given map type.
 func (b *APIs) parseMapValidation(t *types.Type, found sets.String, comments []string) (v1beta1.JSONSchemaProps, string) {
-	additionalProps, result := b.typeToJSONSchemaProps(t.Elem, found, comments, false)
+	additionalProps, result := b.typeToJSONSchemaProps(t.Elem, found, nil, false)
 	additionalProps.Description = ""
 	props := v1beta1.JSONSchemaProps{
 		Type:        "object",
@@ -377,7 +377,7 @@ type arrayTemplateArgs struct {
 // parseArrayValidation returns a JSONSchemaProps object and its serialization in
 // Go that describe the validations for the given array type.
 func (b *APIs) parseArrayValidation(t *types.Type, found sets.String, comments []string) (v1beta1.JSONSchemaProps, string) {
-	items, result := b.typeToJSONSchemaProps(t.Elem, found, comments, false)
+	items, result := b.typeToJSONSchemaProps(t.Elem, found, nil, false)
 	items.Description = ""
 	props := v1beta1.JSONSchemaProps{
 		Type:        "array",


### PR DESCRIPTION
Before this PR tags of map and array instances were pulled into the element type generation. I.e. a minimum value above `[]int` will apply the minimum to the int, not the array. 

This looks good at first, but conflicts with tags which should be applied to the array, not the int. E.g. 1.14 will get `nullable` support (https://github.com/kubernetes/kubernetes/pull/74804). Nullable can be applied to the array and the element type int. Both makes lots of sense. We can mix tags for both use-cases.

Maybe we need something like special items tags?