### PR TITLE
Add ability to set default field requirement status

### DIFF
--- a/pkg/crd/markers/package.go
+++ b/pkg/crd/markers/package.go
@@ -24,5 +24,7 @@ func init() {
 	AllDefinitions = append(AllDefinitions,
 		markers.Must(markers.MakeDefinition("groupName", markers.DescribesPackage, "")),
 		markers.Must(markers.MakeDefinition("versionName", markers.DescribesPackage, "")),
+		markers.Must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesPackage, struct{}{})),
+		markers.Must(markers.MakeDefinition("kubebuilder:validation:Required", markers.DescribesPackage, struct{}{})),
 	)
 }

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -26,7 +26,8 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 
-// ValidationMarkers lists all available markers that affect CRD schema generation.
+// ValidationMarkers lists all available markers that affect CRD schema generation,
+// except for the few that don't make sense as type-level markers (see FieldOnlyMarkers).
 // All markers start with `+kubebuilder:validation:`, and continue with their type name.
 // A copy is produced of all markers that describes types as well, for making types
 // reusable and writing complex validations on slice items.
@@ -60,6 +61,14 @@ var ValidationMarkers = mustMakeAllWithPrefix("kubebuilder:validation", markers.
 	Nullable(false),
 )
 
+// FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make
+// sense on a type, and thus aren't in ValidationMarkers).
+var FieldOnlyMarkers = []*markers.Definition{
+	markers.Must(markers.MakeDefinition("kubebuilder:validation:Required", markers.DescribesField, struct{}{})),
+	markers.Must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesField, struct{}{})),
+	markers.Must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})),
+}
+
 func init() {
 	AllDefinitions = append(AllDefinitions, ValidationMarkers...)
 
@@ -88,6 +97,8 @@ type Enum []interface{}
 type Format string
 type Type string
 type Nullable bool
+type Required struct{}
+type Optional struct{}
 
 func (m Maximum) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
 	if schema.Type != "integer" {

--- a/pkg/crd/parser.go
+++ b/pkg/crd/parser.go
@@ -151,7 +151,15 @@ func (p *Parser) NeedSchemaFor(typ TypeIdent) {
 	p.Schemata[typ] = apiext.JSONSchemaProps{}
 
 	schemaCtx := newSchemaContext(typ.Package, p)
-	schema := infoToSchema(schemaCtx.ForInfo(info))
+	ctxForInfo := schemaCtx.ForInfo(info)
+
+	pkgMarkers, err := markers.PackageMarkers(p.Collector, typ.Package)
+	if err != nil {
+		typ.Package.AddError(err)
+	}
+	ctxForInfo.PackageMarkers = pkgMarkers
+
+	schema := infoToSchema(ctxForInfo)
 
 	p.Schemata[typ] = *schema
 


### PR DESCRIPTION
This introduces a `// +kubebuilder:validation:[Required/Optional]` marker which can be applied to both packages and fields. Placing it at the package level determines the default requirement for fields in that package (ie, a package marked with `// +kubebuilder:validation:Optional` will assume no fields are required unless specifically marked with `// +kubebuilder:validation:Required`).

If no package-level tag is set, this defaults to the current behavior of assuming all fields not tagged with `omitempty`, `inline`, or (now) `// +kubebuilder:validation:Optional` are required, so this change doesn't break current use cases.