### PR TITLE
Make the `Path` field of the "+kubebuilder:resource" marker optional

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -179,7 +179,7 @@ func (s PrintColumn) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, versio
 
 // Resource defines "+kubebuilder:resource"
 type Resource struct {
-	Path       string
+	Path       string   `marker:",optional"`
 	ShortName  []string `marker:",optional"`
 	Categories []string `marker:",optional"`
 	Singular   string   `marker:",optional"`
@@ -187,7 +187,9 @@ type Resource struct {
 }
 
 func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error {
-	crd.Names.Plural = s.Path
+	if s.Path != "" {
+		crd.Names.Plural = s.Path
+	}
 	crd.Names.ShortNames = s.ShortName
 	crd.Names.Categories = s.Categories
 

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -146,6 +146,7 @@ type CronJobStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource
 
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     kind: CronJob
     plural: cronjobs
-  scope: ""
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/test.sh
+++ b/test.sh
@@ -134,7 +134,7 @@ golangci-lint run --disable-all \
 
 header_text "running go test"
 
-go test ./pkg/... ./cmd/... -parallel 4
+go test -race ./pkg/... ./cmd/... -parallel 4
 
 # ensure that Gopkg.{toml,lock} are up-to-date
 header_text "ensuring that Gopkg.{toml,lock} are up to date..."


### PR DESCRIPTION
Fix: https://github.com/kubernetes-sigs/controller-tools/issues/239

This PR also adds `-race` flag into `go test`

This should unblock https://github.com/kubernetes-sigs/kubebuilder/pull/763