### PR TITLE
🐛 Handle the error type in crd gen

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -148,6 +148,11 @@ func findKubeKinds(parser *Parser, metav1Pkg *loader.Package) []schema.GroupKind
 				// ObjectMeta and TypeMeta are named types
 				continue
 			}
+			if namedField.Obj().Pkg() == nil {
+				// Embedded non-builtin universe type (specifically, it's probably `error`),
+				// so it can't be ObjectMeta or TypeMeta
+				continue
+			}
 			fieldPkgPath := loader.NonVendorPath(namedField.Obj().Pkg().Path())
 			fieldPkg := pkg.Imports()[fieldPkgPath]
 			if fieldPkg != metav1Pkg {


### PR DESCRIPTION
So this fixes a very niche parsing issue:

```go
type noNotify struct{ error }
```

That parses as a field, but it has no package because it's a core type I think? Not 100% sure but it definitely causes a segfault :)