### PR TITLE
:sparkles: whitelisting the namespace where the webhook server runs

### DIFF
--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -81,20 +81,21 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 	}
 
-	if len(rules) == 0 {
-		return nil
+	var objs []interface{}
+	if len(rules) != 0 {
+		objs = append(objs, &rbacv1.ClusterRole{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterRole",
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: g.RoleName,
+			},
+			Rules: rules,
+		})
 	}
 
-	if err := ctx.WriteYAML("role.yaml", rbacv1.ClusterRole{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ClusterRole",
-			APIVersion: rbacv1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: g.RoleName,
-		},
-		Rules: rules,
-	}); err != nil {
+	if err := ctx.WriteYAML("role.yaml", objs...); err != nil {
 		return err
 	}
 

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -118,6 +118,15 @@ func (c Config) ToWebhook() admissionreg.Webhook {
 			// Put "\n" as an placeholder as a workaround til 1.13+ is almost everywhere.
 			CABundle: []byte("\n"),
 		},
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "control-plane",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"controller-manager"},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
- whitelist the namespace the webhook server runs
- generate an empty file even when no rbac rules
  - Genearting an empty file is not harmful, and it is useful for using kustomize. When kustomize expects a file, an empty file can zmake it happy.
