### PR TITLE
🐛 Set singular name in generated CRD yaml

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -268,6 +268,9 @@ func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version s
 	if s.Path != "" {
 		crd.Names.Plural = s.Path
 	}
+	if s.Singular != "" {
+		crd.Names.Singular = s.Singular
+	}
 	crd.Names.ShortNames = s.ShortName
 	crd.Names.Categories = s.Categories
 


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

Singular name passed by annotation was not used or set in the generated CRD yamls.