### PR TITLE
Support 1.14 +nullable tag

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -57,6 +57,7 @@ var ValidationMarkers = mustMakeAllWithPrefix("kubebuilder:validation", markers.
 	Enum(nil),
 	Format(""),
 	Type(""),
+	Nullable(false),
 )
 
 func init() {
@@ -86,6 +87,7 @@ type UniqueItems bool
 type Enum []interface{}
 type Format string
 type Type string
+type Nullable bool
 
 func (m Maximum) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
 	if schema.Type != "integer" {
@@ -207,3 +209,8 @@ func (m Type) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
 }
 
 func (m Type) ApplyFirst() {}
+
+func (m Nullable) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
+	schema.Nullable = bool(m)
+	return nil
+}


### PR DESCRIPTION
Kubernetes 1.14 has support for nullable properties. This PR adds a `+nullable` tag in analogy to `+optional`.

Before this compiles, we have to bump to Kubernetes 1.14 libraries.