### PR TITLE
✨ Correctly format metav1.MicroTime as date-time

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -35,6 +35,10 @@ var KnownPackages = map[string]PackageOverride{
 			Type:   "string",
 			Format: "date-time",
 		}
+		p.Schemata[TypeIdent{Name: "MicroTime", Package: pkg}] = apiext.JSONSchemaProps{
+			Type:   "string",
+			Format: "date-time",
+		}
 		p.Schemata[TypeIdent{Name: "Duration", Package: pkg}] = apiext.JSONSchemaProps{
 			// TODO(directxman12): regexp validation for this (or get kube to support it as a format value)
 			Type: "string",

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -142,6 +142,11 @@ type CronJobStatus struct {
 	// Information when was the last time the job was successfully scheduled.
 	// +optional
 	LastScheduleTime *metav1.Time `json:"lastScheduleTime,omitempty"`
+
+	// Information about the last time the job was successfully scheduled,
+	// with microsecond precision.
+	// +optional
+	LastScheduleMicroTime *metav1.MicroTime `json:"lastScheduleMicroTime,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -4978,6 +4978,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              lastScheduleMicroTime:
+                description: Information about the last time the job was successfully
+                  scheduled, with microsecond precision.
+                format: date-time
+                type: string
               lastScheduleTime:
                 description: Information when was the last time the job was successfully
                   scheduled.


### PR DESCRIPTION
This brings the handling of k8s.io/apimachinery/pkg/apis/meta/v1/MicroTime in sync with k8s.io/apimachinery/pkg/apis/meta/v1/Time.

This resolves issue #270.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
