### PR TITLE
🐛 Add +required tag and make members optional by default.

### DIFF
--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -628,7 +628,7 @@ func (b *APIs) getMembers(t *types.Type, found sets.String) (map[string]v1beta1.
 			m, r := b.typeToJSONSchemaProps(member.Type, found, member.CommentLines, false)
 			members[name] = m
 			result[name] = r
-			if !strings.HasSuffix(strat, "omitempty") {
+			if hasRequired(member) {
 				required = append(required, name)
 			}
 		}

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -223,8 +223,22 @@ func hasSingular(t *types.Type) bool {
 	if !IsAPIResource(t) {
 		return false
 	}
-	for _, c := range t.CommentLines{
-		if strings.Contains(c, "+kubebuilder:singular"){
+	for _, c := range t.CommentLines {
+		if strings.Contains(c, "+kubebuilder:singular") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRequired returns true if t is annotated with
+// +required
+func hasRequired(member types.Member) bool {
+	for _, c := range member.CommentLines {
+
+		c = strings.TrimSpace(c)
+
+		if c == "+required" {
 			return true
 		}
 	}
@@ -363,7 +377,9 @@ func parseDescription(res []string) string {
 	var temp strings.Builder
 	var desc string
 	for _, comment := range res {
-		if !(strings.Contains(comment, "+kubebuilder") || strings.Contains(comment, "+optional")) {
+		if !(strings.Contains(comment, "+kubebuilder") ||
+			strings.Contains(comment, "+optional") ||
+			strings.Contains(comment, "+required")) {
 			temp.WriteString(comment)
 			temp.WriteString(" ")
 			desc = strings.TrimRight(temp.String(), " ")

--- a/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -136,15 +136,7 @@ spec:
               description: This is a comment on a boolean field.
               type: boolean
           required:
-          - rank
-          - description
-          - template
-          - replicas
-          - rook
-          - s3Log
-          - location
-          - address
-          - addresses
+          - name
           type: object
         status:
           properties:
@@ -152,8 +144,6 @@ spec:
               description: It tracks the number of replicas.
               format: int32
               type: integer
-          required:
-          - replicas
           type: object
   version: v1alpha1
 status:

--- a/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -44,6 +44,7 @@ type ToySpec struct {
 
 	// +kubebuilder:validation:MaxLength=15
 	// +kubebuilder:validation:MinLength=1
+	// +required
 	Name string `json:"name,omitempty"`
 
 	// This is a comment on an array field.


### PR DESCRIPTION
- [x] Change the default behavior for members to be optional.
- [x] Allow members to be set with a +required comment flag.
- [x] Filter out +require comment flags from CRD description field.
- [x] Change testData to ensure +required is working as expected.

This addresses issue #137.
