### PR TITLE
:bug: skip generating webhooks when no markers defined

### DIFF
--- a/pkg/webhook/manifests.go
+++ b/pkg/webhook/manifests.go
@@ -49,6 +49,10 @@ func Generate(o *Options) error {
 		return fmt.Errorf("failed to parse the input dir: %v", err)
 	}
 
+	if len(o.webhooks) == 0 {
+		return nil
+	}
+
 	objs, err := o.Generate()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/controller-tools/issues/154

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
