### PR TITLE
:bug: ensure defaults are set for controller-gen all

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -155,11 +155,8 @@ Usage:
 			fmt.Printf("CRD manifests generated under '%s' \n", crdGen.OutputDir)
 
 			// RBAC generation
-			rbacOptions := &rbac.ManifestOptions{
-				InputDir:  filepath.Join(projectDir, "pkg"),
-				OutputDir: filepath.Join(projectDir, "config", "rbac"),
-				Name:      "manager",
-			}
+			rbacOptions := &rbac.ManifestOptions{}
+			rbacOptions.SetDefaults()
 			if err := rbac.Generate(rbacOptions); err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/rbac/manifests.go
+++ b/pkg/rbac/manifests.go
@@ -57,7 +57,7 @@ func (o *ManifestOptions) RoleName() string {
 // RoleFileName returns the name of the manifest file to use for the role.
 func (o *ManifestOptions) RoleFileName() string {
 	if len(o.RoleFile) == 0 {
-		return o.Name + "_role.yaml"
+		return "rbac_role.yaml"
 	}
 	// TODO: validate file name
 	return o.RoleFile
@@ -71,7 +71,7 @@ func (o *ManifestOptions) RoleBindingName() string {
 // RoleBindingFileName returns the name of the manifest file to use for the role binding.
 func (o *ManifestOptions) RoleBindingFileName() string {
 	if len(o.BindingFile) == 0 {
-		return o.Name + "_role_binding.yaml"
+		return "rbac_role_binding.yaml"
 	}
 	// TODO: validate file name
 	return o.BindingFile


### PR DESCRIPTION
Fixes a bug that is introduced in https://github.com/kubernetes-sigs/controller-tools/pull/147/files.
RbacOptions should be the same as https://github.com/kubernetes-sigs/controller-tools/blob/v0.1.10/cmd/controller-gen/main.go#L60-L61
Also revert the file name change, though it's not a breaking change. But the user can notice it.
