### PR TITLE
drop annotation in webhook manifests generator

### DIFF
--- a/pkg/webhook/generator.go
+++ b/pkg/webhook/generator.go
@@ -170,10 +170,6 @@ func (o *generatorOptions) mutatingWHConfig() (runtime.Object, error) {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: o.mutatingWebhookConfigName,
-				Annotations: map[string]string{
-					// TODO(DirectXMan12): Change the annotation to the format that cert-manager decides to use.
-					"alpha.admissionwebhook.cert-manager.io": "true",
-				},
 			},
 			Webhooks: mutatingWebhooks,
 		}, nil
@@ -209,10 +205,6 @@ func (o *generatorOptions) validatingWHConfigs() (runtime.Object, error) {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: o.validatingWebhookConfigName,
-				Annotations: map[string]string{
-					// TODO(DirectXMan12): Change the annotation to the format that cert-manager decides to use.
-					"alpha.admissionwebhook.cert-manager.io": "true",
-				},
 			},
 			Webhooks: validatingWebhooks,
 		}, nil
@@ -313,11 +305,6 @@ func (o *generatorOptions) getService() runtime.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      o.service.name,
 			Namespace: o.service.namespace,
-			Annotations: map[string]string{
-				// Secret here only need name, since it will be in the same namespace as the service.
-				// TODO(DirectXMan12): Change the annotation to the format that cert-manager decides to use.
-				"alpha.service.cert-manager.io/serving-cert-secret-name": o.secret.Name,
-			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: o.service.selectors,

--- a/pkg/webhook/generator_test.go
+++ b/pkg/webhook/generator_test.go
@@ -27,8 +27,6 @@ var expected = map[string]string{
 	"config/webhook/webhookmanifests.yaml": `apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    alpha.admissionwebhook.cert-manager.io: "true"
   creationTimestamp: null
   name: test-mutating-webhook-cfg
 webhooks:
@@ -56,8 +54,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    alpha.admissionwebhook.cert-manager.io: "true"
   creationTimestamp: null
   name: test-validating-webhook-cfg
 webhooks:
@@ -86,8 +82,6 @@ webhooks:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    alpha.service.cert-manager.io/serving-cert-secret-name: webhook-secret
   creationTimestamp: null
   name: webhook-service
   namespace: test-system


### PR DESCRIPTION
drop annotation in webhook manifests generator since the annotation will be done in kubebuilder.