### PR TITLE
✨ controller-tools-maintainers is an empty alias

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,5 @@ owners:
   - pwittrock
 approvers:
   - controller-tools-admins
-  - controller-tools-maintainers
 reviewers:
   - controller-tools-admins
-  - controller-tools-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,4 +5,3 @@ aliases:
     - directxman12
     - droot
     - pwittrock
-  controller-tools-maintainers:


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

I'm doing some org/repo-wide OWNERS parsing, an empty alias is not valid