### PR TITLE
crd-gen: fix intOrString type

### DIFF
--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -186,7 +186,7 @@ func (b *APIs) typeToJSONSchemaProps(t *types.Type, found sets.String, comments 
 		}, b.objSchema()
 	case intOrString:
 		return v1beta1.JSONSchemaProps{
-			OneOf: []v1beta1.JSONSchemaProps{
+			AnyOf: []v1beta1.JSONSchemaProps{
 				{
 					Type: "string",
 				},

--- a/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -118,10 +118,10 @@ spec:
               format: int32
               type: integer
             rook:
-              description: This is a newly added field. Using this for testing purpose.
-              oneOf:
+              anyOf:
               - type: string
               - type: integer
+              description: This is a newly added field. Using this for testing purpose.
             s3Log:
               description: Used this for testing fieldNames with number.
               properties:


### PR DESCRIPTION
OneOf is a dangerous junctor (like not) because it is not monotonic. It leads to strange corner cases like `42` being a float and an integer. OneOf with `number` and `integer` will not validate `42`.

In general, rule of thumb is to avoid `OneOf` where possible.

Due to the bad properties of OneOf we cannot publish OneOf types via the swagger spec, i.e. we have to filter out those types in CRD openapi publishing (alpha in 1.14, https://github.com/kubernetes/kubernetes/pull/71192).

Luckily, `AnyOf` does the same for this purpose here and is the way to go for the upper reasons.