### PR TITLE
:sparkles: add support for pointers as map values

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -297,6 +297,8 @@ func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiext.JSONSchemaPro
 			ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map values must be a named type, not %T", mapType.Value), mapType.Value))
 			return &apiext.JSONSchemaProps{}
 		}
+	case *ast.StarExpr:
+		valSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), val)
 	default:
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map values must be a named type, not %T", mapType.Value), mapType.Value))
 		return &apiext.JSONSchemaProps{}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -91,6 +91,9 @@ type CronJobSpec struct {
 	// This tests string slices are allowed as map values.
 	StringSliceData map[string][]string `json:"stringSliceData,omitempty"`
 
+	// This tests pointers are allowed as map values.
+	PtrData map[string]*string `json:"ptrData,omitempty"`
+
 	// This tests that markers that are allowed on both fields and types are applied to fields
 	// +kubebuilder:validation:MinLength=4
 	TwoOfAKindPart0 string `json:"twoOfAKindPart0"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -5038,6 +5038,11 @@ spec:
                 description: This tests that pattern validator is properly applied.
                 pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$
                 type: string
+              ptrData:
+                additionalProperties:
+                  type: string
+                description: This tests pointers are allowed as map values.
+                type: object
               schedule:
                 description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
                 type: string

--- a/pkg/webhook/zz_generated.markerhelp.go
+++ b/pkg/webhook/zz_generated.markerhelp.go
@@ -57,11 +57,11 @@ func (Config) Help() *markers.DefinitionHelp {
 				Details: "",
 			},
 			"Name": markers.DetailedHelp{
-				Summary: "indicates the name of this webhook configuration.",
+				Summary: "indicates the name of this webhook configuration. Should be a domain with at least three segments separated by dots",
 				Details: "",
 			},
 			"Path": markers.DetailedHelp{
-				Summary: "specifies that path that the API server should connect to this webhook on.",
+				Summary: "specifies that path that the API server should connect to this webhook on. Must be prefixed with a '/validate-' or '/mutate-' depending on the type, and followed by $GROUP-$VERSION-$KIND where all values are lower-cased and the periods in the group are substituted for hyphens. For example, a validating webhook path for type batch.tutorial.kubebuilder.io/v1,Kind=CronJob would be /validate-batch-tutorial-kubebuilder-io-v1-cronjob",
 				Details: "",
 			},
 		},


### PR DESCRIPTION
for the time being `controller-gen` does not accept pointers as map values and IMHO my patch should fix this problem as shown below.

```
$ tree .
.
├── api.go
├── go.mod
└── go.sum

0 directories, 3 files
```

```
$ cat api.go
package crd

import (
	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
)

// +kubebuilder:object:root=true
// +kubebuilder:object:generate=true
// +groupName=example.org

type Env struct {
	A int    `json:"a"`
	B string `json:"b"`
}

type App struct {
	metav1.TypeMeta   `json:",inline"`
	metav1.ObjectMeta `json:"metadata,omitempty"`

	Envs map[string]*Env `json:"envs,omitempty"`
}
```

using the latest controller-gen(https://github.com/kubernetes-sigs/controller-tools/commit/9d85d107df07a210d8b23d2b612365fd66bbe187)

```
$ /tmp/controller-gen-9d85d107d crd paths=./... output:crd:stdout

// invalid crd omitted

/private/tmp/crd/api.go:20:18: map values must be a named type, not *ast.StarExpr
Error: not all generators ran successfully
run `controller-gen crd paths=./... output:crd:stdout -w` to see all available markers, or `controller-gen crd paths=./... output:crd:stdout -h` for usage
```

my patch:

```
$ /tmp/controller-gen-fix crd paths=./... output:crd:stdout
```

<summary>
<details>
<pre>
---
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: (devel)
  creationTimestamp: null
  name: apps.example.org
spec:
  group: example.org
  names:
    kind: App
    listKind: AppList
    plural: apps
    singular: app
  scope: Namespaced
  validation:
    openAPIV3Schema:
      properties:
        apiVersion:
          description: 'APIVersion defines the versioned schema of this representation
            of an object. Servers should convert recognized schemas to the latest
            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
          type: string
        envs:
          additionalProperties:
            properties:
              a:
                type: integer
              b:
                type: string
            required:
            - a
            - b
            type: object
          type: object
        kind:
          description: 'Kind is a string value representing the REST resource this
            object represents. Servers may infer this from the endpoint the client
            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
          type: string
        metadata:
          type: object
      type: object
  version: crd
  versions:
  - name: crd
    served: true
    storage: true
status:
  acceptedNames:
    kind: ""
    plural: ""
  conditions: []
  storedVersions: []
</pre>
</details>
<summary>