### PR TITLE
🐛 Fix regression #148 from pr #144

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -114,6 +114,8 @@ Usage:
 	f.StringVar(&g.Domain, "domain", "", "domain of the resources, will try to fetch it from PROJECT file if not specified")
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as cluster scoped if not set")
 	f.BoolVar(&g.SkipMapValidation, "skip-map-validation", true, "if set to true, skip generating OpenAPI validation schema for map type in CRD.")
+	f.StringVar(&g.APIsPath, "apis-path", "pkg/apis", "the path to search for apis relative to the current directory")
+	f.StringVar(&g.APIsPkg, "apis-pkg", "", "package to consider as the project api package")
 
 	return cmd
 }


### PR DESCRIPTION
Fixes #148 

Adds the apis-path and apis-pkg flags (and their defaults) to `cmd/controller-gen/main.go` which in a couple local test runs fixed the problem described in #148. Would also like someone else to verify if possible
