### PR TITLE
:bug: Fix incompatible CRDs

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -119,9 +119,9 @@ type PrintColumn struct {
 	Name        string
 	Type        string
 	JSONPath    string `marker:"JSONPath"` // legacy cruft
-	Description string
-	Format      string
-	Priority    int32
+	Description string `marker:",optional"`
+	Format      string `marker:",optional"`
+	Priority    int32  `marker:",optional"`
 }
 
 func (s PrintColumn) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error {

--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -137,5 +137,11 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind) {
 		packages[0].AddError(fmt.Errorf("CRD for %s has no storage version", groupKind))
 	}
 
+	// NB(directxman12): CRD's status doesn't have omitempty markers, which means things
+	// get serialized as null, which causes the validator to freak out.  Manually set
+	// these to empty till we get a better solution.
+	crd.Status.Conditions = []apiext.CustomResourceDefinitionCondition{}
+	crd.Status.StoredVersions = []string{}
+
 	p.CustomResourceDefinitions[groupKind] = crd
 }


### PR DESCRIPTION
This introduces two fixes for generated CRDs:

- populate the status slices so that they don't fail client-side validation
- allow producing a "trivially versioned" CRD that's compatible with Kubernetes 1.11+ instead of 1.13+
- make the `printcolumn` fields optional when appropriate