### PR TITLE
📖Update builtinToType comments to explain support for int32 and int64

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -389,8 +389,8 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *v1beta1.JSO
 }
 
 // builtinToType converts builtin basic types to their equivalent JSON schema form.
-// It *only* handles types allowed by the kubernetes API standards, meaning
-// no floats (technically we shouldn't allow int64 or plain int either, but :shrug:).
+// It *only* handles types allowed by the kubernetes API standards. Floats are not
+// allowed.
 func builtinToType(basic *types.Basic) (typ string, format string, err error) {
 	// NB(directxman12): formats from OpenAPI v3 are slightly different than those defined
 	// in JSONSchema.  This'll use the OpenAPI v3 ones, since they're useful for bounding our


### PR DESCRIPTION
This PR is to address the request made the following:
- https://github.com/kubernetes-sigs/kubebuilder/issues/921#issuecomment-527563284
- https://github.com/kubernetes-sigs/kubebuilder/pull/975#issuecomment-527563813

I didn't mention `resource.Quantity` in the changes because I saw no sign of it in `builtinToType`. Please let me know if I've missed something and thanks!