### PR TITLE
:bug: Ensure same-line last-comment case is handled

### DIFF
--- a/pkg/markers/collect.go
+++ b/pkg/markers/collect.go
@@ -290,7 +290,9 @@ func (v markerSubVisitor) Visit(node ast.Node) ast.Visitor {
 	}
 
 	// skip comments on the same line as the previous node
-	if v.lastLineCommentGroup != nil && v.lastLineCommentGroup.Pos() == v.allComments[v.commentInd].Pos() {
+	// making sure to double-check for the case where we've gone past the end of the comments
+	// but still have to finish up typespec-gendecl association (see below).
+	if v.lastLineCommentGroup != nil && v.commentInd < len(v.allComments) && v.lastLineCommentGroup.Pos() == v.allComments[v.commentInd].Pos() {
 		v.commentInd++
 	}
 

--- a/pkg/markers/markers_suite_test.go
+++ b/pkg/markers/markers_suite_test.go
@@ -54,7 +54,7 @@ var _ = BeforeSuite(func() {
 						foo "fmt" // +testing:pkglvl="not here import 3"
 
 						// +testing:pkglvl="not here import 4"
-					) 
+					)
 
 					// +testing:pkglvl="here unattached"
 
@@ -105,6 +105,15 @@ var _ = BeforeSuite(func() {
 
 					// +testing:typelvl="here on typedecl with no more"
 					type Cheese struct { }
+
+					// ensure that we're fine if we've got an end-of-line
+					// comment that's the last comment of the file, but
+					// we still have a bit more to traverse (field list --> ident).
+					// THIS MUST CONTAIN THE LAST COMMENT IN THE FILE
+					// TODO(directxman12): split this off into its own case
+					type private struct {
+						bar int // not collected
+					}
 				`,
 			},
 		},


### PR DESCRIPTION
We have special handling to skip end-of-line (same-line) comments while
collecting. However, when such a comment is also the last comment in the
file, we have to take special care, because it'll be associated with a
higher-level AST construct, but we may continue traversing to handle
special cases, so we have to take care to acknowlege that we've reached
the end of the file.

Fixes #212 