### PR TITLE
:sparkles: pkg/crd/generator/generator.go: check if Repo is empty before checking PROJECT

### DIFF
--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -71,16 +71,21 @@ func (c *Generator) ValidateAndInitFields() error {
 		}
 	}
 
-	// Validate PROJECT file
-	if !crdutil.PathHasProjectFile(c.RootPath) {
-		return fmt.Errorf("PROJECT file missing in dir %s", c.RootPath)
+	// If Repo is not explicitly specified,
+	// try to search for PROJECT file as a basis.
+	if c.Repo == "" {
+		if !crdutil.PathHasProjectFile(c.RootPath) {
+			return fmt.Errorf("PROJECT file missing in dir %s", c.RootPath)
+		}
+		c.Repo = crdutil.GetRepoFromProject(c.RootPath)
 	}
-
-	c.Repo = crdutil.GetRepoFromProject(c.RootPath)
 
 	// If Domain is not explicitly specified,
 	// try to search for PROJECT file as a basis.
 	if len(c.Domain) == 0 {
+		if !crdutil.PathHasProjectFile(c.RootPath) {
+			return fmt.Errorf("PROJECT file missing in dir %s", c.RootPath)
+		}
 		c.Domain = crdutil.GetDomainFromProject(c.RootPath)
 	}
 


### PR DESCRIPTION
Previously, using `Generator.ValidateAndInitFields()` did not require a project have a `PROJECT` file. [This commit](https://github.com/estroz/controller-tools/commit/626472cffd8eac5000961685a6c15b5942f6d36f) broke that API. This is a fix to give the same functionality if `Generator.Repo` has not been set.
