### PR TITLE
:warning: Change to use the default rule set for Pluralize.

### DIFF
--- a/pkg/internal/codegen/parse/index.go
+++ b/pkg/internal/codegen/parse/index.go
@@ -71,7 +71,8 @@ func (b *APIs) parseIndex() {
 
 		// TODO: revisit the part...
 		if r.Resource == "" {
-			r.Resource = strings.ToLower(inflect.Pluralize(r.Kind))
+			rs := inflect.NewDefaultRuleset()
+			r.Resource = rs.Pluralize(strings.ToLower(r.Kind))
 		}
 		rt, err := parseResourceAnnotation(c)
 		if err != nil {


### PR DESCRIPTION
This change improves pluralisation on resource names in CRDs (e.g. indexes -> indices).

[Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) that depends on this project uses the default rule set for controller code generation, and so it can generate CRDs and controllers inconsistently. 
The main motivation of this fix is to address the issue.