### PR TITLE
✨ Support for oneOf Groups for Discriminate Types

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -70,6 +70,9 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 	must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional, if fields are required by default.")),
 
+	must(markers.MakeDefinition("kubebuilder:validation:OneOf", markers.DescribesField, struct{}{})).
+		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is part of a oneOf group")),
+
 	must(markers.MakeDefinition("nullable", markers.DescribesField, Nullable{})).
 		WithHelp(Nullable{}.Help()),
 }


### PR DESCRIPTION
These changes add support for the field marker: `kubebuilder:validation:OneOf` which will generate a `oneOf` block in the CRD structural definition[[1](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema)]. This could be expanded in the future to include more complex oneOf objects, however for now, it works to simply define fields which are mutually exclusive:

```go
// Discriminator Test Spec
type TestSpec struct {

	// +kubebuilder:validation:OneOf
	Cat map[string]string `json:"cat,omitempty"`

	// +kubebuilder:validation:OneOf
	Dog map[string]string `json:"dog,omitempty"`
}
```

becomes

```yaml
        spec:
          description: Discriminator Test Spec
          oneOf:
          - properties:
              cat: {}
            required:
            - cat
          - properties:
              dog: {}
            required:
            - dog
          properties:
            cat:
              additionalProperties:
                type: string
              type: object
            dog:
              additionalProperties:
                type: string
              type: object
          type: object
```

This then allows the CRD to enforce a mutually exclusive type:

```yaml
apiVersion: "inflow.arroyo.io/v1"
kind: Test
metadata:
  name: test-both
spec:
  cat: {"says": "meow"}
  dog: {"says": "woof"}
```

produces `"spec" must validate one and only one schema (oneOf). Found 2 valid alternatives`

```yaml
apiVersion: "inflow.arroyo.io/v1"
kind: Test
metadata:
  name: test-none
spec: {}
```

produces `"spec" must validate one and only one schema (oneOf). Found none valid`

---

[1] [https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema)

