### PR TITLE
:sparkles: pkg/crd/spec.go: set default ListKind and Singular CRD names

### DIFF
--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -148,8 +148,10 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind, maxDescLen *int) {
 		Spec: apiext.CustomResourceDefinitionSpec{
 			Group: groupKind.Group,
 			Names: apiext.CustomResourceDefinitionNames{
-				Kind:   groupKind.Kind,
-				Plural: defaultPlural,
+				Kind:     groupKind.Kind,
+				ListKind: groupKind.Kind + "List",
+				Plural:   defaultPlural,
+				Singular: strings.ToLower(groupKind.Kind),
 			},
 		},
 	}

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9,7 +9,9 @@ spec:
   group: testdata.kubebuilder.io
   names:
     kind: CronJob
+    listKind: CronJobList
     plural: cronjobs
+    singular: cronjob
   scope: Namespaced
   version: v1
   versions:


### PR DESCRIPTION
A CRD's ListKind and Singular names are not added by default, but are easy to infer from group data and therefore should be set by default.