### PR TITLE
:bug: Collapse Common CRD Version Info

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -290,9 +290,10 @@
   version = "kubernetes-1.14.1"
 
 [[projects]]
-  digest = "1:2949c401dc3fabc93e6688d3d65e63600778ce706e2eb0ad0c702cddb319c124"
+  digest = "0:"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/resource",
     "pkg/apis/meta/v1",
     "pkg/conversion",
@@ -352,6 +353,7 @@
     "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "sigs.k8s.io/yaml",

--- a/pkg/crd/crd_spec_test.go
+++ b/pkg/crd/crd_spec_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
+	"sigs.k8s.io/controller-tools/pkg/crd"
+)
+
+var _ = Describe("CRD Generation", func() {
+	Describe("Utilities", func() {
+		Describe("MergeIdenticalVersionInfo", func() {
+			It("should replace per-version schemata with a top-level schema if all are identical", func() {
+				spec := &apiext.CustomResourceDefinition{
+					Spec: apiext.CustomResourceDefinitionSpec{
+						Versions: []apiext.CustomResourceDefinitionVersion{
+							{
+								Name: "v1",
+								Schema: &apiext.CustomResourceValidation{
+									OpenAPIV3Schema: &apiext.JSONSchemaProps{
+										Required:   []string{"foo"},
+										Type:       "object",
+										Properties: map[string]apiext.JSONSchemaProps{"foo": apiext.JSONSchemaProps{Type: "string"}},
+									},
+								},
+							},
+							{
+								Name:    "v2",
+								Storage: true,
+								Schema: &apiext.CustomResourceValidation{
+									OpenAPIV3Schema: &apiext.JSONSchemaProps{
+										Required:   []string{"foo"},
+										Type:       "object",
+										Properties: map[string]apiext.JSONSchemaProps{"foo": apiext.JSONSchemaProps{Type: "string"}},
+									},
+								},
+							},
+						},
+					},
+				}
+				crd.MergeIdenticalVersionInfo(spec)
+				Expect(spec.Spec.Validation).To(Equal(&apiext.CustomResourceValidation{
+					OpenAPIV3Schema: &apiext.JSONSchemaProps{
+						Required:   []string{"foo"},
+						Type:       "object",
+						Properties: map[string]apiext.JSONSchemaProps{"foo": apiext.JSONSchemaProps{Type: "string"}},
+					},
+				}))
+				Expect(spec.Spec.Versions).To(Equal([]apiext.CustomResourceDefinitionVersion{
+					{Name: "v1"}, {Name: "v2", Storage: true},
+				}))
+			})
+
+			It("shouldn't merge different schemata", func() {
+				spec := &apiext.CustomResourceDefinition{
+					Spec: apiext.CustomResourceDefinitionSpec{
+						Versions: []apiext.CustomResourceDefinitionVersion{
+							{
+								Name: "v1",
+								Schema: &apiext.CustomResourceValidation{
+									OpenAPIV3Schema: &apiext.JSONSchemaProps{
+										Type:       "object",
+										Properties: map[string]apiext.JSONSchemaProps{"foo": apiext.JSONSchemaProps{Type: "string"}},
+									},
+								},
+							},
+							{
+								Name:    "v2",
+								Storage: true,
+								Schema: &apiext.CustomResourceValidation{
+									OpenAPIV3Schema: &apiext.JSONSchemaProps{
+										Required:   []string{"foo"},
+										Type:       "object",
+										Properties: map[string]apiext.JSONSchemaProps{"foo": apiext.JSONSchemaProps{Type: "string"}},
+									},
+								},
+							},
+						},
+					},
+				}
+				orig := spec.DeepCopy()
+				crd.MergeIdenticalVersionInfo(spec)
+				Expect(spec).To(Equal(orig))
+			})
+
+			It("should replace per-version subresources with top-level subresources if all are identical", func() {
+				spec := &apiext.CustomResourceDefinition{
+					Spec: apiext.CustomResourceDefinitionSpec{
+						Versions: []apiext.CustomResourceDefinitionVersion{
+							{
+								Name: "v1",
+								Subresources: &apiext.CustomResourceSubresources{
+									Status: &apiext.CustomResourceSubresourceStatus{},
+								},
+							},
+							{
+								Name:    "v2",
+								Storage: true,
+								Subresources: &apiext.CustomResourceSubresources{
+									Status: &apiext.CustomResourceSubresourceStatus{},
+								},
+							},
+						},
+					},
+				}
+
+				crd.MergeIdenticalVersionInfo(spec)
+				Expect(spec.Spec.Subresources).To(Equal(&apiext.CustomResourceSubresources{
+					Status: &apiext.CustomResourceSubresourceStatus{},
+				}))
+				Expect(spec.Spec.Versions).To(Equal([]apiext.CustomResourceDefinitionVersion{
+					{Name: "v1"}, {Name: "v2", Storage: true},
+				}))
+			})
+
+			It("shouldn't merge different subresources", func() {
+				spec := &apiext.CustomResourceDefinition{
+					Spec: apiext.CustomResourceDefinitionSpec{
+						Versions: []apiext.CustomResourceDefinitionVersion{
+							{
+								Name: "v1",
+								Subresources: &apiext.CustomResourceSubresources{
+									Status: &apiext.CustomResourceSubresourceStatus{},
+								},
+							},
+							{
+								Name:    "v2",
+								Storage: true,
+							},
+						},
+					},
+				}
+				orig := spec.DeepCopy()
+				crd.MergeIdenticalVersionInfo(spec)
+				Expect(spec).To(Equal(orig))
+			})
+
+			It("should replace per-version printer columns with top-level printer columns if all are identical", func() {
+				spec := &apiext.CustomResourceDefinition{
+					Spec: apiext.CustomResourceDefinitionSpec{
+						Versions: []apiext.CustomResourceDefinitionVersion{
+							{
+								Name: "v1",
+								AdditionalPrinterColumns: []apiext.CustomResourceColumnDefinition{
+									{Name: "Cheddar", JSONPath: ".spec.cheddar"},
+									{Name: "Parmesan", JSONPath: ".status.parmesan"},
+								},
+							},
+							{
+								Name:    "v2",
+								Storage: true,
+								AdditionalPrinterColumns: []apiext.CustomResourceColumnDefinition{
+									{Name: "Cheddar", JSONPath: ".spec.cheddar"},
+									{Name: "Parmesan", JSONPath: ".status.parmesan"},
+								},
+							},
+						},
+					},
+				}
+
+				crd.MergeIdenticalVersionInfo(spec)
+				Expect(spec.Spec.AdditionalPrinterColumns).To(Equal([]apiext.CustomResourceColumnDefinition{
+					{Name: "Cheddar", JSONPath: ".spec.cheddar"},
+					{Name: "Parmesan", JSONPath: ".status.parmesan"},
+				}))
+				Expect(spec.Spec.Versions).To(Equal([]apiext.CustomResourceDefinitionVersion{
+					{Name: "v1"}, {Name: "v2", Storage: true},
+				}))
+			})
+
+			It("shouldn't merge different printer columns", func() {
+				spec := &apiext.CustomResourceDefinition{
+					Spec: apiext.CustomResourceDefinitionSpec{
+						Versions: []apiext.CustomResourceDefinitionVersion{
+							{
+								Name: "v1",
+								AdditionalPrinterColumns: []apiext.CustomResourceColumnDefinition{
+									{Name: "Cheddar", JSONPath: ".spec.cheddar"},
+									{Name: "Parmesan", JSONPath: ".status.parmesan"},
+								},
+							},
+							{
+								Name:    "v2",
+								Storage: true,
+							},
+						},
+					},
+				}
+				orig := spec.DeepCopy()
+				crd.MergeIdenticalVersionInfo(spec)
+				Expect(spec).To(Equal(orig))
+			})
+		})
+	})
+})

--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gobuffalo/flect"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -34,6 +35,86 @@ type SpecMarker interface {
 	// ApplyToCRD applies this marker to the given CRD, in the given version
 	// within that CRD.  It's called after everything else in the CRD is populated.
 	ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error
+}
+
+// mergeIdenticalSubresources checks to see if subresources are identical across
+// all versions, and if so, merges them into a top-level version.
+//
+// This assumes you're not using trivial versions.
+func mergeIdenticalSubresources(crd *apiext.CustomResourceDefinition) {
+	subres := crd.Spec.Versions[0].Subresources
+	for _, ver := range crd.Spec.Versions {
+		if ver.Subresources == nil || !equality.Semantic.DeepEqual(subres, ver.Subresources) {
+			// either all nil, or not identical
+			return
+		}
+	}
+
+	// things are identical if we've gotten this far, so move the subresources up
+	// and discard the identical per-version ones
+	crd.Spec.Subresources = subres
+	for i := range crd.Spec.Versions {
+		crd.Spec.Versions[i].Subresources = nil
+	}
+}
+
+// mergeIdenticalSchemata checks to see if schemata are identical across
+// all versions, and if so, merges them into a top-level version.
+//
+// This assumes you're not using trivial versions.
+func mergeIdenticalSchemata(crd *apiext.CustomResourceDefinition) {
+	schema := crd.Spec.Versions[0].Schema
+	for _, ver := range crd.Spec.Versions {
+		if ver.Schema == nil || !equality.Semantic.DeepEqual(schema, ver.Schema) {
+			// either all nil, or not identical
+			return
+		}
+	}
+
+	// things are identical if we've gotten this far, so move the schemata up
+	// to a single schema and discard the identical per-version ones
+	crd.Spec.Validation = schema
+	for i := range crd.Spec.Versions {
+		crd.Spec.Versions[i].Schema = nil
+	}
+}
+
+// mergeIdenticalPrinterColumns checks to see if schemata are identical across
+// all versions, and if so, merges them into a top-level version.
+//
+// This assumes you're not using trivial versions.
+func mergeIdenticalPrinterColumns(crd *apiext.CustomResourceDefinition) {
+	cols := crd.Spec.Versions[0].AdditionalPrinterColumns
+	for _, ver := range crd.Spec.Versions {
+		if len(ver.AdditionalPrinterColumns) == 0 || !equality.Semantic.DeepEqual(cols, ver.AdditionalPrinterColumns) {
+			// either all nil, or not identical
+			return
+		}
+	}
+
+	// things are identical if we've gotten this far, so move the printer columns up
+	// and discard the identical per-version ones
+	crd.Spec.AdditionalPrinterColumns = cols
+	for i := range crd.Spec.Versions {
+		crd.Spec.Versions[i].AdditionalPrinterColumns = nil
+	}
+}
+
+// MergeIdenticalVersionInfo makes sure that components of the Versions field that are identical
+// across all versions get merged into the top-level fields in v1beta1.
+//
+// This is required by the Kubernetes API server validation.
+//
+// The reason is that a v1beta1 -> v1 -> v1beta1 conversion cycle would need to
+// round-trip identically, v1 doesn't have top-level subresources, and without
+// this restriction it would be ambiguous how a v1-with-identical-subresources
+// converts into a v1beta1).
+func MergeIdenticalVersionInfo(crd *apiext.CustomResourceDefinition) {
+	if len(crd.Spec.Versions) > 1 {
+		mergeIdenticalSubresources(crd)
+		mergeIdenticalSchemata(crd)
+		mergeIdenticalPrinterColumns(crd)
+	}
 }
 
 // NeedCRDFor requests the full CRD for the given group-kind.  It requires
@@ -143,6 +224,10 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind) {
 	// these to empty till we get a better solution.
 	crd.Status.Conditions = []apiext.CustomResourceDefinitionCondition{}
 	crd.Status.StoredVersions = []string{}
+
+	// make sure we merge identical per-version parts, to avoid validation errors
+	// (see the reasoning near the top of the file).
+	MergeIdenticalVersionInfo(&crd)
 
 	p.CustomResourceDefinitions[groupKind] = crd
 }


### PR DESCRIPTION
The Kube API server requires that information common to all versions of
a CRD be collapsed into the top-level fields in v1beta1, since not doing
so would create ambiguity when round-tripping through the upcoming v1
version (which doesn't have top-level fields).  This makes sure we
collapse things.
