### PR TITLE
WIP:  :bug: Update known_types to add x-kubernetes-int-or-string for intStr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,13 +7,9 @@ require (
 	github.com/gobuffalo/flect v0.1.5
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/google/go-cmp v0.3.0
-	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.6 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 	github.com/spf13/cobra v0.0.3
@@ -25,9 +21,8 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
-	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
-	k8s.io/apiextensions-apiserver v0.0.0-20190409022649-727a075fdec8
-	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
-	k8s.io/klog v0.2.0 // indirect
+	k8s.io/api v0.0.0-20190620085009-fd6d441bb4ee
+	k8s.io/apiextensions-apiserver v0.0.0-20190620085545-9a1be6d1ab4f
+	k8s.io/apimachinery v0.0.0-20190513181300-e403c24f3a75
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -70,6 +70,7 @@ var KnownPackages = map[string]PackageOverride{
 
 	"k8s.io/apimachinery/pkg/util/intstr": func(p *Parser, pkg *loader.Package) {
 		p.Schemata[TypeIdent{Name: "IntOrString", Package: pkg}] = apiext.JSONSchemaProps{
+			XIntOrString: true,
 			AnyOf: []apiext.JSONSchemaProps{
 				{Type: "string"},
 				{Type: "integer"},

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -1222,6 +1222,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                                 scheme:
                                                   description: Scheme to use for connecting
                                                     to the host. Defaults to HTTP.
@@ -1248,6 +1249,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
@@ -1337,6 +1339,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                                 scheme:
                                                   description: Scheme to use for connecting
                                                     to the host. Defaults to HTTP.
@@ -1363,6 +1366,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
@@ -1445,6 +1449,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
                                                 to the host. Defaults to HTTP.
@@ -1489,6 +1494,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
@@ -1632,6 +1638,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
                                                 to the host. Defaults to HTTP.
@@ -1676,6 +1683,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
@@ -2407,6 +2415,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                                 scheme:
                                                   description: Scheme to use for connecting
                                                     to the host. Defaults to HTTP.
@@ -2433,6 +2442,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
@@ -2522,6 +2532,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                                 scheme:
                                                   description: Scheme to use for connecting
                                                     to the host. Defaults to HTTP.
@@ -2548,6 +2559,7 @@ spec:
                                                     port to access on the container.
                                                     Number must be in the range 1
                                                     to 65535. Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
@@ -2630,6 +2642,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
                                                 to the host. Defaults to HTTP.
@@ -2674,6 +2687,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
@@ -2817,6 +2831,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                             scheme:
                                               description: Scheme to use for connecting
                                                 to the host. Defaults to HTTP.
@@ -2861,6 +2876,7 @@ spec:
                                                 to access on the container. Number
                                                 must be in the range 1 to 65535. Name
                                                 must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object


### PR DESCRIPTION
:bug: 

Fixes #304 

Note:

 * Have not committed `go.sum`- should I?
 * Its unclear what version controller-tools requires of dependant tools. I have taken the first update to apiextensions-apiserver that includes the commit: https://github.com/kubernetes/apiextensions-apiserver/commit/7551f6323c3a36e7e3515881792b78aa7b6107a9

