### PR TITLE
✨ crd: add a resource scope marker

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -36,7 +36,6 @@ var CRDMarkers = []*markers.Definition{
 
 // TODO: categories and singular used to be annotations types
 // TODO: doc
-// TODO: nonNamespaced
 
 func init() {
 	AllDefinitions = append(AllDefinitions, CRDMarkers...)
@@ -184,12 +183,14 @@ type Resource struct {
 	ShortName  []string `marker:",optional"`
 	Categories []string `marker:",optional"`
 	Singular   string   `marker:",optional"`
+	Scope      string   `marker:",optional"`
 }
 
 func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error {
 	crd.Names.Plural = s.Path
 	crd.Names.ShortNames = s.ShortName
 	crd.Names.Categories = s.Categories
+	crd.Scope = apiext.ResourceScope(s.Scope)
 
 	return nil
 }

--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -190,7 +190,13 @@ func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version s
 	crd.Names.Plural = s.Path
 	crd.Names.ShortNames = s.ShortName
 	crd.Names.Categories = s.Categories
-	crd.Scope = apiext.ResourceScope(s.Scope)
+
+	switch s.Scope {
+	case "":
+		crd.Scope = apiext.NamespaceScoped
+	default:
+		crd.Scope = apiext.ResourceScope(s.Scope)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Add a crd resource scope marker to allow generation of cluster scoped resources.
This change is backwards compatible (absence of the scope marker results in an
empty scope).

This also allows for explicit scoping of namespaced resources should the user so
desire (fixes https://github.com/kubernetes-sigs/controller-tools/issues/214).

