### PR TITLE
🐛Fix generated RBAC manifests defaults

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -34,9 +34,9 @@ func main() {
 		Long:  `A reference implementation generation tool for Kubernetes APIs.`,
 		Example: `	# Generate RBAC manifests for a project
 	controller-gen rbac
-	
+
 	# Generate CRD manifests for a project
-	controller-gen crd 
+	controller-gen crd
 
 	# Run all the generators for a given project
 	controller-gen all
@@ -155,7 +155,10 @@ Usage:
 			fmt.Printf("CRD manifests generated under '%s' \n", crdGen.OutputDir)
 
 			// RBAC generation
-			rbacOptions := &rbac.ManifestOptions{}
+			rbacOptions := &rbac.ManifestOptions{
+				InputDir:  filepath.Join(projectDir, "pkg"),
+				OutputDir: filepath.Join(projectDir, "config", "rbac"),
+			}
 			rbacOptions.SetDefaults()
 			if err := rbac.Generate(rbacOptions); err != nil {
 				log.Fatal(err)

--- a/pkg/rbac/manifests.go
+++ b/pkg/rbac/manifests.go
@@ -42,11 +42,21 @@ type ManifestOptions struct {
 
 // SetDefaults sets up the default options for RBAC Manifest generator.
 func (o *ManifestOptions) SetDefaults() {
-	o.Name = "manager"
-	o.InputDir = filepath.Join(".", "pkg")
-	o.OutputDir = filepath.Join(".", "config", "rbac")
-	o.ServiceAccount = "default"
-	o.Namespace = "system"
+	if o.Name == "" {
+		o.Name = "manager"
+	}
+	if o.InputDir == "" {
+		o.InputDir = filepath.Join(".", "pkg")
+	}
+	if o.OutputDir == "" {
+		o.OutputDir = filepath.Join(".", "config", "rbac")
+	}
+	if o.ServiceAccount == "" {
+		o.ServiceAccount = "default"
+	}
+	if o.Namespace == "" {
+		o.Namespace = "system"
+	}
 }
 
 // RoleName returns the RBAC role name to be used in the manifests.


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
This PR fixes an issue where the RBAC files where being generated without ServiceAccount or Namespace when running `controller-gen all`.
