### PR TITLE
🐛 fix windows filepath compatibility

### DIFF
--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -203,7 +203,7 @@ func (c *Generator) setAPIsPkg() error {
 	c.apisPkg = c.APIsPkg
 	if c.apisPkg == "" {
 		// Validate apis directory exists under working path
-		apisPath := path.Join(c.RootPath, c.APIsPath)
+		apisPath := filepath.Join(c.RootPath, c.APIsPath)
 		if _, err := os.Stat(apisPath); err != nil {
 			return fmt.Errorf("error validating apis path %s: %v", apisPath, err)
 		}

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -91,7 +91,7 @@ func (c *Generator) ValidateAndInitFields() error {
 
 	// Init output directory
 	if c.OutputDir == "" {
-		c.OutputDir = filepath.Join(c.RootPath, "config/crds")
+		c.OutputDir = path.Join(c.RootPath, "config/crds")
 	}
 
 	return nil
@@ -144,7 +144,7 @@ func (c *Generator) writeCRDs(crds map[string][]byte) error {
 	}
 
 	for file, crd := range crds {
-		outFile := filepath.Join(c.OutputDir, file)
+		outFile := path.Join(c.OutputDir, file)
 		if err := (&util.FileWriter{Fs: c.OutFs}).WriteFile(outFile, crd); err != nil {
 			return err
 		}
@@ -202,12 +202,12 @@ func (c *Generator) setAPIsPkg() error {
 	c.apisPkg = c.APIsPkg
 	if c.apisPkg == "" {
 		// Validate apis directory exists under working path
-		apisPath := filepath.Join(c.RootPath, c.APIsPath)
+		apisPath := path.Join(c.RootPath, c.APIsPath)
 		if _, err := os.Stat(apisPath); err != nil {
 			return fmt.Errorf("error validating apis path %s: %v", apisPath, err)
 		}
 
-		c.apisPkg = filepath.Join(c.Repo, c.APIsPath)
+		c.apisPkg = path.Join(c.Repo, c.APIsPath)
 	}
 	return nil
 }

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -191,7 +191,7 @@ func (c *Generator) getCrds(p *parse.APIs) map[string][]byte {
 // belongsToAPIsPkg returns true if type t is defined under pkg/apis pkg of
 // current project.
 func (c *Generator) belongsToAPIsPkg(t *types.Type) bool {
-	return strings.HasPrefix(t.Name.Package, filepath.ToSlash(c.apisPkg))
+	return strings.HasPrefix(t.Name.Package, c.apisPkg)
 }
 
 func (c *Generator) setAPIsPkg() error {

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -91,7 +91,7 @@ func (c *Generator) ValidateAndInitFields() error {
 
 	// Init output directory
 	if c.OutputDir == "" {
-		c.OutputDir = path.Join(c.RootPath, "config/crds")
+		c.OutputDir = filepath.Join(c.RootPath, "config/crds")
 	}
 
 	return nil
@@ -144,7 +144,7 @@ func (c *Generator) writeCRDs(crds map[string][]byte) error {
 	}
 
 	for file, crd := range crds {
-		outFile := path.Join(c.OutputDir, file)
+		outFile := filepath.Join(c.OutputDir, file)
 		if err := (&util.FileWriter{Fs: c.OutFs}).WriteFile(outFile, crd); err != nil {
 			return err
 		}
@@ -202,12 +202,12 @@ func (c *Generator) setAPIsPkg() error {
 	c.apisPkg = c.APIsPkg
 	if c.apisPkg == "" {
 		// Validate apis directory exists under working path
-		apisPath := path.Join(c.RootPath, c.APIsPath)
+		apisPath := filepath.Join(c.RootPath, c.APIsPath)
 		if _, err := os.Stat(apisPath); err != nil {
 			return fmt.Errorf("error validating apis path %s: %v", apisPath, err)
 		}
 
-		c.apisPkg = path.Join(c.Repo, c.APIsPath)
+		c.apisPkg = filepath.Join(c.Repo, c.APIsPath)
 	}
 	return nil
 }

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -191,7 +191,7 @@ func (c *Generator) getCrds(p *parse.APIs) map[string][]byte {
 // belongsToAPIsPkg returns true if type t is defined under pkg/apis pkg of
 // current project.
 func (c *Generator) belongsToAPIsPkg(t *types.Type) bool {
-	return strings.HasPrefix(t.Name.Package, c.apisPkg)
+	return strings.HasPrefix(t.Name.Package, filepath.ToSlash(c.apisPkg))
 }
 
 func (c *Generator) setAPIsPkg() error {

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -91,7 +92,7 @@ func (c *Generator) ValidateAndInitFields() error {
 
 	// Init output directory
 	if c.OutputDir == "" {
-		c.OutputDir = path.Join(c.RootPath, "config/crds")
+		c.OutputDir = filepath.Join(c.RootPath, "config/crds")
 	}
 
 	return nil
@@ -144,7 +145,7 @@ func (c *Generator) writeCRDs(crds map[string][]byte) error {
 	}
 
 	for file, crd := range crds {
-		outFile := path.Join(c.OutputDir, file)
+		outFile := filepath.Join(c.OutputDir, file)
 		if err := (&util.FileWriter{Fs: c.OutFs}).WriteFile(outFile, crd); err != nil {
 			return err
 		}

--- a/pkg/crd/util/util.go
+++ b/pkg/crd/util/util.go
@@ -30,7 +30,7 @@ import (
 // IsGoSrcPath validate if given path is of path $GOPATH/src.
 func IsGoSrcPath(filePath string) bool {
 	for _, gopath := range getGoPaths() {
-		goSrc := path.Join(gopath, "src")
+		goSrc := filepath.Join(gopath, "src")
 		if filePath == goSrc {
 			return true
 		}
@@ -42,7 +42,7 @@ func IsGoSrcPath(filePath string) bool {
 // IsUnderGoSrcPath validate if given path is under path $GOPATH/src.
 func IsUnderGoSrcPath(filePath string) bool {
 	for _, gopath := range getGoPaths() {
-		goSrc := path.Join(gopath, "src")
+		goSrc := filepath.Join(gopath, "src")
 		if strings.HasPrefix(filepath.Dir(filePath), goSrc) {
 			return true
 		}
@@ -57,7 +57,7 @@ func IsUnderGoSrcPath(filePath string) bool {
 func DirToGoPkg(dir string) (pkg string, err error) {
 	goPaths := getGoPaths()
 	for _, gopath := range goPaths {
-		goSrc := path.Join(gopath, "src")
+		goSrc := filepath.Join(gopath, "src")
 		if !strings.HasPrefix(dir, goSrc) {
 			continue
 		}

--- a/pkg/crd/util/util.go
+++ b/pkg/crd/util/util.go
@@ -22,7 +22,6 @@ import (
 	gobuild "go/build"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -80,7 +79,7 @@ func getGoPaths() []string {
 
 // PathHasProjectFile validate if PROJECT file exists under the path.
 func PathHasProjectFile(filePath string) bool {
-	if _, err := os.Stat(path.Join(filePath, "PROJECT")); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(filePath, "PROJECT")); os.IsNotExist(err) {
 		return false
 	}
 
@@ -101,7 +100,7 @@ func GetRepoFromProject(rootPath string) string {
 func GetFieldFromProject(fieldKey string, rootPath string) string {
 	var fieldVal string
 
-	file, err := os.Open(path.Join(rootPath, "PROJECT"))
+	file, err := os.Open(filepath.Join(rootPath, "PROJECT"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/crd/util/util.go
+++ b/pkg/crd/util/util.go
@@ -22,6 +22,7 @@ import (
 	gobuild "go/build"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -79,7 +80,7 @@ func getGoPaths() []string {
 
 // PathHasProjectFile validate if PROJECT file exists under the path.
 func PathHasProjectFile(filePath string) bool {
-	if _, err := os.Stat(filepath.Join(filePath, "PROJECT")); os.IsNotExist(err) {
+	if _, err := os.Stat(path.Join(filePath, "PROJECT")); os.IsNotExist(err) {
 		return false
 	}
 
@@ -100,7 +101,7 @@ func GetRepoFromProject(rootPath string) string {
 func GetFieldFromProject(fieldKey string, rootPath string) string {
 	var fieldVal string
 
-	file, err := os.Open(filepath.Join(rootPath, "PROJECT"))
+	file, err := os.Open(path.Join(rootPath, "PROJECT"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/internal/codegen/parse/apis.go
+++ b/pkg/internal/codegen/parse/apis.go
@@ -18,6 +18,7 @@ package parse
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -190,7 +191,7 @@ func parseType(t *types.Type) (*codegen.Struct, []*types.Type) {
 				if strings.HasPrefix(mSubType.Name.Package, "k8s.io/api/") {
 					// Import the package under an alias so it doesn't conflict with other groups
 					// having the same version
-					importAlias := filepath.Base(filepath.Dir(mSubType.Name.Package)) + filepath.Base(mSubType.Name.Package)
+					importAlias := path.Base(path.Dir(mSubType.Name.Package)) + path.Base(mSubType.Name.Package)
 					uImport = fmt.Sprintf("%s \"%s\"", importAlias, mSubType.Name.Package)
 					if hasElem {
 						// Replace the full package with the alias when referring to the type
@@ -221,8 +222,8 @@ func parseType(t *types.Type) (*codegen.Struct, []*types.Type) {
 							name := str[endPkg+1:]
 							prefix := str[:startPkg+1]
 
-							uImportBase := filepath.Base(pkg)
-							uImportName := filepath.Base(filepath.Dir(pkg)) + uImportBase
+							uImportBase := path.Base(pkg)
+							uImportName := path.Base(path.Dir(pkg)) + uImportBase
 							uImport = fmt.Sprintf("%s \"%s\"", uImportName, pkg)
 
 							uType = prefix + uImportName + "." + name
@@ -233,8 +234,8 @@ func parseType(t *types.Type) (*codegen.Struct, []*types.Type) {
 
 							// Come up with the alias the package is imported under
 							// Concatenate with directory package to reduce naming collisions
-							uImportBase := filepath.Base(pkg)
-							uImportName := filepath.Base(filepath.Dir(pkg)) + uImportBase
+							uImportBase := path.Base(pkg)
+							uImportName := path.Base(path.Dir(pkg)) + uImportBase
 
 							// Create the import statement
 							uImport = fmt.Sprintf("%s \"%s\"", uImportName, pkg)

--- a/pkg/internal/codegen/parse/apis.go
+++ b/pkg/internal/codegen/parse/apis.go
@@ -18,7 +18,6 @@ package parse
 
 import (
 	"fmt"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -191,7 +190,7 @@ func parseType(t *types.Type) (*codegen.Struct, []*types.Type) {
 				if strings.HasPrefix(mSubType.Name.Package, "k8s.io/api/") {
 					// Import the package under an alias so it doesn't conflict with other groups
 					// having the same version
-					importAlias := path.Base(path.Dir(mSubType.Name.Package)) + path.Base(mSubType.Name.Package)
+					importAlias := filepath.Base(filepath.Dir(mSubType.Name.Package)) + filepath.Base(mSubType.Name.Package)
 					uImport = fmt.Sprintf("%s \"%s\"", importAlias, mSubType.Name.Package)
 					if hasElem {
 						// Replace the full package with the alias when referring to the type
@@ -222,8 +221,8 @@ func parseType(t *types.Type) (*codegen.Struct, []*types.Type) {
 							name := str[endPkg+1:]
 							prefix := str[:startPkg+1]
 
-							uImportBase := path.Base(pkg)
-							uImportName := path.Base(path.Dir(pkg)) + uImportBase
+							uImportBase := filepath.Base(pkg)
+							uImportName := filepath.Base(filepath.Dir(pkg)) + uImportBase
 							uImport = fmt.Sprintf("%s \"%s\"", uImportName, pkg)
 
 							uType = prefix + uImportName + "." + name
@@ -234,8 +233,8 @@ func parseType(t *types.Type) (*codegen.Struct, []*types.Type) {
 
 							// Come up with the alias the package is imported under
 							// Concatenate with directory package to reduce naming collisions
-							uImportBase := path.Base(pkg)
-							uImportName := path.Base(path.Dir(pkg)) + uImportBase
+							uImportBase := filepath.Base(pkg)
+							uImportName := filepath.Base(filepath.Dir(pkg)) + uImportBase
 
 							// Create the import statement
 							uImport = fmt.Sprintf("%s \"%s\"", uImportName, pkg)

--- a/pkg/webhook/generator.go
+++ b/pkg/webhook/generator.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
-	"path/filepath"
+	"path"
 	"sort"
 	"strconv"
 
@@ -85,7 +85,7 @@ func (o *generatorOptions) setDefaults() {
 		o.port = 443
 	}
 	if len(o.certDir) == 0 {
-		o.certDir = filepath.Join("/tmp", "k8s-webhook-server", "serving-certs")
+		o.certDir = path.Join("/tmp", "k8s-webhook-server", "serving-certs")
 	}
 
 	if len(o.mutatingWebhookConfigName) == 0 {

--- a/pkg/webhook/generator.go
+++ b/pkg/webhook/generator.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"net"
 	"net/url"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 
@@ -85,7 +85,7 @@ func (o *generatorOptions) setDefaults() {
 		o.port = 443
 	}
 	if len(o.certDir) == 0 {
-		o.certDir = path.Join("/tmp", "k8s-webhook-server", "serving-certs")
+		o.certDir = filepath.Join("/tmp", "k8s-webhook-server", "serving-certs")
 	}
 
 	if len(o.mutatingWebhookConfigName) == 0 {

--- a/pkg/webhook/manifests.go
+++ b/pkg/webhook/manifests.go
@@ -19,7 +19,7 @@ package webhook
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 	"text/template"
 
@@ -121,7 +121,7 @@ spec:
 	if err := temp.Execute(buf, p); err != nil {
 		return err
 	}
-	return afero.WriteFile(o.outFs, filepath.Join(o.PatchOutputDir, "manager_patch.yaml"), buf.Bytes(), 0644)
+	return afero.WriteFile(o.outFs, path.Join(o.PatchOutputDir, "manager_patch.yaml"), buf.Bytes(), 0644)
 }
 
 func toYAML(m map[string]string) (string, error) {

--- a/pkg/webhook/manifests.go
+++ b/pkg/webhook/manifests.go
@@ -19,7 +19,7 @@ package webhook
 import (
 	"bytes"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -121,7 +121,7 @@ spec:
 	if err := temp.Execute(buf, p); err != nil {
 		return err
 	}
-	return afero.WriteFile(o.outFs, path.Join(o.PatchOutputDir, "manager_patch.yaml"), buf.Bytes(), 0644)
+	return afero.WriteFile(o.outFs, filepath.Join(o.PatchOutputDir, "manager_patch.yaml"), buf.Bytes(), 0644)
 }
 
 func toYAML(m map[string]string) (string, error) {

--- a/pkg/webhook/writer.go
+++ b/pkg/webhook/writer.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"bytes"
 	"fmt"
+	"path"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -83,7 +84,7 @@ func (o *WriterOptions) WriteObjectsToDisk(objects ...runtime.Object) error {
 		}
 		isFirstObject = false
 	}
-	err = afero.WriteFile(o.outFs, filepath.Join(o.OutputDir, "webhookmanifests.yaml"), buf.Bytes(), 0644)
+	err = afero.WriteFile(o.outFs, path.Join(o.OutputDir, "webhookmanifests.yaml"), buf.Bytes(), 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/writer.go
+++ b/pkg/webhook/writer.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"bytes"
 	"fmt"
-	"path"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -84,7 +83,7 @@ func (o *WriterOptions) WriteObjectsToDisk(objects ...runtime.Object) error {
 		}
 		isFirstObject = false
 	}
-	err = afero.WriteFile(o.outFs, path.Join(o.OutputDir, "webhookmanifests.yaml"), buf.Bytes(), 0644)
+	err = afero.WriteFile(o.outFs, filepath.Join(o.OutputDir, "webhookmanifests.yaml"), buf.Bytes(), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes #152, enables Kubebuilder Windows releases.