### PR TITLE
🐛Patch metav1.Time to be nullable

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -27,8 +27,9 @@ var KnownPackages = map[string]PackageOverride{
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1": func(p *Parser, pkg *loader.Package) {
 		p.Schemata[TypeIdent{Name: "Time", Package: pkg}] = apiext.JSONSchemaProps{
-			Type:   "string",
-			Format: "date-time",
+			Type:     "string",
+			Format:   "date-time",
+			Nullable: true,
 		}
 		p.Schemata[TypeIdent{Name: "Duration", Package: pkg}] = apiext.JSONSchemaProps{
 			// TODO(directxman12): regexp validation for this (or get kube to support it as a format value)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This PR adds `Nullable: true` to `metav1.Time` types, discovered while debugging an issue in Cluster API (details on [slack](https://kubernetes.slack.com/archives/CAR30FCJZ/p1561092115400800)).