### PR TITLE
:bug: CLI Help issues and Marker Registration Regression

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -129,6 +129,9 @@ func main() {
 
 	# Run all the generators for a given project
 	controller-gen paths=./apis/...
+
+	# Explain the markers for generating CRDs, and their arguments
+	controller-gen crd -ww
 `,
 		RunE: func(c *cobra.Command, rawOpts []string) error {
 			if helpLevel > 0 {
@@ -137,8 +140,8 @@ func main() {
 			return runGenerators(c, rawOpts, whichLevel)
 		},
 	}
-	cmd.Flags().CountVarP(&whichLevel, "which-markers", "w", "print out all markers available with the requested generators (passing more times yields more detailed information)")
-	cmd.Flags().CountVarP(&helpLevel, "detailed-help", "h", "print out more detailed help (passing more times yields more detailed information about options)")
+	cmd.Flags().CountVarP(&whichLevel, "which-markers", "w", "print out all markers available with the requested generators\n(up to -www for the most detailed output, or -wwww for json output)")
+	cmd.Flags().CountVarP(&helpLevel, "detailed-help", "h", "print out more detailed help\n(up to -hhh for the most detailed output, or -hhhh for json output)")
 	cmd.Flags().Bool("help", false, "print out usage and a summary of options")
 	oldUsage := cmd.UsageFunc()
 	cmd.SetUsageFunc(func(c *cobra.Command) error {

--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -124,8 +124,8 @@ func main() {
 	# outputting crds to /tmp/crds and everything else to stdout
 	controller-gen rbac:roleName=<role name> crd paths=./apis/... output:crd:dir=/tmp/crds output:stdout
 
-	# Generate deepcopy implementations for a particular file
-	controller-gen deepcopy paths=./apis/v1beta1/some_types.go
+	# Generate deepcopy/runtime.Object implementations for a particular file
+	controller-gen object paths=./apis/v1beta1/some_types.go
 
 	# Run all the generators for a given project
 	controller-gen paths=./apis/...

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -78,7 +78,12 @@ func init() {
 	AllDefinitions = append(AllDefinitions, ValidationMarkers...)
 
 	for _, def := range ValidationMarkers {
-		typDef := *def
+		newDef := *def.Definition
+		// copy both parts so we don't change the definition
+		typDef := definitionWithHelp{
+			Definition: &newDef,
+			Help:       def.Help,
+		}
 		typDef.Target = markers.DescribesType
 		AllDefinitions = append(AllDefinitions, &typDef)
 	}

--- a/pkg/crd/testdata/README.md
+++ b/pkg/crd/testdata/README.md
@@ -10,7 +10,14 @@ Book](https://book.kubebuilder.io/cronjob-tutorial.html), but with added
 fields to test additional markers and generation behavior.
 
 If you add a new marker, re-generate the golden output file,
-`testdata.kubebuilder.io_cronjobs.yaml`, with:
+`testdata.kubebuilder.io_cronjobs.yaml`, with (if you have the latest
+controller-gen on your path):
+
+```bash
+go generate
+```
+
+or, if you don't have the latest controller-gen on your path, use:
 
 ```bash
 $ /path/to/current/build/of/controller-gen crd paths=. output:dir=.

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:generate controller-gen crd paths=. output:dir=.
+
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1
 package cronjob
@@ -84,7 +86,18 @@ type CronJobSpec struct {
 
 	// This tests string slices are allowed as map values.
 	StringSliceData map[string][]string `json:"stringSliceData,omitempty"`
+
+	// This tests that markers that are allowed on both fields and types are applied to fields
+	// +kubebuilder:validation:MinLength=4
+	TwoOfAKindPart0 string `json:"twoOfAKindPart0"`
+
+	// This tests that markers that are allowed on both fields and types are applied to types
+	TwoOfAKindPart1 LongerString `json:"twoOfAKindPart1"`
 }
+
+// +kubebuilder:validation:MinLength=4
+// This tests that markers that are allowed on both fields and types are applied to types
+type LongerString string
 
 // use an explicit type marker to verify that apply-first markers generate properly
 

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -4929,11 +4929,23 @@ spec:
                   executions, it does not apply to already started executions.  Defaults
                   to false.
                 type: boolean
+              twoOfAKindPart0:
+                description: This tests that markers that are allowed on both fields
+                  and types are applied to fields
+                minLength: 4
+                type: string
+              twoOfAKindPart1:
+                description: This tests that markers that are allowed on both fields
+                  and types are applied to types
+                minLength: 4
+                type: string
             required:
             - binaryName
             - canBeNull
             - jobTemplate
             - schedule
+            - twoOfAKindPart0
+            - twoOfAKindPart1
             type: object
           status:
             description: CronJobStatus defines the observed state of CronJob

--- a/pkg/genall/help/pretty/help.go
+++ b/pkg/genall/help/pretty/help.go
@@ -164,6 +164,7 @@ func MarkerSyntaxHelp(def help.MarkerDoc) Span {
 
 	for _, arg := range def.Fields {
 		out.Print(fieldStyle.Containing(fieldSyntaxHelp(arg, sep)))
+		sep = ","
 	}
 
 	return out


### PR DESCRIPTION
This fixes a number of minor CLI help issues, including #261, as well as other minor nits.

It also fixes a regression around dual field/type CRD validation marker registration introduced by #248, which happens to directly manifest in help output, but will actually show up in generation as well.
