### PR TITLE
:sparkle: pkg/internal/codegen/parse: "Title" CRD validation annotation

### DIFF
--- a/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -89,16 +89,18 @@ spec:
                 type: string
               maxItems: 500
               minItems: 1
-              title: A List of Knights
+              title: A \"List\" "of" Knights
               type: array
             location:
               additionalProperties:
                 type: string
               description: This is a comment on a map field.
+              title: A Map
               type: object
             name:
               maxLength: 15
               minLength: 1
+              title: A primitive Name
               type: string
             power:
               exclusiveMinimum: true
@@ -132,6 +134,7 @@ spec:
               type: object
             template:
               description: This is a comment on an object field.
+              title: An Object
               type: object
             winner:
               description: This is a comment on a boolean field.

--- a/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -89,6 +89,7 @@ spec:
                 type: string
               maxItems: 500
               minItems: 1
+              title: A List of Knights
               type: array
             location:
               additionalProperties:

--- a/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -47,6 +47,7 @@ type ToySpec struct {
 	Name string `json:"name,omitempty"`
 
 	// This is a comment on an array field.
+	// +kubebuilder:validation:Title="A List of Knights"
 	// +kubebuilder:validation:MaxItems=500
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:UniqueItems=false

--- a/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -44,10 +44,11 @@ type ToySpec struct {
 
 	// +kubebuilder:validation:MaxLength=15
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Title="A primitive Name"
 	Name string `json:"name,omitempty"`
 
 	// This is a comment on an array field.
-	// +kubebuilder:validation:Title="A List of Knights"
+	// +kubebuilder:validation:Title="A \"List\" "of" Knights"
 	// +kubebuilder:validation:MaxItems=500
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:UniqueItems=false
@@ -68,6 +69,7 @@ type ToySpec struct {
 	Description string `json:"description"`
 
 	// This is a comment on an object field.
+	// +kubebuilder:validation:Title="An Object"
 	Template v1.PodTemplateSpec `json:"template"`
 
 	Claim v1.PersistentVolumeClaim `json:"claim,omitempty"`
@@ -84,6 +86,7 @@ type ToySpec struct {
 	S3Log ToyS3LogConfig `json:"s3Log"`
 
 	// This is a comment on a map field.
+	// +kubebuilder:validation:Title="A Map"
 	Location map[string]string `json:"location"`
 
 	// This is an IPv4 address.


### PR DESCRIPTION
This PR implements the [`SchemaProps.Title`](https://godoc.org/github.com/go-openapi/spec#SchemaProps) field as an annotation: `+kubebuilder:validation:Title="some title"`, where the quoted string following `=` is stripped of surrounding quotes and interpreted literally as a field's title. This validation is not inherited by child props.

Reference: https://github.com/kubernetes-sigs/controller-tools/issues/156#issuecomment-479632914

/cc @mengqiy @DirectXMan12 @droot 
