### PR TITLE
 🐛Add simple +required marker

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -66,6 +66,7 @@ var FieldOnlyMarkers = []*markers.Definition{
 	markers.Must(markers.MakeDefinition("kubebuilder:validation:Required", markers.DescribesField, struct{}{})),
 	markers.Must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesField, struct{}{})),
 	markers.Must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})),
+	markers.Must(markers.MakeDefinition("required", markers.DescribesField, struct{}{})),
 	markers.Must(markers.MakeDefinition("nullable", markers.DescribesField, Nullable{})),
 }
 

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -361,7 +361,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *v1beta1.JSO
 		// if this package isn't set to required default...
 		case "optional":
 			// ...everything that isn't explicitly required is optional
-			if field.Markers.Get("kubebuilder:validation:Required") != nil {
+			if field.Markers.Get("kubebuilder:validation:Required") != nil && field.Markers.Get("required") != nil {
 				props.Required = append(props.Required, fieldName)
 			}
 		}


### PR DESCRIPTION
If an API is set to default optional with `// +kubebuilder:validation:Optional`, the `// +required` marker isn't respected (because it doesn't exist, however `// +kubebuilder:validation:Required` does work). This adds the simple form of the required marker for parity with existing expectations
