### PR TITLE
:sparkles: Add a marker to support field defaulting in crd schema

### DIFF
--- a/pkg/crd/markers/doc.go
+++ b/pkg/crd/markers/doc.go
@@ -21,7 +21,7 @@ limitations under the License.
 //
 // Validation Markers
 //
-// Validation markers have values that imprlement ApplyToSchema
+// Validation markers have values that implement ApplyToSchema
 // (crd.SchemaMarker).  Any marker implementing this will automatically
 // be run after the rest of a given schema node has been generated.
 // Markers that need to be run before any other markers can also

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -72,6 +72,9 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("nullable", markers.DescribesField, Nullable{})).
 		WithHelp(Nullable{}.Help()),
+
+	must(markers.MakeAnyTypeDefinition("kubebuilder:validation:Default", markers.DescribesField, Default{})).
+		WithHelp(Default{}.Help()),
 }
 
 func init() {
@@ -158,6 +161,19 @@ type Type string
 //
 // This is often not necessary, but may be helpful with custom serialization.
 type Nullable struct{}
+
+// +controllertools:marker:generateHelp:category="CRD validation"
+// Default sets the default value for this field.
+//
+// A default value will be accepted as any value valid for the
+// field. Formatting for common types include: boolean: `true`, string:
+// `Cluster`, numerical: `1.24`, array: `{1,2}`, object: `{policy:
+// "delete"}`). Defaults should be defined in pruned form, and only best-effort
+// validation will be performed. Full validation of a default requires
+// submission of the containing CRD to an apiserver.
+type Default struct {
+	Value interface{}
+}
 
 func (m Maximum) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
 	if schema.Type != "integer" {
@@ -282,5 +298,15 @@ func (m Type) ApplyFirst() {}
 
 func (m Nullable) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
 	schema.Nullable = true
+	return nil
+}
+
+// Defaults are only valid CRDs created with the v1 API
+func (m Default) ApplyToSchema(schema *v1beta1.JSONSchemaProps) error {
+	marshalledDefault, err := json.Marshal(m.Value)
+	if err != nil {
+		return err
+	}
+	schema.Default = &v1beta1.JSON{Raw: marshalledDefault}
 	return nil
 }

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -24,6 +24,22 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 
+func (Default) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "sets the default value for this field. ",
+			Details: " A default value will be accepted as any value valid for the field. Formatting for common types include: boolean: `true`, string: `Cluster`, numerical: `1.24`, array: `{1,2}`, object: `{policy: \"delete\"}`). Defaults should be defined in pruned form, and only best-effort validation will be performed. Full validation of a default requires submission of the containing CRD to an apiserver.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{
+			"Value": markers.DetailedHelp{
+				Summary: "",
+				Details: "",
+			},
+		},
+	}
+}
+
 func (Enum) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -93,6 +93,27 @@ type CronJobSpec struct {
 
 	// This tests that markers that are allowed on both fields and types are applied to types
 	TwoOfAKindPart1 LongerString `json:"twoOfAKindPart1"`
+
+	// This tests that primitive defaulting can be performed.
+	// +kubebuilder:validation:Default=forty-two
+	DefaultedString string `json:"defaultedString"`
+
+	// This tests that slice defaulting can be performed.
+	// +kubebuilder:validation:Default={a,b}
+	DefaultedSlice []string `json:"defaultedSlice"`
+
+	// This tests that object defaulting can be performed.
+	// +kubebuilder:validation:Default={{nested: {foo: "baz", bar: true}},{nested: {bar: false}}}
+	DefaultedObject []RootObject `json:"defaultedObject"`
+}
+
+type NestedObject struct {
+	Foo string `json:"foo"`
+	Bar bool   `json:"bar"`
+}
+
+type RootObject struct {
+	Nested NestedObject `json:"nested"`
 }
 
 // +kubebuilder:validation:MinLength=4

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -59,6 +59,42 @@ spec:
               - Forbid
               - Replace
               type: string
+            defaultedObject:
+              default:
+              - nested:
+                  bar: true
+                  foo: baz
+              - nested:
+                  bar: false
+              description: This tests that object defaulting can be performed.
+              items:
+                properties:
+                  nested:
+                    properties:
+                      bar:
+                        type: boolean
+                      foo:
+                        type: string
+                    required:
+                    - bar
+                    - foo
+                    type: object
+                required:
+                - nested
+                type: object
+              type: array
+            defaultedSlice:
+              default:
+              - a
+              - b
+              description: This tests that slice defaulting can be performed.
+              items:
+                type: string
+              type: array
+            defaultedString:
+              default: forty-two
+              description: This tests that primitive defaulting can be performed.
+              type: string
             failedJobsHistoryLimit:
               description: The number of failed finished jobs to retain. This is a
                 pointer to distinguish between explicit zero and not specified.
@@ -4790,6 +4826,9 @@ spec:
           required:
           - binaryName
           - canBeNull
+          - defaultedObject
+          - defaultedSlice
+          - defaultedString
           - jobTemplate
           - schedule
           - twoOfAKindPart0

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -865,6 +865,19 @@ func MakeDefinition(name string, target TargetType, output interface{}) (*Defini
 	return def, nil
 }
 
+// MakeAnyTypeDefinition constructs a definition for an output struct with a
+// field named `Value` of type `interface{}`. The argument to the marker will
+// be parsed as AnyType and assigned to the field named `Value`.
+func MakeAnyTypeDefinition(name string, target TargetType, output interface{}) (*Definition, error) {
+	defn, err := MakeDefinition(name, target, output)
+	if err != nil {
+		return nil, err
+	}
+	defn.FieldNames = map[string]string{"": "Value"}
+	defn.Fields = map[string]Argument{"": defn.Fields["value"]}
+	return defn, nil
+}
+
 // splitMarker takes a marker in the form of `+a:b:c=arg,d=arg` and splits it
 // into the name (`a:b`), the name if it's not a struct (`a:b:c`), and the parts
 // that are definitely fields (`arg,d=arg`).

--- a/pkg/markers/parse_test.go
+++ b/pkg/markers/parse_test.go
@@ -76,10 +76,8 @@ var _ = Describe("Parsing", func() {
 			mustDefine(reg, "testing:tripleDefined", DescribesField, "")
 			mustDefine(reg, "testing:tripleDefined", DescribesType, false)
 
-			defn, err := MakeDefinition("testing:custom", DescribesPackage, CustomType{})
+			defn, err := MakeAnyTypeDefinition("testing:custom", DescribesPackage, CustomType{})
 			Expect(err).NotTo(HaveOccurred())
-			defn.FieldNames = map[string]string{"": "Value"}
-			defn.Fields = map[string]Argument{"": defn.Fields["value"]}
 
 			Expect(reg.Register(defn)).To(Succeed())
 		})

--- a/test.sh
+++ b/test.sh
@@ -109,6 +109,11 @@ setup_envs
 
 header_text "running golangci-lint"
 
+header_text "generating marker help"
+pushd cmd/controller-gen > /dev/null
+  go generate
+popd > /dev/null
+
 golangci-lint run --disable-all \
     --enable=misspell \
     --enable=golint \


### PR DESCRIPTION
**NOTE:** This PR is not ready for review until #329 merges.

Kube 1.16 adds beta support [for providing default values for fields](https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#defaulting) in a CRD schema. This PR adds a marker that supports specifying defaults for all supported types.
 
cc: @sttts 