### PR TITLE
🐛 Add apiextensions JSON type to known_types.go

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -84,6 +84,17 @@ var KnownPackages = map[string]PackageOverride{
 		}
 		// No point in calling AddPackage, this is the sole inhabitant
 	},
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1": func(p *Parser, pkg *loader.Package) {
+		p.Schemata[TypeIdent{Name: "JSON", Package: pkg}] = apiext.JSONSchemaProps{
+			XPreserveUnknownFields: boolPtr(true),
+		}
+		p.AddPackage(pkg) // get the rest of the types
+	},
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 // AddKnownTypes registers the packages overrides in KnownPackages with the given parser.


### PR DESCRIPTION
Adds support for the apiextensions-apiserver JSON type.

Without this patch I get the following error:

```
/Users/james/go/src/github.com/jetstack/cert-manager/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types_jsonschema.go:98:2: enountered struct field "Raw" without JSON tag in type "JSON"
```

/cc @DirectXMan12 