### PR TITLE
:bug: Fix import path for references to testData/

### DIFF
--- a/testData/Dockerfile
+++ b/testData/Dockerfile
@@ -2,16 +2,16 @@
 FROM golang:1.10.3 as builder
 
 # Copy in the go src
-WORKDIR /go/src/sigs.k8s.io/controller-tools/pkg/crd/generator/testData
+WORKDIR /go/src/sigs.k8s.io/controller-tools/testData
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 COPY vendor/ vendor/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/controller-tools/pkg/crd/generator/testData/cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/controller-tools/testData/cmd/manager
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
 WORKDIR /
-COPY --from=builder /go/src/sigs.k8s.io/controller-tools/pkg/crd/generator/testData/manager .
+COPY --from=builder /go/src/sigs.k8s.io/controller-tools/testData/manager .
 ENTRYPOINT ["/manager"]

--- a/testData/Makefile
+++ b/testData/Makefile
@@ -10,7 +10,7 @@ test: generate fmt vet manifests
 
 # Build manager binary
 manager: generate fmt vet
-	go build -o bin/manager sigs.k8s.io/controller-tools/pkg/crd/generator/testData/cmd/manager
+	go build -o bin/manager sigs.k8s.io/controller-tools/testData/cmd/manager
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet

--- a/testData/PROJECT
+++ b/testData/PROJECT
@@ -1,3 +1,3 @@
 version: "1"
 domain: myk8s.io
-repo: sigs.k8s.io/controller-tools/pkg/crd/generator/testData
+repo: sigs.k8s.io/controller-tools/testData

--- a/testData/cmd/manager/main.go
+++ b/testData/cmd/manager/main.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
-	"sigs.k8s.io/controller-tools/pkg/crd/generator/testData/pkg/apis"
-	"sigs.k8s.io/controller-tools/pkg/crd/generator/testData/pkg/controller"
+	"sigs.k8s.io/controller-tools/testData/pkg/apis"
+	"sigs.k8s.io/controller-tools/testData/pkg/controller"
 )
 
 func main() {

--- a/testData/go.mod
+++ b/testData/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/controller-tools/pkg/crd/generator/testData
+module sigs.k8s.io/controller-tools/testData
 
 go 1.12
 

--- a/testData/pkg/apis/addtoscheme_fun_v1alpha1.go
+++ b/testData/pkg/apis/addtoscheme_fun_v1alpha1.go
@@ -16,7 +16,7 @@ limitations under the License.
 package apis
 
 import (
-	"sigs.k8s.io/controller-tools/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1"
+	"sigs.k8s.io/controller-tools/testData/pkg/apis/fun/v1alpha1"
 )
 
 func init() {

--- a/testData/pkg/apis/fun/v1alpha1/doc.go
+++ b/testData/pkg/apis/fun/v1alpha1/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the fun v1alpha1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=sigs.k8s.io/controller-tools/pkg/crd/generator/testData/pkg/apis/fun
+// +k8s:conversion-gen=sigs.k8s.io/controller-tools/testData/pkg/apis/fun
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=fun.myk8s.io
 package v1alpha1

--- a/testData/pkg/apis/fun/v1alpha1/register.go
+++ b/testData/pkg/apis/fun/v1alpha1/register.go
@@ -18,7 +18,7 @@ limitations under the License.
 // Package v1alpha1 contains API Schema definitions for the fun v1alpha1 API group
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=sigs.k8s.io/controller-tools/pkg/crd/generator/testData/pkg/apis/fun
+// +k8s:conversion-gen=sigs.k8s.io/controller-tools/testData/pkg/apis/fun
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=fun.myk8s.io
 package v1alpha1


### PR DESCRIPTION
It appears that the testData/ directory was moved to its current location in a different PR but the previous  path was not modified in a few files. This causes `go get sigs.k8s.io/controller-tools` to fail.

With this fix, the mentioned command will work. I noticed that even with these fixes, `make all` fails but I think that is out of scope for this PR. 
