### PR TITLE
:sparkles: write multiple webhooks in one file and add defaulting

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -71,7 +71,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			toTrivialVersions(&crd)
 		}
 		fileName := fmt.Sprintf("%s_%s.yaml", crd.Spec.Group, crd.Spec.Names.Plural)
-		if err := ctx.WriteYAML(crd, fileName); err != nil {
+		if err := ctx.WriteYAML(fileName, crd); err != nil {
 			return err
 		}
 	}

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -83,27 +83,29 @@ type GenerationContext struct {
 	InputRule
 }
 
-// WriteYAML writes the given object out, serialized as YAML, using the
+// WriteYAML writes the given objects out, serialized as YAML, using the
 // context's OutputRule.
-func (g GenerationContext) WriteYAML(obj interface{}, itemPath string) error {
-	yamlContent, err := yaml.Marshal(obj)
-	if err != nil {
-		return err
-	}
-
+func (g GenerationContext) WriteYAML(itemPath string, objs ...interface{}) error {
 	out, err := g.Open(nil, itemPath)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
 
-	n, err := out.Write(yamlContent)
-	if err != nil {
-		return err
+	for _, obj := range objs {
+		yamlContent, err := yaml.Marshal(obj)
+		if err != nil {
+			return err
+		}
+		n, err := out.Write(append([]byte("\n---\n"), yamlContent...))
+		if err != nil {
+			return err
+		}
+		if n < len(yamlContent) {
+			return io.ErrShortWrite
+		}
 	}
-	if n < len(yamlContent) {
-		return io.ErrShortWrite
-	}
+
 	return nil
 }
 

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -85,7 +85,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		return nil
 	}
 
-	if err := ctx.WriteYAML(rbacv1.ClusterRole{
+	if err := ctx.WriteYAML("role.yaml", rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterRole",
 			APIVersion: rbacv1.SchemeGroupVersion.String(),
@@ -94,7 +94,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			Name: g.RoleName,
 		},
 		Rules: rules,
-	}, "role.yaml"); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -113,6 +113,10 @@ func (c Config) ToWebhook() admissionreg.Webhook {
 				Namespace: "system",
 				Path:      &path,
 			},
+			// OpenAPI marks the field as required before 1.13 because of a bug that got fixed in
+			// https://github.com/kubernetes/api/commit/e7d9121e9ffd63cea0288b36a82bcc87b073bd1b
+			// Put "\n" as an placeholder as a workaround til 1.13+ is almost everywhere.
+			CABundle: []byte("\n"),
 		},
 	}
 }
@@ -123,6 +127,7 @@ type Generator struct{}
 func (Generator) RegisterMarkers(into *markers.Registry) error {
 	return into.Register(ConfigDefinition)
 }
+
 func (Generator) Generate(ctx *genall.GenerationContext) error {
 	var mutatingCfgs []admissionreg.Webhook
 	var validatingCfgs []admissionreg.Webhook

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -140,28 +140,30 @@ func (Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 	}
 
+	var objs []interface{}
 	if len(mutatingCfgs) > 0 {
-		if err := ctx.WriteYAML(admissionreg.MutatingWebhookConfiguration{
+		objs = append(objs, &admissionreg.MutatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "MutatingWebhookConfiguration",
 				APIVersion: admissionreg.SchemeGroupVersion.String(),
 			},
 			Webhooks: mutatingCfgs,
-		}, "mutating-webhook.yaml"); err != nil {
-			return err
-		}
+		})
 	}
 
 	if len(validatingCfgs) > 0 {
-		if err := ctx.WriteYAML(admissionreg.ValidatingWebhookConfiguration{
+		objs = append(objs, &admissionreg.ValidatingWebhookConfiguration{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ValidatingWebhookConfiguration",
 				APIVersion: admissionreg.SchemeGroupVersion.String(),
 			},
 			Webhooks: validatingCfgs,
-		}, "validating-webhook.yaml"); err != nil {
-			return err
-		}
+		})
+
+	}
+
+	if err := ctx.WriteYAML("manifests.yaml", objs...); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -109,7 +109,9 @@ func (c Config) ToWebhook() admissionreg.Webhook {
 		FailurePolicy: &failurePolicy,
 		ClientConfig: admissionreg.WebhookClientConfig{
 			Service: &admissionreg.ServiceReference{
-				Path: &path,
+				Name:      "webhook-service",
+				Namespace: "system",
+				Path:      &path,
 			},
 		},
 	}
@@ -147,6 +149,9 @@ func (Generator) Generate(ctx *genall.GenerationContext) error {
 				Kind:       "MutatingWebhookConfiguration",
 				APIVersion: admissionreg.SchemeGroupVersion.String(),
 			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mutating-webhook-configuration",
+			},
 			Webhooks: mutatingCfgs,
 		})
 	}
@@ -156,6 +161,9 @@ func (Generator) Generate(ctx *genall.GenerationContext) error {
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ValidatingWebhookConfiguration",
 				APIVersion: admissionreg.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "validating-webhook-configuration",
 			},
 			Webhooks: validatingCfgs,
 		})


### PR DESCRIPTION
This PR does 2 things:
- support writing multiple webhooks in one file
- add defaulting to admission webhook configurations
- work around the "required" caBundle field