### PR TITLE
⚠Rewriting CRD generator to use built-in go type inferences

### DIFF
--- a/pkg/crd/v2/crd.go
+++ b/pkg/crd/v2/crd.go
@@ -1,0 +1,569 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"log"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+// methods under this file is mostly copied from controller-tools old generator's parsing logic.
+// A lot of places are not consistent :(
+// This should be cleanup
+
+// parseCRDs populates the CRD field of each Group.Version.Resource,
+// creating validations using the annotations on type fields.
+func parseCRDs(comments []string) *v1beta1.CustomResourceDefinitionSpec {
+	if !IsAPIResource(comments) {
+		return nil
+	}
+
+	crdVersion := v1beta1.CustomResourceDefinitionVersion{
+		Name:    parseVersion(comments),
+		Served:  true,
+		Storage: isStorageVersion(comments),
+	}
+
+	crdSpec := &v1beta1.CustomResourceDefinitionSpec{
+		Group:    "",
+		Names:    v1beta1.CustomResourceDefinitionNames{},
+		Versions: []v1beta1.CustomResourceDefinitionVersion{crdVersion},
+	}
+
+	if IsNonNamespaced(comments) {
+		crdSpec.Scope = "Cluster"
+	} else {
+		crdSpec.Scope = "Namespaced"
+	}
+
+	if hasCategories(comments) {
+		categoriesTag := getCategoriesTag(comments)
+		categories := strings.Split(categoriesTag, ",")
+		crdSpec.Names.Categories = categories
+	}
+
+	if hasSingular(comments) {
+		singularName := getSingularName(comments)
+		crdSpec.Names.Singular = singularName
+	}
+
+	if hasStatusSubresource(comments) {
+		if crdSpec.Subresources == nil {
+			crdSpec.Subresources = &v1beta1.CustomResourceSubresources{}
+		}
+		crdSpec.Subresources.Status = &v1beta1.CustomResourceSubresourceStatus{}
+	}
+
+	if hasScaleSubresource(comments) {
+		if crdSpec.Subresources == nil {
+			crdSpec.Subresources = &v1beta1.CustomResourceSubresources{}
+		}
+		jsonPath, err := parseScaleParams(comments)
+		if err != nil {
+			log.Fatalf("failed in parsing CRD, error: %v", err.Error())
+		}
+		crdSpec.Subresources.Scale = &v1beta1.CustomResourceSubresourceScale{
+			SpecReplicasPath:   jsonPath[specReplicasPath],
+			StatusReplicasPath: jsonPath[statusReplicasPath],
+		}
+		labelSelctor, ok := jsonPath[labelSelectorPath]
+		if ok && labelSelctor != "" {
+			crdSpec.Subresources.Scale.LabelSelectorPath = &labelSelctor
+		}
+	}
+	if hasPrintColumn(comments) {
+		result, err := parsePrintColumnParams(comments)
+		if err != nil {
+			log.Fatalf("failed to parse printcolumn annotations, error: %v", err.Error())
+		}
+		crdSpec.Versions[0].AdditionalPrinterColumns = result
+	}
+
+	rt, err := parseResourceAnnotation(comments)
+	if err != nil {
+		log.Fatalf("failed to parse resource annotations, error: %v", err.Error())
+	}
+	crdSpec.Names.Plural = rt.Resource
+	if len(rt.ShortName) > 0 {
+		crdSpec.Names.ShortNames = strings.Split(rt.ShortName, ";")
+	}
+
+	return crdSpec
+}
+
+const (
+	specReplicasPath   = "specpath"
+	statusReplicasPath = "statuspath"
+	labelSelectorPath  = "selectorpath"
+	jsonPathError      = "invalid scale path. specpath, statuspath key-value pairs are required, only selectorpath key-value is optinal. For example: // +kubebuilder:subresource:scale:specpath=.spec.replica,statuspath=.status.replica,selectorpath=.spec.Label"
+	printColumnName    = "name"
+	printColumnType    = "type"
+	printColumnDescr   = "description"
+	printColumnPath    = "JSONPath"
+	printColumnFormat  = "format"
+	printColumnPri     = "priority"
+	printColumnError   = "invalid printcolumn path. name,type, and JSONPath are required kye-value pairs and rest of the fields are optinal. For example: // +kubebuilder:printcolumn:name=abc,type=string,JSONPath=status"
+)
+
+// IsAPIResource returns true if either of the two conditions become true:
+// 1. t has a +resource/+kubebuilder:resource comment tag
+// 2. t has TypeMeta and ObjectMeta in its member list.
+func IsAPIResource(comments []string) bool {
+	for _, c := range comments {
+		if strings.Contains(c, "+resource") || strings.Contains(c, "+kubebuilder:resource") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsNonNamespaced returns true if t has a +nonNamespaced comment tag
+func IsNonNamespaced(comments []string) bool {
+	if !IsAPIResource(comments) {
+		return false
+	}
+
+	for _, c := range comments {
+		if strings.Contains(c, "+genclient:nonNamespaced") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasPrintColumn returns true if t has a +printcolumn or +kubebuilder:printcolumn annotation.
+func hasPrintColumn(comments []string) bool {
+	for _, c := range comments {
+		if strings.Contains(c, "+printcolumn") || strings.Contains(c, "+kubebuilder:printcolumn") {
+			return true
+		}
+	}
+	return false
+}
+
+// IsInformer returns true if t has a +informers or +kubebuilder:informers tag
+func IsInformer(comments []string) bool {
+	for _, c := range comments {
+		if strings.Contains(c, "+informers") || strings.Contains(c, "+kubebuilder:informers") {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAPISubresource returns true if t has a +subresource-request comment tag
+func IsAPISubresource(comments []string) bool {
+	for _, c := range comments {
+		if strings.Contains(c, "+subresource-request") {
+			return true
+		}
+	}
+	return false
+}
+
+// HasSubresource returns true if t is an APIResource with one or more Subresources
+func HasSubresource(comments []string) bool {
+	if !IsAPIResource(comments) {
+		return false
+	}
+	for _, c := range comments {
+		if strings.Contains(c, "subresource") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasStatusSubresource returns true if t is an APIResource annotated with
+// +kubebuilder:subresource:status
+func hasStatusSubresource(comments []string) bool {
+	if !IsAPIResource(comments) {
+		return false
+	}
+	for _, c := range comments {
+		if strings.Contains(c, "+kubebuilder:subresource:status") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasScaleSubresource returns true if t is an APIResource annotated with
+// +kubebuilder:subresource:scale
+func hasScaleSubresource(comments []string) bool {
+	if !IsAPIResource(comments) {
+		return false
+	}
+	for _, c := range comments {
+		if strings.Contains(c, "+kubebuilder:subresource:scale") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasCategories returns true if t is an APIResource annotated with
+// +kubebuilder:categories
+func hasCategories(comments []string) bool {
+	if !IsAPIResource(comments) {
+		return false
+	}
+
+	for _, c := range comments {
+		if strings.Contains(c, "+kubebuilder:categories") {
+			return true
+		}
+	}
+	return false
+}
+
+// HasDocAnnotation returns true if t is an APIResource with doc annotation
+// +kubebuilder:doc
+func HasDocAnnotation(comments []string) bool {
+	if !IsAPIResource(comments) {
+		return false
+	}
+	for _, c := range comments {
+		if strings.Contains(c, "+kubebuilder:doc") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSingular returns true if t is an APIResource annotated with
+// +kubebuilder:singular
+func hasSingular(comments []string) bool {
+	if !IsAPIResource(comments) {
+		return false
+	}
+	for _, c := range comments {
+		if strings.Contains(c, "+kubebuilder:singular") {
+			return true
+		}
+	}
+	return false
+}
+
+// resourceTags contains the tags present in a "+resource=" comment
+type resourceTags struct {
+	Resource  string
+	REST      string
+	Strategy  string
+	ShortName string
+}
+
+// ParseKV parses key-value string formatted as "foo=bar" and returns key and value.
+func ParseKV(s string) (key, value string, err error) {
+	kv := strings.Split(s, "=")
+	if len(kv) != 2 {
+		err = fmt.Errorf("invalid key value pair")
+		return key, value, err
+	}
+	key, value = kv[0], kv[1]
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		value = value[1 : len(value)-1]
+	}
+	return key, value, err
+}
+
+// resourceAnnotationValue is a helper function to extract resource annotation.
+func resourceAnnotationValue(tag string) (resourceTags, error) {
+	res := resourceTags{}
+	for _, elem := range strings.Split(tag, ",") {
+		key, value, err := ParseKV(elem)
+		if err != nil {
+			return resourceTags{}, fmt.Errorf("// +kubebuilder:resource: tags must be key value pairs.  Expected "+
+				"keys [path=<resourcepath>] "+
+				"Got string: [%s]", tag)
+		}
+		switch key {
+		case "path":
+			res.Resource = value
+		case "shortName":
+			res.ShortName = value
+		default:
+			return resourceTags{}, fmt.Errorf("The given input %s is invalid", value)
+		}
+	}
+	return res, nil
+}
+
+// GetAnnotation extracts the annotation from comment text.
+// It will return "foo" for comment "+kubebuilder:webhook:foo" .
+func GetAnnotation(c, name string) string {
+	prefix := fmt.Sprintf("+%s:", name)
+	if strings.HasPrefix(c, prefix) {
+		return strings.TrimPrefix(c, prefix)
+	}
+	return ""
+}
+
+// parseResourceAnnotation parses the tags in a "+resource=" comment into a resourceTags struct.
+func parseResourceAnnotation(comments []string) (resourceTags, error) {
+	finalResult := resourceTags{}
+	var resourceAnnotationFound bool
+	for _, comment := range comments {
+		anno := GetAnnotation(comment, "kubebuilder:resource")
+		if len(anno) == 0 {
+			continue
+		}
+		result, err := resourceAnnotationValue(anno)
+		if err != nil {
+			return resourceTags{}, err
+		}
+		if resourceAnnotationFound {
+			return resourceTags{}, fmt.Errorf("resource annotation should only exists once per type")
+		}
+		resourceAnnotationFound = true
+		finalResult = result
+	}
+	return finalResult, nil
+}
+
+// GetVersion returns version of t.
+func GetVersion(pwd string) string {
+	return filepath.Base(pwd)
+}
+
+// Comments is a structure for using comment tags on go structs and fields
+type Comments []string
+
+// GetTags returns the value for the first comment with a prefix matching "+name="
+// e.g. "+name=foo\n+name=bar" would return "foo"
+func (c Comments) getTag(name, sep string) string { // nolint: unparam
+	for _, c := range c {
+		prefix := fmt.Sprintf("+%s%s", name, sep)
+		if strings.HasPrefix(c, prefix) {
+			return strings.Replace(c, prefix, "", 1)
+		}
+	}
+	return ""
+}
+
+// hasTag returns true if the Comments has a tag with the given name
+func (c Comments) hasTag(name string) bool {
+	for _, c := range c {
+		prefix := fmt.Sprintf("+%s", name)
+		if strings.HasPrefix(c, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// GetTags returns the value for all comments with a prefix and separator.  E.g. for "name" and "="
+// "+name=foo\n+name=bar" would return []string{"foo", "bar"}
+func (c Comments) getTags(name, sep string) []string {
+	tags := []string{}
+	for _, c := range c {
+		prefix := fmt.Sprintf("+%s%s", name, sep)
+		if strings.HasPrefix(c, prefix) {
+			tags = append(tags, strings.Replace(c, prefix, "", 1))
+		}
+	}
+	return tags
+}
+
+// getKVTags returns the value for all comments with a prefix and separator.  E.g. for "name" and "="
+// "+name=foo\n+name=bar" would return []string{"foo", "bar"}
+func (c Comments) getKVTags(prefix, sep string) []string { // nolint: unparam
+	tags := []string{}
+	for _, c := range c {
+		if strings.HasPrefix(c, prefix) {
+			rawKVs := strings.Replace(c, prefix, "", 1)
+			for _, rawKV := range strings.Split(rawKVs, ",") {
+				strings.Split(rawKV, "=")
+			}
+		}
+	}
+	return tags
+}
+
+// getCategoriesTag returns the value of the +kubebuilder:categories tags
+func getCategoriesTag(comments []string) string {
+	cs := Comments(comments)
+	resource := cs.getTag("kubebuilder:categories", "=")
+	if len(resource) == 0 {
+		panic(fmt.Errorf("must specify +kubebuilder:categories comment"))
+	}
+	return resource
+}
+
+// getSingularName returns the value of the +kubebuilder:singular tag
+func getSingularName(comments []string) string {
+	cs := Comments(comments)
+	singular := cs.getTag("kubebuilder:singular", "=")
+	if len(singular) == 0 {
+		panic(fmt.Errorf("must specify a value to use with +kubebuilder:singular comment"))
+	}
+	return singular
+}
+
+// Scale subresource requires specpath, statuspath, selectorpath key values, represents for JSONPath of
+// SpecReplicasPath, StatusReplicasPath, LabelSelectorPath separately. e.g.
+// +kubebuilder:subresource:scale:specpath=.spec.replica,statuspath=.status.replica,selectorpath=
+func parseScaleParams(comments []string) (map[string]string, error) {
+	jsonPath := make(map[string]string)
+	for _, c := range comments {
+		if strings.Contains(c, "+kubebuilder:subresource:scale") {
+			paths := strings.Replace(c, "+kubebuilder:subresource:scale:", "", -1)
+			path := strings.Split(paths, ",")
+			if len(path) < 2 {
+				return nil, fmt.Errorf(jsonPathError)
+			}
+			for _, s := range path {
+				kv := strings.Split(s, "=")
+				if kv[0] == specReplicasPath || kv[0] == statusReplicasPath || kv[0] == labelSelectorPath {
+					jsonPath[kv[0]] = kv[1]
+				} else {
+					return nil, fmt.Errorf(jsonPathError)
+				}
+			}
+			var ok bool
+			_, ok = jsonPath[specReplicasPath]
+			if !ok {
+				return nil, fmt.Errorf(jsonPathError)
+			}
+			_, ok = jsonPath[statusReplicasPath]
+			if !ok {
+				return nil, fmt.Errorf(jsonPathError)
+			}
+			return jsonPath, nil
+		}
+	}
+	return nil, fmt.Errorf(jsonPathError)
+}
+
+// printColumnKV parses key-value string formatted as "foo=bar" and returns key and value.
+func printColumnKV(s string) (key, value string, err error) {
+	kv := strings.SplitN(s, "=", 2)
+	if len(kv) != 2 {
+		err = fmt.Errorf("invalid key value pair")
+		return key, value, err
+	}
+	key, value = kv[0], kv[1]
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		value = value[1 : len(value)-1]
+	}
+	return key, value, err
+}
+
+// helperPrintColumn is a helper function for the parsePrintColumnParams to compute printer columns.
+// TODO: reduce the cyclomatic complexity and remove next line
+// nolint: gocyclo,goconst
+func helperPrintColumn(parts string) (v1beta1.CustomResourceColumnDefinition, error) {
+	config := v1beta1.CustomResourceColumnDefinition{}
+	var count int
+	part := strings.Split(parts, ",")
+	if len(part) < 3 {
+		return v1beta1.CustomResourceColumnDefinition{}, fmt.Errorf(printColumnError)
+	}
+
+	for _, elem := range strings.Split(parts, ",") {
+		key, value, err := printColumnKV(elem)
+		if err != nil {
+			return v1beta1.CustomResourceColumnDefinition{},
+				fmt.Errorf("//+kubebuilder:printcolumn: tags must be key value pairs.Expected "+
+					"keys [name=<name>,type=<type>,description=<descr>,format=<format>] "+
+					"Got string: [%s]", parts)
+		}
+		if key == printColumnName || key == printColumnType || key == printColumnPath {
+			count++
+		}
+		switch key {
+		case printColumnName:
+			config.Name = value
+		case printColumnType:
+			if value == "integer" || value == "number" || value == "string" || value == "boolean" || value == "date" {
+				config.Type = value
+			} else {
+				return v1beta1.CustomResourceColumnDefinition{}, fmt.Errorf("invalid value for %s printcolumn", printColumnType)
+			}
+		case printColumnFormat:
+			if config.Type == "integer" && (value == "int32" || value == "int64") {
+				config.Format = value
+			} else if config.Type == "number" && (value == "float" || value == "double") {
+				config.Format = value
+			} else if config.Type == "string" && (value == "byte" || value == "date" || value == "date-time" || value == "password") {
+				config.Format = value
+			} else {
+				return v1beta1.CustomResourceColumnDefinition{}, fmt.Errorf("invalid value for %s printcolumn", printColumnFormat)
+			}
+		case printColumnPath:
+			config.JSONPath = value
+		case printColumnPri:
+			i, err := strconv.Atoi(value)
+			v := int32(i)
+			if err != nil {
+				return v1beta1.CustomResourceColumnDefinition{}, fmt.Errorf("invalid value for %s printcolumn", printColumnPri)
+			}
+			config.Priority = v
+		case printColumnDescr:
+			config.Description = value
+		default:
+			return v1beta1.CustomResourceColumnDefinition{}, fmt.Errorf(printColumnError)
+		}
+	}
+	if count != 3 {
+		return v1beta1.CustomResourceColumnDefinition{}, fmt.Errorf(printColumnError)
+	}
+	return config, nil
+}
+
+// printcolumn requires name,type,JSONPath fields and rest of the field are optional
+// +kubebuilder:printcolumn:name=<name>,type=<type>,description=<desc>,JSONPath:<.spec.Name>,priority=<int32>,format=<format>
+func parsePrintColumnParams(comments []string) ([]v1beta1.CustomResourceColumnDefinition, error) {
+	result := []v1beta1.CustomResourceColumnDefinition{}
+	for _, comment := range comments {
+		if strings.Contains(comment, "+kubebuilder:printcolumn") {
+			parts := strings.Replace(comment, "+kubebuilder:printcolumn:", "", -1)
+			res, err := helperPrintColumn(parts)
+			if err != nil {
+				return []v1beta1.CustomResourceColumnDefinition{}, err
+			}
+			result = append(result, res)
+		}
+	}
+	return result, nil
+}
+
+func parseVersion(comments []string) string {
+	return Comments(comments).getTag("kubebuilder:crd:version", "=")
+}
+
+func isStorageVersion(comments []string) bool {
+	storage := strings.ToLower(Comments(comments).getTag("kubebuilder:crd:storage", "="))
+	if len(storage) > 0 {
+		switch storage {
+		case "true":
+			return true
+		case "false":
+			return false
+		default:
+			log.Fatalf("the value associated with kubebuilder:crd:storage should either true or false")
+		}
+	}
+	return false
+}

--- a/pkg/crd/v2/definition_checker.go
+++ b/pkg/crd/v2/definition_checker.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+func checkDefinitions(defs v1beta1.JSONSchemaDefinitions, startingTypes map[string]bool) {
+	fmt.Printf("Type checking Starting expecting %d types\n", len(defs))
+	pruner := DefinitionPruner{defs, startingTypes}
+	newDefs := pruner.Prune(false)
+	if len(defs) != len(newDefs) {
+		fmt.Printf("Type checking failed. Expected %d actual %d\n", len(defs), len(newDefs))
+	} else {
+		fmt.Println("Type checking PASSED")
+	}
+}

--- a/pkg/crd/v2/definition_pruner.go
+++ b/pkg/crd/v2/definition_pruner.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+// DefinitionPruner prunes unwanted definitions
+type DefinitionPruner struct {
+	definitions   v1beta1.JSONSchemaDefinitions
+	startingTypes map[string]bool
+}
+
+// Prune prunes the definitions
+func (pruner *DefinitionPruner) Prune(ignoreUnknownTypes bool) map[string]bool {
+	visitedDefs := make(map[string]bool)
+	queue := make([]string, 0)
+	// Push starting types into queue
+	for typeName := range pruner.startingTypes {
+		queue = append(queue, typeName)
+	}
+
+	// Perform BFS and keep track of visited types
+	for len(queue) > 0 {
+		curType := queue[0]
+		queue = queue[1:]
+		// If already visited, skip it
+		if _, exists := visitedDefs[curType]; exists {
+			continue
+		}
+		// If no definitions present, (probably an external reference)
+		// Skip it
+		if _, exists := pruner.definitions[curType]; !exists {
+			if ignoreUnknownTypes {
+				continue
+			} else {
+				fmt.Println("Unknown type ", curType)
+				panic("Unknown type")
+			}
+		}
+		visitedDefs[curType] = true
+		curDef := pruner.definitions[curType]
+		queue = append(queue, processDefinition(&curDef)...)
+	}
+
+	return visitedDefs
+}
+
+func processDefinition(def *v1beta1.JSONSchemaProps) []string {
+	allTypes := []string{}
+	if def == nil {
+		return allTypes
+	}
+	if def.Ref != nil && len(*def.Ref) > 0 {
+		allTypes = append(allTypes, getNameFromURL(*def.Ref))
+	}
+	allTypes = append(allTypes, processDefinitionMap(def.Definitions)...)
+	allTypes = append(allTypes, processDefinitionMap(def.Properties)...)
+	allTypes = append(allTypes, processDefinitionArray(def.AllOf)...)
+	allTypes = append(allTypes, processDefinitionArray(def.AnyOf)...)
+	allTypes = append(allTypes, processDefinitionArray(def.OneOf)...)
+	if def.AdditionalItems != nil {
+		allTypes = append(allTypes, processDefinition(def.AdditionalItems.Schema)...)
+	}
+	if def.Items != nil {
+		allTypes = append(allTypes, processDefinition(def.Items.Schema)...)
+	}
+	allTypes = append(allTypes, processDefinition(def.Not)...)
+	return allTypes
+}
+
+func processDefinitionMap(defMap v1beta1.JSONSchemaDefinitions) []string {
+	allTypes := []string{}
+	if defMap == nil {
+		return allTypes
+	}
+	for key := range defMap {
+		def := defMap[key]
+		allTypes = append(allTypes, processDefinition(&def)...)
+	}
+	return allTypes
+}
+
+func processDefinitionArray(defArray []v1beta1.JSONSchemaProps) []string {
+	allTypes := []string{}
+	if defArray == nil {
+		return allTypes
+	}
+	for i := range defArray {
+		def := defArray[i]
+		allTypes = append(allTypes, processDefinition(&def)...)
+	}
+	return allTypes
+}

--- a/pkg/crd/v2/embed.go
+++ b/pkg/crd/v2/embed.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"log"
+	"strings"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+func embedSchema(defs map[string]v1beta1.JSONSchemaProps, startingTypes map[string]bool) map[string]v1beta1.JSONSchemaProps {
+	newDefs := map[string]v1beta1.JSONSchemaProps{}
+	for name := range startingTypes {
+		def := defs[name]
+		embedDefinition(&def, defs)
+		newDefs[name] = def
+	}
+	return newDefs
+}
+
+func embedDefinition(def *v1beta1.JSONSchemaProps, refs map[string]v1beta1.JSONSchemaProps) {
+	if def == nil {
+		return
+	}
+
+	if def.Ref != nil && len(*def.Ref) > 0 {
+		refName := strings.TrimPrefix(*def.Ref, defPrefix)
+		ref, ok := refs[refName]
+		if !ok {
+			log.Panicf("can't find the definition of %q", refName)
+		}
+		def.Properties = ref.Properties
+		def.Required = ref.Required
+		def.Type = ref.Type
+		def.Ref = nil
+	}
+
+	def.Definitions = embedDefinitionMap(def.Definitions, refs)
+	def.Properties = embedDefinitionMap(def.Properties, refs)
+	// TODO: decide if we want to do this.
+	//def.AllOf = embedDefinitionArray(def.AllOf, refs)
+	def.AnyOf = embedDefinitionArray(def.AnyOf, refs)
+	def.OneOf = embedDefinitionArray(def.OneOf, refs)
+	if def.AdditionalItems != nil {
+		embedDefinition(def.AdditionalItems.Schema, refs)
+	}
+	if def.Items != nil {
+		embedDefinition(def.Items.Schema, refs)
+	}
+	embedDefinition(def.Not, refs)
+}
+
+func embedDefinitionMap(defs map[string]v1beta1.JSONSchemaProps, refs map[string]v1beta1.JSONSchemaProps) map[string]v1beta1.JSONSchemaProps {
+	newDefs := map[string]v1beta1.JSONSchemaProps{}
+	for i := range defs {
+		def := defs[i]
+		embedDefinition(&def, refs)
+		newDefs[i] = def
+	}
+	return newDefs
+}
+
+func embedDefinitionArray(defs []v1beta1.JSONSchemaProps, refs map[string]v1beta1.JSONSchemaProps) []v1beta1.JSONSchemaProps {
+	newDefs := make([]v1beta1.JSONSchemaProps, len(defs))
+	for i := range defs {
+		def := defs[i]
+		embedDefinition(&def, refs)
+		newDefs[i] = def
+	}
+	return newDefs
+}

--- a/pkg/crd/v2/flattener.go
+++ b/pkg/crd/v2/flattener.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+// Recursively flattens "allOf" tags. If there is cyclic
+// dependency, execution is aborted.
+func recursiveFlatten(defs v1beta1.JSONSchemaDefinitions, definition *v1beta1.JSONSchemaProps, defName string, visited *map[string]bool) *v1beta1.JSONSchemaProps {
+	if len(definition.AllOf) == 0 {
+		return definition
+	}
+	isAlreadyVisited := (*visited)[defName]
+	if isAlreadyVisited {
+		panic("Cycle detected in definitions")
+	}
+	(*visited)[defName] = true
+
+	aggregatedDef := &v1beta1.JSONSchemaProps{
+		Properties: definition.Properties,
+		Required:   definition.Required,
+		Type:       definition.Type,
+	}
+	for _, allOfDef := range definition.AllOf {
+		var newDef *v1beta1.JSONSchemaProps
+		if allOfDef.Ref != nil && len(*allOfDef.Ref) > 0 {
+			// If the definition has $ref url, fetch the referred resource
+			// after flattening it.
+			nameOfRef := getNameFromURL(*allOfDef.Ref)
+			def := defs[nameOfRef]
+			newDef = recursiveFlatten(defs, &def, nameOfRef, visited)
+		} else {
+			newDef = &allOfDef
+		}
+		mergeDefinitions(aggregatedDef, newDef)
+	}
+
+	delete(*visited, defName)
+	return aggregatedDef
+}
+
+// Merges the properties from the 'rhsDef' to the 'lhsDef'.
+// Also transfers the description as well.
+func mergeDefinitions(lhsDef *v1beta1.JSONSchemaProps, rhsDef *v1beta1.JSONSchemaProps) {
+	if lhsDef == nil || rhsDef == nil {
+		return
+	}
+	// At this point, both defs will not have any 'AnyOf' defs.
+	// 1. Add all the properties from rhsDef to lhsDef
+	if lhsDef.Properties == nil {
+		lhsDef.Properties = make(map[string]v1beta1.JSONSchemaProps)
+	}
+	for propKey := range rhsDef.Properties {
+		lhsDef.Properties[propKey] = rhsDef.Properties[propKey]
+	}
+	// 2. Transfer the description
+	lhsDef.Description = rhsDef.Description
+	// 3. Merge required fields
+	lhsDef.Required = append(lhsDef.Required, rhsDef.Required...)
+}
+
+// Flattens the schema by inlining 'allOf' tags.
+func flattenAllOf(defs v1beta1.JSONSchemaDefinitions) {
+	for nameOfDef := range defs {
+		visited := make(map[string]bool)
+		def := defs[nameOfDef]
+		defs[nameOfDef] = *recursiveFlatten(defs, &def, nameOfDef, &visited)
+	}
+}

--- a/pkg/crd/v2/generator.go
+++ b/pkg/crd/v2/generator.go
@@ -1,0 +1,668 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/spf13/afero"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	defPrefix = "#/definitions/"
+	inlineTag = "inline"
+)
+
+// Checks whether the typeName represents a simple json type
+
+// Removes a character by replacing it with a space
+func removeChar(str string, removedStr string) string {
+	return strings.Replace(str, removedStr, " ", -1)
+}
+
+// This is a hacky function that does the one job of
+// extracting the tag values in the structs
+// Example struct:
+// type MyType struct {
+//   MyField string `yaml:"myField,omitempty"`
+// }
+//
+// From the above example struct, we need to extract
+// and return this: ("myField", "omitempty")
+func extractFromTag(tag *ast.BasicLit) (string, string) {
+	if tag == nil || tag.Value == "" {
+		return "", ""
+	}
+	tagValue := tag.Value
+
+	tagValue = removeChar(tagValue, "`")
+	tagValue = removeChar(tagValue, `"`)
+	tagValue = strings.TrimSpace(tagValue)
+
+	var tagContent, tagKey string
+	fmt.Sscanf(tagValue, `%s %s`, &tagKey, &tagContent)
+
+	if tagKey != "json:" && tagKey != "yaml:" {
+		return "", ""
+	}
+
+	if strings.Contains(tagContent, ",") {
+		splitContent := strings.Split(tagContent, ",")
+		return splitContent[0], splitContent[1]
+	}
+	return tagContent, ""
+}
+
+// exprToSchema converts ast.Expr to JSONSchemaProps
+func (f *file) exprToSchema(t ast.Expr, doc string, comments []*ast.CommentGroup) (*v1beta1.JSONSchemaProps, []TypeReference) {
+	var def *v1beta1.JSONSchemaProps
+	var externalTypeRefs []TypeReference
+
+	switch tt := t.(type) {
+	case *ast.Ident:
+		def = f.identToSchema(tt, comments)
+	case *ast.ArrayType:
+		def, externalTypeRefs = f.arrayTypeToSchema(tt, doc, comments)
+	case *ast.MapType:
+		def = f.mapTypeToSchema(tt, doc, comments)
+	case *ast.SelectorExpr:
+		def, externalTypeRefs = f.selectorExprToSchema(tt, comments)
+	case *ast.StarExpr:
+		def, externalTypeRefs = f.exprToSchema(tt.X, "", comments)
+	case *ast.StructType:
+		def, externalTypeRefs = f.structTypeToSchema(tt)
+	case *ast.InterfaceType: // TODO: handle interface if necessary.
+		return &v1beta1.JSONSchemaProps{}, []TypeReference{}
+	}
+	def.Description = filterDescription(doc)
+
+	return def, externalTypeRefs
+}
+
+// identToSchema converts ast.Ident to JSONSchemaProps.
+func (f *file) identToSchema(ident *ast.Ident, comments []*ast.CommentGroup) *v1beta1.JSONSchemaProps {
+	def := &v1beta1.JSONSchemaProps{}
+	if isSimpleType(ident.Name) {
+		def.Type = jsonifyType(ident.Name)
+	} else {
+		def.Ref = getPrefixedDefLink(ident.Name, f.pkgPrefix)
+	}
+	processMarkersInComments(def, comments...)
+	return def
+}
+
+// identToSchema converts ast.SelectorExpr to JSONSchemaProps.
+func (f *file) selectorExprToSchema(selectorType *ast.SelectorExpr, comments []*ast.CommentGroup) (*v1beta1.JSONSchemaProps, []TypeReference) {
+	pkgAlias := selectorType.X.(*ast.Ident).Name
+	typeName := selectorType.Sel.Name
+
+	typ := TypeReference{
+		TypeName:    typeName,
+		PackageName: f.importPaths[pkgAlias],
+	}
+
+	time := TypeReference{TypeName: "Time", PackageName: "k8s.io/apimachinery/pkg/apis/meta/v1"}
+	duration := TypeReference{TypeName: "Duration", PackageName: "k8s.io/apimachinery/pkg/apis/meta/v1"}
+	quantity := TypeReference{TypeName: "Quantity", PackageName: "k8s.io/apimachinery/pkg/api/resource"}
+	unstructured := TypeReference{TypeName: "Unstructured", PackageName: "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"}
+	rawExtension := TypeReference{TypeName: "RawExtension", PackageName: "k8s.io/apimachinery/pkg/runtime"}
+	intOrString := TypeReference{TypeName: "IntOrString", PackageName: "k8s.io/apimachinery/pkg/util/intstr"}
+
+	switch typ {
+	case time:
+		return &v1beta1.JSONSchemaProps{
+			Type:   "string",
+			Format: "date-time",
+		}, []TypeReference{}
+	case duration:
+		return &v1beta1.JSONSchemaProps{
+			Type: "string",
+		}, []TypeReference{}
+	case quantity:
+		return &v1beta1.JSONSchemaProps{
+			Type: "string",
+		}, []TypeReference{}
+	case unstructured, rawExtension:
+		return &v1beta1.JSONSchemaProps{
+			Type: "object",
+		}, []TypeReference{}
+	case intOrString:
+		return &v1beta1.JSONSchemaProps{
+			AnyOf: []v1beta1.JSONSchemaProps{
+				{
+					Type: "string",
+				},
+				{
+					Type: "integer",
+				},
+			},
+		}, []TypeReference{}
+	}
+
+	def := &v1beta1.JSONSchemaProps{
+		Ref: getPrefixedDefLink(typeName, f.importPaths[pkgAlias]),
+	}
+	processMarkersInComments(def, comments...)
+	return def, []TypeReference{{TypeName: typeName, PackageName: pkgAlias}}
+}
+
+// arrayTypeToSchema converts ast.ArrayType to JSONSchemaProps by examining the elements in the array.
+func (f *file) arrayTypeToSchema(arrayType *ast.ArrayType, doc string, comments []*ast.CommentGroup) (*v1beta1.JSONSchemaProps, []TypeReference) {
+	// not passing doc down to exprToSchema
+	items, extRefs := f.exprToSchema(arrayType.Elt, "", comments)
+	processMarkersInComments(items, comments...)
+
+	def := &v1beta1.JSONSchemaProps{
+		Type:        "array",
+		Items:       &v1beta1.JSONSchemaPropsOrArray{Schema: items},
+		Description: doc,
+	}
+
+	// TODO: clear the schema on the parent level, since it is on the children level.
+
+	return def, extRefs
+}
+
+// mapTypeToSchema converts ast.MapType to JSONSchemaProps.
+func (f *file) mapTypeToSchema(mapType *ast.MapType, doc string, comments []*ast.CommentGroup) *v1beta1.JSONSchemaProps {
+	def := &v1beta1.JSONSchemaProps{}
+	switch mapType.Value.(type) {
+	case *ast.Ident:
+		valueType := mapType.Value.(*ast.Ident)
+		if def.AdditionalProperties == nil {
+			def.AdditionalProperties = &v1beta1.JSONSchemaPropsOrBool{}
+		}
+		def.AdditionalProperties.Schema = new(v1beta1.JSONSchemaProps)
+
+		if isSimpleType(valueType.Name) {
+			def.AdditionalProperties.Schema.Type = valueType.Name
+		} else {
+			def.AdditionalProperties.Schema.Ref = getPrefixedDefLink(valueType.Name, f.pkgPrefix)
+		}
+	case *ast.InterfaceType:
+		// No op
+		panic("Map Interface Type")
+	}
+	def.Type = "object"
+	def.Description = doc
+	processMarkersInComments(def, comments...)
+	return def
+}
+
+// structTypeToSchema converts ast.StructType to JSONSchemaProps by examining each field in the struct.
+func (f *file) structTypeToSchema(structType *ast.StructType) (*v1beta1.JSONSchemaProps, []TypeReference) {
+	def := &v1beta1.JSONSchemaProps{
+		Type: "object",
+	}
+	externalTypeRefs := []TypeReference{}
+	for _, field := range structType.Fields.List {
+		yamlName, option := extractFromTag(field.Tag)
+
+		if (yamlName == "" && option != inlineTag) || yamlName == "-" {
+			continue
+		}
+
+		if option != inlineTag && option != "omitempty" {
+			def.Required = append(def.Required, yamlName)
+		}
+
+		if def.Properties == nil {
+			def.Properties = make(map[string]v1beta1.JSONSchemaProps)
+		}
+
+		propDef, propExternalTypeDefs := f.exprToSchema(field.Type, field.Doc.Text(), f.commentMap[field])
+
+		externalTypeRefs = append(externalTypeRefs, propExternalTypeDefs...)
+
+		if option == inlineTag {
+			def.AllOf = append(def.AllOf, *propDef)
+			continue
+		}
+
+		def.Properties[yamlName] = *propDef
+	}
+
+	return def, externalTypeRefs
+}
+
+func getReachableTypes(startingTypes map[string]bool, definitions v1beta1.JSONSchemaDefinitions) map[string]bool {
+	pruner := DefinitionPruner{definitions, startingTypes}
+	prunedTypes := pruner.Prune(true)
+	return prunedTypes
+}
+
+type file struct {
+	// name prefix of the package
+	pkgPrefix string
+	// importPaths contains a map from import alias to the import path for the file.
+	importPaths map[string]string
+	// commentMap is comment mapping for this file.
+	commentMap ast.CommentMap
+}
+
+func (pr *prsr) parseTypesInFile(filePath string, curPkgPrefix string, skipCRD bool) (
+	v1beta1.JSONSchemaDefinitions, ExternalReferences, crdSpecByKind) {
+	// Open the input go file and parse the Abstract Syntax Tree
+	fset := token.NewFileSet()
+	srcFile, err := pr.fs.Open(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	node, err := parser.ParseFile(fset, filePath, srcFile, parser.ParseComments)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !skipCRD {
+		// process top-level (not tied to a struct field) markers.
+		// e.g. group name marker +groupName=<group-name>
+		pr.processTopLevelMarkers(node.Comments)
+	}
+
+	definitions := make(v1beta1.JSONSchemaDefinitions)
+	externalRefs := make(ExternalReferences)
+
+	// Parse import statements to get "alias: pkgName" mapping
+	importPaths := make(map[string]string)
+	for _, importItem := range node.Imports {
+		pathValue := strings.Trim(importItem.Path.Value, "\"")
+		if importItem.Name != nil {
+			// Process aliased import
+			importPaths[importItem.Name.Name] = pathValue
+		} else if strings.Contains(pathValue, "/") {
+			// Process unnamed imports with "/"
+			segments := strings.Split(pathValue, "/")
+			importPaths[segments[len(segments)-1]] = pathValue
+		} else {
+			importPaths[pathValue] = pathValue
+		}
+	}
+
+	// Create an ast.CommentMap from the ast.File's comments.
+	// This helps keeping the association between comments and AST nodes.
+	// TODO: if necessary, support our own rules of comments ownership, golang's
+	// builtin rules are listed at https://golang.org/pkg/go/ast/#NewCommentMap.
+	// It seems it can meet our need at the moment.
+	cmap := ast.NewCommentMap(fset, node, node.Comments)
+
+	f := &file{
+		pkgPrefix:   curPkgPrefix,
+		importPaths: importPaths,
+		commentMap:  cmap,
+	}
+
+	crdSpecs := crdSpecByKind{}
+	for i := range node.Decls {
+		declaration, ok := node.Decls[i].(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+
+		// Skip it if it's not type declaration.
+		if declaration.Tok != token.TYPE {
+			continue
+		}
+
+		// We support the following format
+		// // TreeNode doc
+		// type TreeNode struct {
+		//   left, right *TreeNode
+		//   value *Comparable
+		// }
+		// but not
+		// type (
+		//   // Point doc
+		//   Point struct{ x, y float64 }
+		//   // Point2 doc
+		//   Point2 struct{ x, y int }
+		// )
+		// since the latter format is rarely used in k8s.
+		if len(declaration.Specs) != 1 {
+			continue
+		}
+		ts := declaration.Specs[0]
+		typeSpec, ok := ts.(*ast.TypeSpec)
+		if !ok {
+			fmt.Printf("spec type is: %T\n", ts)
+			continue
+		}
+
+		typeName := typeSpec.Name.Name
+		typeDescription := declaration.Doc.Text()
+
+		fmt.Println("Generating schema definition for type:", typeName)
+		def, refTypes := f.exprToSchema(typeSpec.Type, typeDescription, []*ast.CommentGroup{})
+		definitions[getFullName(typeName, curPkgPrefix)] = *def
+		externalRefs[getFullName(typeName, curPkgPrefix)] = refTypes
+
+		var comments []string
+		for _, c := range f.commentMap[node.Decls[i]] {
+			comments = append(comments, strings.Split(c.Text(), "\n")...)
+		}
+
+		if !skipCRD {
+			crdSpec := parseCRDs(comments)
+			if crdSpec != nil {
+				crdSpec.Names.Kind = typeName
+				gk := schema.GroupKind{Kind: typeName}
+				crdSpecs[gk] = crdSpec
+				// TODO: validate the CRD spec for one version.
+			}
+		}
+	}
+
+	// Overwrite import aliases with actual package names
+	for typeName := range externalRefs {
+		for i, ref := range externalRefs[typeName] {
+			externalRefs[typeName][i].PackageName = importPaths[ref.PackageName]
+		}
+	}
+
+	return definitions, externalRefs, crdSpecs
+}
+
+// processTopLevelMarkers process top-level (not tied to a struct field) markers.
+// e.g. group name marker +groupName=<group-name>
+func (pr *prsr) processTopLevelMarkers(comments []*ast.CommentGroup) {
+	for _, c := range comments {
+		commentLines := strings.Split(c.Text(), "\n")
+		cs := Comments(commentLines)
+		if cs.hasTag("groupName") {
+			group := cs.getTag("groupName", "=")
+			if len(group) == 0 {
+				log.Fatalf("can't use an empty name for the +groupName marker")
+			}
+			if pr.generatorOptions != nil && len(pr.generatorOptions.group) > 0 && group != pr.generatorOptions.group {
+				log.Fatalf("can't have different group names %q and %q one package", pr.generatorOptions.group, group)
+			}
+			if pr.generatorOptions == nil {
+				pr.generatorOptions = &toplevelGeneratorOptions{group: group}
+			} else {
+				pr.generatorOptions.group = group
+			}
+		}
+	}
+}
+
+// mock this in testing.
+var listFiles = func(pkgPath string) (string, []string, error) {
+	pkg, err := build.Import(pkgPath, "", 0)
+	return pkg.Dir, pkg.GoFiles, err
+}
+
+func (pr *prsr) parseTypesInPackage(pkgName string, referencedTypes map[string]bool, rootPackage, skipCRD bool) (
+	v1beta1.JSONSchemaDefinitions, crdSpecByKind) {
+	pkgDefs := make(v1beta1.JSONSchemaDefinitions)
+	pkgExternalTypes := make(ExternalReferences)
+	pkgCRDSpecs := make(crdSpecByKind)
+
+	pkgDir, listOfFiles, err := listFiles(pkgName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pkgPrefix := strings.Replace(pkgName, "/", ".", -1)
+	if rootPackage {
+		pkgPrefix = ""
+	}
+	fmt.Println("pkgPrefix=", pkgPrefix)
+	for _, fileName := range listOfFiles {
+		fmt.Println("Processing file ", fileName)
+		fileDefs, fileExternalRefs, fileCRDSpecs := pr.parseTypesInFile(filepath.Join(pkgDir, fileName), pkgPrefix, skipCRD)
+		mergeDefs(pkgDefs, fileDefs)
+		mergeExternalRefs(pkgExternalTypes, fileExternalRefs)
+		mergeCRDSpecs(pkgCRDSpecs, fileCRDSpecs)
+	}
+
+	// Add pkg prefix to referencedTypes
+	newReferencedTypes := make(map[string]bool)
+	for key := range referencedTypes {
+		altKey := getFullName(key, pkgPrefix)
+		newReferencedTypes[altKey] = referencedTypes[key]
+	}
+	referencedTypes = newReferencedTypes
+
+	fmt.Println("referencedTypes")
+	debugPrint(referencedTypes)
+
+	allReachableTypes := getReachableTypes(referencedTypes, pkgDefs)
+	for key := range pkgDefs {
+		if _, exists := allReachableTypes[key]; !exists {
+			delete(pkgDefs, key)
+			delete(pkgExternalTypes, key)
+		}
+	}
+	fmt.Println("allReachableTypes")
+	debugPrint(allReachableTypes)
+	fmt.Println("pkgDefs")
+	debugPrint(pkgDefs)
+	fmt.Println("pkgExternalTypes")
+	debugPrint(pkgExternalTypes)
+
+	uniquePkgTypeRefs := make(map[string]map[string]bool)
+	for _, item := range pkgExternalTypes {
+		for _, typeRef := range item {
+			if _, ok := uniquePkgTypeRefs[typeRef.PackageName]; !ok {
+				uniquePkgTypeRefs[typeRef.PackageName] = make(map[string]bool)
+			}
+			uniquePkgTypeRefs[typeRef.PackageName][typeRef.TypeName] = true
+		}
+	}
+
+	for childPkgName := range uniquePkgTypeRefs {
+		childTypes := uniquePkgTypeRefs[childPkgName]
+		childPkgPr := prsr{fs: pr.fs}
+		childDefs, _ := childPkgPr.parseTypesInPackage(childPkgName, childTypes, false, true)
+		mergeDefs(pkgDefs, childDefs)
+	}
+
+	return pkgDefs, pkgCRDSpecs
+}
+
+type SingleVersionOptions struct {
+	// InputPackage is the path of the input package that contains source files.
+	InputPackage string
+	// Types is a list of target types.
+	Types []string
+	// Flatten contains if we use a flattened structure or a embedded structure.
+	Flatten bool
+
+	// fs is provided FS. We can use afero.NewMemFs() for testing.
+	fs afero.Fs
+}
+
+type WriterOptions struct {
+	// OutputPath is the path that the schema will be written to.
+	OutputPath string
+	// OutputFormat should be either json or yaml. Default to json
+	OutputFormat string
+
+	defs     v1beta1.JSONSchemaDefinitions
+	crdSpecs crdSpecByKind
+}
+
+type SingleVersionGenerator struct {
+	SingleVersionOptions
+	WriterOptions
+
+	outputCRD bool
+}
+
+type toplevelGeneratorOptions struct {
+	group string
+}
+
+type prsr struct {
+	generatorOptions *toplevelGeneratorOptions
+
+	fs afero.Fs
+}
+
+func (op *SingleVersionGenerator) Generate() {
+	if len(op.InputPackage) == 0 || len(op.OutputPath) == 0 {
+		log.Panic("Both input path and output paths need to be set")
+	}
+
+	if op.fs == nil {
+		op.fs = afero.NewOsFs()
+	}
+
+	if op.outputCRD {
+		// if generating CRD, we should always embed schemas.
+		op.Flatten = false
+	}
+
+	op.defs, op.crdSpecs = op.parse()
+
+	op.write(op.outputCRD, op.Types)
+}
+
+func (pr *prsr) linkCRDSpec(defs v1beta1.JSONSchemaDefinitions, crdSpecs crdSpecByKind) crdSpecByKind {
+	rtCRDSpecs := crdSpecByKind{}
+	for gk := range crdSpecs {
+		if pr.generatorOptions != nil {
+			crdSpecs[gk].Group = pr.generatorOptions.group
+			rtCRDSpecs[schema.GroupKind{Group: pr.generatorOptions.group, Kind: gk.Kind}] = crdSpecs[gk]
+		} else {
+			rtCRDSpecs[gk] = crdSpecs[gk]
+		}
+
+		if len(crdSpecs[gk].Versions) == 0 {
+			log.Printf("no version for CRD %q", gk)
+			continue
+		}
+		if len(crdSpecs[gk].Versions) > 1 {
+			log.Fatalf("the number of versions in one package is more than 1")
+		}
+		def, ok := defs[gk.Kind]
+		if !ok {
+			log.Printf("can't get json shchema for %q", gk)
+			continue
+		}
+		crdSpecs[gk].Versions[0].Schema = &v1beta1.CustomResourceValidation{
+			OpenAPIV3Schema: &def,
+		}
+	}
+	return rtCRDSpecs
+}
+
+func (op *SingleVersionOptions) parse() (v1beta1.JSONSchemaDefinitions, crdSpecByKind) {
+	startingPointMap := make(map[string]bool)
+	for i := range op.Types {
+		startingPointMap[op.Types[i]] = true
+	}
+	pr := prsr{fs: op.fs}
+	defs, crdSpecs := pr.parseTypesInPackage(op.InputPackage, startingPointMap, true, false)
+
+	// flattenAllOf only flattens allOf tags
+	flattenAllOf(defs)
+
+	reachableTypes := getReachableTypes(startingPointMap, defs)
+	for key := range defs {
+		if _, exists := reachableTypes[key]; !exists {
+			delete(defs, key)
+		}
+	}
+
+	checkDefinitions(defs, startingPointMap)
+
+	if !op.Flatten {
+		defs = embedSchema(defs, startingPointMap)
+
+		newDefs := v1beta1.JSONSchemaDefinitions{}
+		for name := range startingPointMap {
+			newDefs[name] = defs[name]
+		}
+		defs = newDefs
+	}
+
+	return defs, pr.linkCRDSpec(defs, crdSpecs)
+}
+
+func (op *WriterOptions) write(outputCRD bool, types []string) {
+	var toSerilizeList []interface{}
+	if outputCRD {
+		for gk, spec := range op.crdSpecs {
+			crd := &v1beta1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apiextensions.k8s.io/v1beta1",
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   strings.ToLower(gk.Kind),
+					Labels: map[string]string{"controller-tools.k8s.io": "1.0"},
+				},
+				Spec: *spec,
+			}
+			toSerilizeList = append(toSerilizeList, crd)
+		}
+	} else {
+		schema := v1beta1.JSONSchemaProps{Definitions: op.defs}
+		schema.Type = "object"
+		schema.AnyOf = []v1beta1.JSONSchemaProps{}
+		for _, typeName := range types {
+			schema.AnyOf = append(schema.AnyOf, v1beta1.JSONSchemaProps{Ref: getDefLink(typeName)})
+		}
+		toSerilizeList = []interface{}{schema}
+	}
+
+	// TODO: create dir is not exist.
+	out, err := os.Create(op.OutputPath)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	for i := range toSerilizeList {
+		switch strings.ToLower(op.OutputFormat) {
+		// default to json
+		case "json", "":
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			err = enc.Encode(toSerilizeList[i])
+			if err2 := out.Close(); err == nil {
+				err = err2
+			}
+			if err != nil {
+				log.Panic(err)
+			}
+		case "yaml":
+			m, err := yaml.Marshal(toSerilizeList[i])
+			if err != nil {
+				log.Panic(err)
+			}
+			err = ioutil.WriteFile(op.OutputPath, m, 0644)
+			if err != nil {
+				log.Panic(err)
+			}
+		}
+	}
+}

--- a/pkg/crd/v2/multiversion.go
+++ b/pkg/crd/v2/multiversion.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+)
+
+type MultiVersionOptions struct {
+	// InputPackage is the path of the input package that contains source files.
+	InputPackage string
+	// Types is a list of target types.
+	Types []string
+
+	// fs is provided FS. We can use afero.NewMemFs() for testing.
+	fs afero.Fs
+}
+
+type MultiVersionGenerator struct {
+	MultiVersionOptions
+	WriterOptions
+}
+
+func (op *MultiVersionGenerator) Generate() {
+	if len(op.InputPackage) == 0 || len(op.OutputPath) == 0 {
+		log.Panic("Both input path and output paths need to be set")
+	}
+
+	if op.fs == nil {
+		op.fs = afero.NewOsFs()
+	}
+
+	op.crdSpecs = op.parse()
+
+	op.write(true, op.Types)
+}
+
+func listDirs(path string) ([]string, error) {
+	pkg, err := build.Import(path, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	infos, err := ioutil.ReadDir(pkg.Dir)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, info := range infos {
+		if info.IsDir() {
+			dirs = append(dirs, info.Name())
+		}
+	}
+	return dirs, nil
+}
+
+func (op *MultiVersionOptions) parse() crdSpecByKind {
+	startingPointMap := make(map[string]bool)
+	for i := range op.Types {
+		startingPointMap[op.Types[i]] = true
+	}
+
+	dirs, err := listDirs(op.InputPackage)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(dirs)
+
+	crdSpecs := crdSpecByKind{}
+	for _, dir := range dirs {
+		singleVer := SingleVersionOptions{
+			Types:        op.Types,
+			InputPackage: filepath.Join(op.InputPackage, dir),
+			Flatten:      false,
+			fs:           op.fs,
+		}
+		_, crdSingleVersionSpecs := singleVer.parse()
+		// merge crd versions
+		err = mergeCRDVersions(crdSpecs, crdSingleVersionSpecs)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return crdSpecs
+}

--- a/pkg/crd/v2/parser.go
+++ b/pkg/crd/v2/parser.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"go/ast"
+	"log"
+	"strconv"
+	"strings"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+// filterDescription parse comments above each field in the type definition.
+func filterDescription(res string) string {
+	var temp strings.Builder
+	var desc string
+	for _, comment := range strings.Split(res, "\n") {
+		comment = strings.Trim(comment, " ")
+		if !(strings.Contains(comment, "+kubebuilder") || strings.HasPrefix(comment, "+")) {
+			temp.WriteString(comment)
+			temp.WriteString(" ")
+			desc = strings.TrimRight(temp.String(), " ")
+		}
+	}
+	return desc
+}
+
+func processMarkersInComments(def *v1beta1.JSONSchemaProps, commentGroups ...*ast.CommentGroup) {
+	for _, commentGroup := range commentGroups {
+		for _, comment := range strings.Split(commentGroup.Text(), "\n") {
+			getValidation(comment, def)
+		}
+	}
+}
+
+// This method is ported from controller-tools, it can removed when things are moved back.
+// getValidation parses the validation tags from the comment and sets the
+// validation rules on the given JSONSchemaProps.
+// TODO: reduce the cyclomatic complexity and remove next line
+//// nolint: gocyclo
+func getValidation(comment string, props *v1beta1.JSONSchemaProps) {
+	const arrayType = "array"
+	comment = strings.TrimLeft(comment, " ")
+	if !strings.HasPrefix(comment, "+kubebuilder:validation:") {
+		return
+	}
+	c := strings.Replace(comment, "+kubebuilder:validation:", "", -1)
+	parts := strings.Split(c, "=")
+	if len(parts) != 2 {
+		log.Fatalf("Expected +kubebuilder:validation:<key>=<value> actual: %s", comment)
+		return
+	}
+	switch parts[0] {
+	case "Maximum":
+		f, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			log.Fatalf("Could not parse float from %s: %v", comment, err)
+			return
+		}
+		props.Maximum = &f
+	case "ExclusiveMaximum":
+		b, err := strconv.ParseBool(parts[1])
+		if err != nil {
+			log.Fatalf("Could not parse bool from %s: %v", comment, err)
+			return
+		}
+		props.ExclusiveMaximum = b
+	case "Minimum":
+		f, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			log.Fatalf("Could not parse float from %s: %v", comment, err)
+			return
+		}
+		props.Minimum = &f
+	case "ExclusiveMinimum":
+		b, err := strconv.ParseBool(parts[1])
+		if err != nil {
+			log.Fatalf("Could not parse bool from %s: %v", comment, err)
+			return
+		}
+		props.ExclusiveMinimum = b
+	case "MaxLength":
+		i, err := strconv.Atoi(parts[1])
+		v := int64(i)
+		if err != nil {
+			log.Fatalf("Could not parse int from %s: %v", comment, err)
+			return
+		}
+		props.MaxLength = &v
+	case "MinLength":
+		i, err := strconv.Atoi(parts[1])
+		v := int64(i)
+		if err != nil {
+			log.Fatalf("Could not parse int from %s: %v", comment, err)
+			return
+		}
+		props.MinLength = &v
+	case "Pattern":
+		props.Pattern = parts[1]
+	case "MaxItems":
+		if props.Type == arrayType {
+			i, err := strconv.Atoi(parts[1])
+			v := int64(i)
+			if err != nil {
+				log.Fatalf("Could not parse int from %s: %v", comment, err)
+				return
+			}
+			props.MaxItems = &v
+		}
+	case "MinItems":
+		if props.Type == arrayType {
+			i, err := strconv.Atoi(parts[1])
+			v := int64(i)
+			if err != nil {
+				log.Fatalf("Could not parse int from %s: %v", comment, err)
+				return
+			}
+			props.MinItems = &v
+		}
+	case "UniqueItems":
+		if props.Type == arrayType {
+			b, err := strconv.ParseBool(parts[1])
+			if err != nil {
+				log.Fatalf("Could not parse bool from %s: %v", comment, err)
+				return
+			}
+			props.UniqueItems = b
+		}
+	case "MultipleOf":
+		f, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			log.Fatalf("Could not parse float from %s: %v", comment, err)
+			return
+		}
+		props.MultipleOf = &f
+	case "Enum":
+		if props.Type != arrayType {
+			value := strings.Split(parts[1], ",")
+			enums := []v1beta1.JSON{}
+			for _, s := range value {
+				checkType(props, s, &enums)
+			}
+			props.Enum = enums
+		}
+	case "Format":
+		props.Format = parts[1]
+	default:
+		log.Fatalf("Unsupport validation: %s", comment)
+	}
+}
+
+// check type of enum element value to match type of field
+func checkType(props *v1beta1.JSONSchemaProps, s string, enums *[]v1beta1.JSON) {
+	switch props.Type {
+	case "integer":
+		if _, err := strconv.ParseInt(s, 0, 64); err != nil {
+			log.Fatalf("Invalid integer value [%v] for a field of integer type", s)
+		}
+		*enums = append(*enums, v1beta1.JSON{Raw: []byte(fmt.Sprintf("%v", s))})
+	case "float", "number":
+		if _, err := strconv.ParseFloat(s, 64); err != nil {
+			log.Fatalf("Invalid float value [%v] for a field of float type", s)
+		}
+		*enums = append(*enums, v1beta1.JSON{Raw: []byte(fmt.Sprintf("%v", s))})
+	case "string":
+		*enums = append(*enums, v1beta1.JSON{Raw: []byte(`"` + s + `"`)})
+	}
+}

--- a/pkg/crd/v2/types.go
+++ b/pkg/crd/v2/types.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type crdSpecByKind map[schema.GroupKind]*v1beta1.CustomResourceDefinitionSpec
+
+// TypeReference denotes the (typeName, packageName) tuple
+type TypeReference struct {
+	TypeName    string
+	PackageName string
+}
+
+// ExternalReferences map contains list of "type: packageName" entries
+type ExternalReferences map[string][]TypeReference

--- a/pkg/crd/v2/utils.go
+++ b/pkg/crd/v2/utils.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+const (
+	stringType  = "string"
+	intType     = "int"
+	int32Type   = "int32"
+	int64Type   = "int64"
+	boolType    = "bool"
+	byteType    = "byte"
+	float32Type = "float32"
+	float64Type = "float64"
+
+	stringJSONType  = "string"
+	integerJSONType = "integer"
+	booleanJSONType = "boolean"
+	floatJSONType   = "float"
+)
+
+func isSimpleType(typeName string) bool {
+	return typeName == stringType || typeName == intType ||
+		typeName == int32Type || typeName == int64Type ||
+		typeName == boolType || typeName == byteType ||
+		typeName == float32Type || typeName == float64Type
+}
+
+// Converts the typeName simple type to json type
+func jsonifyType(typeName string) string {
+	switch typeName {
+	case stringType:
+		return stringJSONType
+	case boolType:
+		return booleanJSONType
+	case intType, int32Type, int64Type:
+		return integerJSONType
+	case float32Type, float64Type:
+		return floatJSONType
+	case byteType:
+		return stringJSONType
+	}
+	fmt.Println("jsonifyType called with a complex type ", typeName)
+	panic("jsonifyType called with a complex type")
+}
+
+func mergeDefs(lhs v1beta1.JSONSchemaDefinitions, rhs v1beta1.JSONSchemaDefinitions) {
+	if lhs == nil || rhs == nil {
+		return
+	}
+	for key := range rhs {
+		_, ok := lhs[key]
+		if ok {
+			// change this to logger
+			fmt.Println("JSONSchemaProps ", key, " already present")
+			continue
+		}
+		lhs[key] = rhs[key]
+	}
+}
+
+func mergeExternalRefs(lhs ExternalReferences, rhs ExternalReferences) {
+	if lhs == nil || rhs == nil {
+		return
+	}
+	for key := range rhs {
+		_, ok := lhs[key]
+		if !ok {
+			lhs[key] = rhs[key]
+		} else {
+			lhs[key] = append(lhs[key], rhs[key]...)
+		}
+	}
+}
+
+func mergeCRDSpecs(lhs, rhs crdSpecByKind) {
+	if lhs == nil || rhs == nil {
+		return
+	}
+	for key := range rhs {
+		_, ok := lhs[key]
+		if ok {
+			// TODO: change this to use logger
+			fmt.Printf("CRD spec for kind %q already present", key)
+			continue
+		}
+		lhs[key] = rhs[key]
+	}
+}
+
+func mergeCRDVersions(lhs, rhs crdSpecByKind) error {
+	if lhs == nil || rhs == nil {
+		return nil
+	}
+	for gk := range rhs {
+		_, ok := lhs[gk]
+		if !ok {
+			lhs[gk] = rhs[gk]
+			continue
+		}
+
+		if len(lhs[gk].Group) == 0 {
+			lhs[gk].Group = rhs[gk].Group
+		} else if lhs[gk].Group != rhs[gk].Group {
+			return fmt.Errorf("group names %q and %q from different packages must match", lhs[gk].Group, rhs[gk].Group)
+		}
+
+		if len(lhs[gk].Scope) == 0 {
+			lhs[gk].Scope = rhs[gk].Scope
+		} else if lhs[gk].Scope != rhs[gk].Scope {
+			return fmt.Errorf("group names %q and %q from different packages must match", lhs[gk].Group, rhs[gk].Group)
+		}
+
+		if len(lhs[gk].Names.Kind) == 0 {
+			lhs[gk].Names.Kind = rhs[gk].Names.Kind
+		} else if lhs[gk].Names.Kind != rhs[gk].Names.Kind {
+			return fmt.Errorf("kind names %q and %q from different packages must match", lhs[gk].Names.Kind, rhs[gk].Names.Kind)
+		}
+		if len(lhs[gk].Names.Plural) == 0 {
+			lhs[gk].Names.Plural = rhs[gk].Names.Plural
+		} else if lhs[gk].Names.Plural != rhs[gk].Names.Plural {
+			return fmt.Errorf("plural resource names %q and %q from different packages must match", lhs[gk].Names.Plural, rhs[gk].Names.Plural)
+		}
+		if len(lhs[gk].Names.Singular) == 0 {
+			lhs[gk].Names.Singular = rhs[gk].Names.Singular
+		} else if lhs[gk].Names.Singular != rhs[gk].Names.Singular {
+			return fmt.Errorf("singular resource names %q and %q from different packages must match", lhs[gk].Names.Singular, rhs[gk].Names.Singular)
+		}
+		if len(lhs[gk].Names.ShortNames) == 0 {
+			lhs[gk].Names.ShortNames = rhs[gk].Names.ShortNames
+		} else if !reflect.DeepEqual(lhs[gk].Names.ShortNames, rhs[gk].Names.ShortNames) {
+			return fmt.Errorf("short names %s and %s from different packages must match", lhs[gk].Names.ShortNames, rhs[gk].Names.ShortNames)
+		}
+
+		lhs[gk].Versions = append(lhs[gk].Versions, rhs[gk].Versions...)
+	}
+	return nil
+}
+
+func debugPrint(obj interface{}) {
+	b, err3 := json.Marshal(obj)
+	if err3 != nil {
+		panic("Error")
+	}
+	fmt.Println(string(b))
+}
+
+// Gets the schema definition link of a resource
+func getDefLink(resourceName string) *string {
+	ret := defPrefix + resourceName
+	return &ret
+}
+
+func getFullName(resourceName string, prefix string) string {
+	if prefix == "" {
+		return resourceName
+	}
+	prefix = strings.Replace(prefix, "/", ".", -1)
+	return prefix + "." + resourceName
+}
+
+func getPrefixedDefLink(resourceName string, prefix string) *string {
+	ret := defPrefix + getFullName(resourceName, prefix)
+	return &ret
+}
+
+// Gets the resource name from definitions url.
+// Eg, returns 'TypeName' from '#/definitions/TypeName'
+func getNameFromURL(url string) string {
+	slice := strings.Split(url, "/")
+	return slice[len(slice)-1]
+}


### PR DESCRIPTION
In this PR, I am contributing changes from: https://github.com/redborian/go-types-to-jsonschema. It uses built-in go types to parse a given go package into JSON schema. This has contributions from both myself as well as @mengqiy.
These changes will go to `crdgenerator` feature branch. The generator has not been wired up with commands. Once this PR goes through, we will look at wiring it up. Also, it needs test coverage that we will be adding later in the feature branch. Once we get the green light, we will merge the feature branch into master branch.