### PR TITLE
🐛Add FieldOnlyMarkers to AllDefinitions and update Nullable

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -58,7 +58,6 @@ var ValidationMarkers = mustMakeAllWithPrefix("kubebuilder:validation", markers.
 	Enum(nil),
 	Format(""),
 	Type(""),
-	Nullable(false),
 )
 
 // FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make
@@ -67,6 +66,7 @@ var FieldOnlyMarkers = []*markers.Definition{
 	markers.Must(markers.MakeDefinition("kubebuilder:validation:Required", markers.DescribesField, struct{}{})),
 	markers.Must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesField, struct{}{})),
 	markers.Must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})),
+	markers.Must(markers.MakeDefinition("nullable", markers.DescribesField, Nullable{})),
 }
 
 func init() {
@@ -77,6 +77,8 @@ func init() {
 		typDef.Target = markers.DescribesType
 		AllDefinitions = append(AllDefinitions, &typDef)
 	}
+
+	AllDefinitions = append(AllDefinitions, FieldOnlyMarkers...)
 }
 
 type Maximum int
@@ -96,7 +98,7 @@ type UniqueItems bool
 type Enum []interface{}
 type Format string
 type Type string
-type Nullable bool
+type Nullable struct{}
 type Required struct{}
 type Optional struct{}
 
@@ -222,6 +224,6 @@ func (m Type) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
 func (m Type) ApplyFirst() {}
 
 func (m Nullable) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
-	schema.Nullable = bool(m)
+	schema.Nullable = true
 	return nil
 }

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -80,6 +80,6 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 		Expect(yaml.Unmarshal(expectedFile, &crd)).To(Succeed())
 
 		By("comparing the two")
-		Expect(parser.CustomResourceDefinitions[groupKind]).To(Equal(crd), "%s", cmp.Diff(parser.CustomResourceDefinitions[groupKind], crd))
+		Expect(parser.CustomResourceDefinitions[groupKind]).To(Equal(crd), "type not as expected, check pkg/crd/testdata/README.md for more details.\n\nDiff:\n\n%s", cmp.Diff(parser.CustomResourceDefinitions[groupKind], crd))
 	})
 })

--- a/pkg/crd/testdata/README.md
+++ b/pkg/crd/testdata/README.md
@@ -1,0 +1,23 @@
+# CRD Integration Test testdata
+
+This contains a tiny module used for testdata for the CRD integration
+test.  The directory should always be called testdata, so Go treats it
+specially.
+
+The `cronjob_types.go` file contains the input types, and is loosely based
+on the CronJob tutorial from the [KubeBuilder
+Book](https://book.kubebuilder.io/cronjob-tutorial.html), but with added
+fields to test additional markers and generation behavior.
+
+If you add a new marker, re-generate the golden output file,
+`testdata.kubebuilder.io_cronjobs.yaml`, with:
+
+```bash
+$ /path/to/current/build/of/controller-gen crd paths=. output:dir=.
+```
+
+Make sure you review the diff to ensure that it only contains the desired
+changes!
+
+If you didn't add a new marker and this output changes, make sure you have
+a good explanation for why generated output needs to change!

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -62,6 +62,10 @@ type CronJobSpec struct {
 	// This tests byte slice schema generation.
 	BinaryName []byte `json:"binaryName"`
 
+	// This tests that nullable works correctly
+	// +nullable
+	CanBeNull string `json:"canBeNull"`
+
 	// Specifies the job that will be created when executing a CronJob.
 	JobTemplate batchv1beta1.JobTemplateSpec `json:"jobTemplate"`
 

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -427,6 +427,10 @@ spec:
                 description: This tests byte slice schema generation.
                 format: byte
                 type: string
+              canBeNull:
+                description: This tests that nullable works correctly
+                nullable: true
+                type: string
               concurrencyPolicy:
                 description: 'Specifies how to treat concurrent executions of a Job.
                   Valid values are: - "Allow" (default): allows CronJobs to run concurrently;
@@ -6197,6 +6201,7 @@ spec:
                 type: boolean
             required:
             - binaryName
+            - canBeNull
             - jobTemplate
             - schedule
             type: object


### PR DESCRIPTION
Currently the `+optional` and `+nullable` markers don't work. I've fixed `optional` by making sure the `FieldOnlyMarkers` slice that was added in https://github.com/kubernetes-sigs/controller-tools/pull/211 actually gets added to `AllDefinitions`. In the current code, `+nullable` would actually only be recognized as `+kubebuilder:validation:Nullable=true`, so I'm updating this to be more consistent with what's expected for that marker.

However, I still can't get nullable to be generated in the output CRD, so I would appreciate some input on this