### PR TITLE
:sparkles: Add support for CRD v1 to crdschema generator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -294,6 +294,7 @@
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
+    "pkg/apis/apiextensions/v1",
     "pkg/apis/apiextensions/v1beta1",
   ]
   pruneopts = "UT"
@@ -372,10 +373,12 @@
     "gopkg.in/yaml.v3",
     "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/rbac/v1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/klog",
     "sigs.k8s.io/yaml",
   ]
   solver-name = "gps-cdcl"

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,6 @@ require (
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
+	k8s.io/klog v0.4.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/schemapatcher/testdata/apis/kubebuilder/v1/types_example_v1.go
+++ b/pkg/schemapatcher/testdata/apis/kubebuilder/v1/types_example_v1.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+
+// ExampleV1 is a kind with schema changes intended to be generated as
+// a V1 CRD.
+type ExampleV1 struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// +required
+	Spec ExampleV1Spec `json:"spec"`
+}
+
+type ExampleV1Spec struct {
+	// foo contains foo.
+	Foo string `json:"foo"`
+	// foo contains foo.
+	Bar string `json:"bar"`
+}
+
+// +kubebuilder:object:root=true
+
+// ExampleV1List contains a list of ExampleV1.
+type ExampleV1List struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+	Items           []ExampleV1 `json:"items"`
+}

--- a/pkg/schemapatcher/testdata/expected/kubebuilder-example-v1-crd.yaml
+++ b/pkg/schemapatcher/testdata/expected/kubebuilder-example-v1-crd.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: example.kubebuilder.schemapatcher.controller-tools.sigs.k8s.io
+spec:
+  group: kubebuilder.schemapatcher.controller-tools.sigs.k8s.io
+  scope: Cluster
+  names:
+    kind: ExampleV1
+    singular: examplev1
+    plural: examplesv1
+    listKind: ExampleV1List
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ExampleV1 is a kind with schema changes intended to be generated
+          as a V1 CRD.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - bar
+            - foo
+            properties:
+              bar:
+                description: foo contains foo.
+                type: string
+              foo:
+                description: foo contains foo.
+                type: string

--- a/pkg/schemapatcher/testdata/manifests/kubebuilder-example-v1-crd.yaml
+++ b/pkg/schemapatcher/testdata/manifests/kubebuilder-example-v1-crd.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: example.kubebuilder.schemapatcher.controller-tools.sigs.k8s.io
+spec:
+  group: kubebuilder.schemapatcher.controller-tools.sigs.k8s.io
+  scope: Cluster
+  names:
+    kind: ExampleV1
+    singular: examplev1
+    plural: examplesv1
+    listKind: ExampleV1List
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ExampleV1 is a kind with schema changes intended to be generated
+          as a V1 CRD.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            required:
+            - bar
+            properties:
+              bar:
+                description: foo contains foo.
+                type: string
+              foo:
+                description: foo contains foo.
+                type: string


### PR DESCRIPTION
This PR adds support to crdschema generator for CRD v1 manifests. ~The schema generated for a v1 CRD is also validated for [structural compatibility](https://kubernetes.io/blog/2019/06/20/crd-structural-schema/).~

Upon the advice of @sttts I have removed the structural schema validation since the implementation requires the use of code intended to be internal to the kube apiserver. Schema construction is intended to be correct, but ultimately validation can only be authoritatively performed on submission to an apiserver.  

cc: @sttts 