### PR TITLE
✨ update the kubernetes dependencies to the latest patch release of 1.13 -  1.13.4

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -181,7 +181,7 @@
   version = "v2.2.2"
 
 [[projects]]
-  digest = "1:58ea1e83236dcd9271e3043aca04a8d98911dc4c401d03af1b0239763367849e"
+  digest = "1:4304137d46b791f0d5280f65728be893c00dd2511f78a8a6505072271480ed75"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1beta1",
@@ -189,8 +189,8 @@
     "rbac/v1",
   ]
   pruneopts = "UT"
-  revision = "05914d821849570fba9eacfb29466f2d8d3cd229"
-  version = "kubernetes-1.13.1"
+  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
   digest = "1:46e3296eec0a6e864c2ef813ccfdb0b83d144fcc23414d97dd4894e9464cf4d5"
@@ -200,11 +200,11 @@
     "pkg/apis/apiextensions/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "0fe22c71c47604641d9aa352c785b7912c200562"
-  version = "kubernetes-1.13.1"
+  revision = "d002e88f6236312f0289d9d1deab106751718ff0"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
-  digest = "1:64cc55bfc7c794bc04562c22daf8486dc65c84251d820e41672d76893205ad45"
+  digest = "1:cdadd6ffbd40cc74095fc26f5cf8bb06631adf7a614307b6c6ddf19da29dec05"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/resource",
@@ -230,8 +230,8 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "2b1284ed4c93a43499e781493253e2ac5959c4fd"
-  version = "kubernetes-1.13.1"
+  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
+  version = "kubernetes-1.13.4"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,15 +4,15 @@ ignored = [
 
 [[constraint]]
   name="k8s.io/api"
-  version="kubernetes-1.13.1"
+  version="kubernetes-1.13.4"
 
 [[constraint]]
   name="k8s.io/apiextensions-apiserver"
-  version="kubernetes-1.13.1"
+  version="kubernetes-1.13.4"
 
 [[constraint]]
   name="k8s.io/apimachinery"
-  version="kubernetes-1.13.1"
+  version="kubernetes-1.13.4"
 
 [[constraint]]
   name = "github.com/spf13/afero"

--- a/vendor/k8s.io/api/core/v1/generated.proto
+++ b/vendor/k8s.io/api/core/v1/generated.proto
@@ -3156,6 +3156,7 @@ message PodSpec {
 
   // EnableServiceLinks indicates whether information about services should be injected into pod's
   // environment variables, matching the syntax of Docker links.
+  // Optional: Defaults to true.
   // +optional
   optional bool enableServiceLinks = 30;
 }

--- a/vendor/k8s.io/api/core/v1/types.go
+++ b/vendor/k8s.io/api/core/v1/types.go
@@ -2920,6 +2920,7 @@ type PodSpec struct {
 	RuntimeClassName *string `json:"runtimeClassName,omitempty" protobuf:"bytes,29,opt,name=runtimeClassName"`
 	// EnableServiceLinks indicates whether information about services should be injected into pod's
 	// environment variables, matching the syntax of Docker links.
+	// Optional: Defaults to true.
 	// +optional
 	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty" protobuf:"varint,30,opt,name=enableServiceLinks"`
 }

--- a/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/vendor/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1540,7 +1540,7 @@ var map_PodSpec = map[string]string{
 	"dnsConfig":                     "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
 	"readinessGates":                "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/community/blob/master/keps/sig-network/0007-pod-ready%2B%2B.md",
 	"runtimeClassName":              "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/community/blob/master/keps/sig-node/0014-runtime-class.md This is an alpha feature and may change in the future.",
-	"enableServiceLinks":            "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links.",
+	"enableServiceLinks":            "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
 }
 
 func (PodSpec) SwaggerDoc() map[string]string {

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -713,6 +713,10 @@ const (
 	// Status code 406
 	StatusReasonNotAcceptable StatusReason = "NotAcceptable"
 
+	// StatusReasonRequestEntityTooLarge means that the request entity is too large.
+	// Status code 413
+	StatusReasonRequestEntityTooLarge StatusReason = "RequestEntityTooLarge"
+
 	// StatusReasonUnsupportedMediaType means that the content type sent by the client is not acceptable
 	// to the server - for instance, attempting to send protobuf for a resource that supports only json and yaml.
 	// API calls that return UnsupportedMediaType can never succeed.


### PR DESCRIPTION
✨

It is in the best interests of any k8s API consumer that we always vendor in the latest patch release of a minor version.

As controller-tools acts as a source of k8s-dependencies for cluster-API and its providers, best practices mandate that we update the versions at the root so that they percolate down to the Cluster API providers. If this change is not accepted, we would be forced to use override deps.
