### PR TITLE
✨ Fix "encountered" typo in error message

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -328,7 +328,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *v1beta1.JSO
 		jsonTag, hasTag := field.Tag.Lookup("json")
 		if !hasTag {
 			// if the field doesn't have a JSON tag, it doesn't belong in output (and shouldn't exist in a serialized type)
-			ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("enountered struct field %q without JSON tag in type %q", field.Name, ctx.info.Name), field.RawField))
+			ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("encountered struct field %q without JSON tag in type %q", field.Name, ctx.info.Name), field.RawField))
 			continue
 		}
 		jsonOpts := strings.Split(jsonTag, ",")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This fixes an obvious typo encountered while using kubebuilder.