### PR TITLE
Sort the CRD Versions in the generated CRD and set `crd.Spec.Version` explicitly

### DIFF
--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -17,6 +17,7 @@ package crd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/gobuffalo/flect"
@@ -118,6 +119,11 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind) {
 	if len(crd.Spec.Versions) == 0 {
 		return
 	}
+
+	// it is necessary to make sure the order of CRD versions in crd.Spec.Versions is stable and explicitly set crd.Spec.Version.
+	// Otherwise, crd.Spec.Version may point to different CRD versions across different runs.
+	sort.Slice(crd.Spec.Versions, func(i, j int) bool { return crd.Spec.Versions[i].Name < crd.Spec.Versions[j].Name })
+	crd.Spec.Version = crd.Spec.Versions[0].Name
 
 	// make sure we have *a* storage version
 	// (default it if we only have one, otherwise, bail)

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -11,6 +11,7 @@ spec:
     kind: CronJob
     plural: cronjobs
   scope: Namespaced
+  version: v1
   versions:
   - name: v1
     schema:


### PR DESCRIPTION
According to the kubernetes CRD validation, we need to make sure that the `Version` field always matches the first version in the versions list.  If that changes, we have to explicitly set the version field, since the defaulting will have pointed it at a different version on initial creation.

Fixes: https://github.com/kubernetes-sigs/controller-tools/issues/236