### PR TITLE
✨ Add skipversion marker to selectively exclude CRD versions

### DIFF
--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -235,6 +235,17 @@ func (Resource) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (SkipVersion) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "removes the particular version of the CRD from the CRDs spec. ",
+			Details: " This is useful if you need to skip generating and listing version entries for 'internal' resource versions, which typically exist if using the Kubernetes upstream conversion-gen tool.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (StorageVersion) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD",


### PR DESCRIPTION
Adds a new marker that allows excluding particular CRD versions from the generated CRD output.

This is specifically useful to me in order to support having a stable 'internal' version that is used for a basis for conversion (we prefer to define this instead of using an external version as our 'hub' as we don't want to have to rewrite older conversion functions as we deprecate APIs 😄).

For more context, see #307 
