### PR TITLE
:running: drop the useless PROJECT file

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,2 +1,0 @@
-domain: k8s.io
-repo: sigs.k8s.io/controller-tools


### PR DESCRIPTION
IIRC this file was used by the example project a long time ago.
