### PR TITLE
🐛Add apiextension JSONSchemaPropsOrArray, JSONSchemaPropsOrBool, JSONSchemaOrStringArray to known_types.go

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -84,6 +84,42 @@ var KnownPackages = map[string]PackageOverride{
 		}
 		// No point in calling AddPackage, this is the sole inhabitant
 	},
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1": func(p *Parser, pkg *loader.Package) {
+		yes := true
+		p.Schemata[TypeIdent{Name: "JSON", Package: pkg}] = apiext.JSONSchemaProps{
+			XPreserveUnknownFields: &yes,
+		}
+
+		p.Schemata[TypeIdent{Name: "JSONSchemaPropsOrArray", Package: pkg}] = apiext.JSONSchemaProps{
+			AnyOf: []apiext.JSONSchemaProps{
+				{Type: "object"},
+				{
+					Type:  "array",
+					Items: &apiext.JSONSchemaPropsOrArray{Schema: &apiext.JSONSchemaProps{Type: "object"}},
+				},
+			},
+		}
+
+		p.Schemata[TypeIdent{Name: "JSONSchemaPropsOrBool", Package: pkg}] = apiext.JSONSchemaProps{
+			AnyOf: []apiext.JSONSchemaProps{
+				{Type: "object"},
+				{Type: "boolean"},
+			},
+		}
+
+		p.Schemata[TypeIdent{Name: "JSONSchemaPropsOrStringArray", Package: pkg}] = apiext.JSONSchemaProps{
+			AnyOf: []apiext.JSONSchemaProps{
+				{Type: "object"},
+				{
+					Type:  "array",
+					Items: &apiext.JSONSchemaPropsOrArray{Schema: &apiext.JSONSchemaProps{Type: "string"}},
+				},
+			},
+		}
+
+		p.AddPackage(pkg) // get the rest of the types
+	},
 }
 
 // AddKnownTypes registers the packages overrides in KnownPackages with the given parser.

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -403,6 +403,8 @@ func builtinToType(basic *types.Basic) (typ string, format string, err error) {
 		typ = "string"
 	case basicInfo&types.IsInteger != 0:
 		typ = "integer"
+	case basicInfo&types.IsFloat != 0:
+		typ = "number"
 	default:
 		// NB(directxman12): floats are *NOT* allowed in kubernetes APIs
 		return "", "", fmt.Errorf("unsupported type %q", basic.String())


### PR DESCRIPTION
Fix: #291 
Ref: #277 
cc @thetechnick
cc @munnerz @sttts @DirectXMan12 

This PR adds the `JSONSchemaPropsOrArray`, `JSONSchemaPropsOrBool`, `JSONSchemaOrStringArray` types to known_types.go, but we haven't figured out the `Type` for the `JSONSchemaProps`, and we are keeping it to `object` in this PR, but if it is not correct, we can still change it.


<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
