### PR TITLE
crd-gen: add RawExtension support

### DIFF
--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -161,6 +161,7 @@ func (b *APIs) typeToJSONSchemaProps(t *types.Type, found sets.String, comments 
 	duration := types.Name{Name: "Duration", Package: "k8s.io/apimachinery/pkg/apis/meta/v1"}
 	meta := types.Name{Name: "ObjectMeta", Package: "k8s.io/apimachinery/pkg/apis/meta/v1"}
 	unstructured := types.Name{Name: "Unstructured", Package: "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"}
+	rawExtension := types.Name{Name: "RawExtension", Package: "k8s.io/apimachinery/pkg/runtime"}
 	intOrString := types.Name{Name: "IntOrString", Package: "k8s.io/apimachinery/pkg/util/intstr"}
 	switch t.Name {
 	case time:
@@ -179,7 +180,7 @@ func (b *APIs) typeToJSONSchemaProps(t *types.Type, found sets.String, comments 
 			Type:        "object",
 			Description: parseDescription(comments),
 		}, b.objSchema()
-	case unstructured:
+	case unstructured, rawExtension:
 		return v1beta1.JSONSchemaProps{
 			Type:        "object",
 			Description: parseDescription(comments),


### PR DESCRIPTION
RawExtension is the canonical type for embedded kube objects, at least when working with typed clients. From the OpenAPI point of view it is like Unstructured.