### PR TITLE
:sparkles: Trim leading space from generated marker help `Details` field

### DIFF
--- a/cmd/helpgen/main.go
+++ b/cmd/helpgen/main.go
@@ -83,7 +83,7 @@ func godocToDetails(typeName string, doc string) (summary, details string) {
 
 	details = ""
 	if len(docParts) > 1 {
-		details = docParts[1]
+		details = strings.TrimSpace(docParts[1])
 	}
 	return summary, details
 }

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -62,7 +62,7 @@ func (Format) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies additional \"complex\" formatting for this field. ",
-			Details: " For example, a date-time field would be marked as \"type: string\" and \"format: date-time\".",
+			Details: "For example, a date-time field would be marked as \"type: string\" and \"format: date-time\".",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -150,7 +150,7 @@ func (Nullable) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks this field as allowing the \"null\" value. ",
-			Details: " This is often not necessary, but may be helpful with custom serialization.",
+			Details: "This is often not necessary, but may be helpful with custom serialization.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -181,7 +181,7 @@ func (PrintColumn) Help() *markers.DefinitionHelp {
 			},
 			"Type": markers.DetailedHelp{
 				Summary: "indicates the type of the column. ",
-				Details: " It may be any OpenAPI data type listed at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.",
+				Details: "It may be any OpenAPI data type listed at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.",
 			},
 			"JSONPath": markers.DetailedHelp{
 				Summary: "specifies the jsonpath expression used to extract the value of the column.",
@@ -193,11 +193,11 @@ func (PrintColumn) Help() *markers.DefinitionHelp {
 			},
 			"Format": markers.DetailedHelp{
 				Summary: "specifies the format of the column. ",
-				Details: " It may be any OpenAPI data format corresponding to the type, listed at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.",
+				Details: "It may be any OpenAPI data format corresponding to the type, listed at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.",
 			},
 			"Priority": markers.DetailedHelp{
 				Summary: "indicates how important it is that this column be displayed. ",
-				Details: " Lower priority (*higher* numbered) columns will be hidden if the terminal width is too small.",
+				Details: "Lower priority (*higher* numbered) columns will be hidden if the terminal width is too small.",
 			},
 		},
 	}
@@ -213,23 +213,23 @@ func (Resource) Help() *markers.DefinitionHelp {
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Path": markers.DetailedHelp{
 				Summary: "specifies the plural \"resource\" for this CRD. ",
-				Details: " It generally corresponds to a plural, lower-cased version of the Kind. See https://book.kubebuilder.io/cronjob-tutorial/gvks.html.",
+				Details: "It generally corresponds to a plural, lower-cased version of the Kind. See https://book.kubebuilder.io/cronjob-tutorial/gvks.html.",
 			},
 			"ShortName": markers.DetailedHelp{
 				Summary: "specifies aliases for this CRD. ",
-				Details: " Short names are often used when people have work with your resource over and over again.  For instance, \"rs\" for \"replicaset\" or \"crd\" for customresourcedefinition.",
+				Details: "Short names are often used when people have work with your resource over and over again.  For instance, \"rs\" for \"replicaset\" or \"crd\" for customresourcedefinition.",
 			},
 			"Categories": markers.DetailedHelp{
 				Summary: "specifies which group aliases this resource is part of. ",
-				Details: " Group aliases are used to work with groups of resources at once. The most common one is \"all\" which covers about a third of the base resources in Kubernetes, and is generally used for \"user-facing\" resources.",
+				Details: "Group aliases are used to work with groups of resources at once. The most common one is \"all\" which covers about a third of the base resources in Kubernetes, and is generally used for \"user-facing\" resources.",
 			},
 			"Singular": markers.DetailedHelp{
 				Summary: "overrides the singular form of your resource. ",
-				Details: " The singular form is otherwise defaulted off the plural (path).",
+				Details: "The singular form is otherwise defaulted off the plural (path).",
 			},
 			"Scope": markers.DetailedHelp{
 				Summary: "overrides the scope of the CRD (cluster vs namespaced). ",
-				Details: " Scope defaults to \"namespaced\".  Cluster-scoped (\"cluster\") resources don't exist in namespaces.",
+				Details: "Scope defaults to \"namespaced\".  Cluster-scoped (\"cluster\") resources don't exist in namespaces.",
 			},
 		},
 	}
@@ -240,7 +240,7 @@ func (SkipVersion) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "removes the particular version of the CRD from the CRDs spec. ",
-			Details: " This is useful if you need to skip generating and listing version entries for 'internal' resource versions, which typically exist if using the Kubernetes upstream conversion-gen tool.",
+			Details: "This is useful if you need to skip generating and listing version entries for 'internal' resource versions, which typically exist if using the Kubernetes upstream conversion-gen tool.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -251,7 +251,7 @@ func (StorageVersion) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks this version as the \"storage version\" for the CRD for conversion. ",
-			Details: " When conversion is enabled for a CRD (i.e. it's not a trivial-versions/single-version CRD), one version is set as the \"storage version\" to be stored in etcd.  Attempting to store any other version will result in conversion to the storage version via a conversion webhook.",
+			Details: "When conversion is enabled for a CRD (i.e. it's not a trivial-versions/single-version CRD), one version is set as the \"storage version\" to be stored in etcd.  Attempting to store any other version will result in conversion to the storage version via a conversion webhook.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -275,7 +275,7 @@ func (SubresourceScale) Help() *markers.DefinitionHelp {
 			},
 			"SelectorPath": markers.DetailedHelp{
 				Summary: "specifies the jsonpath to the pod label selector field for the scale's status. ",
-				Details: " The selector field must be the *string* form (serialized form) of a selector. Setting a pod label selector is necessary for your type to work with the HorizontalPodAutoscaler.",
+				Details: "The selector field must be the *string* form (serialized form) of a selector. Setting a pod label selector is necessary for your type to work with the HorizontalPodAutoscaler.",
 			},
 		},
 	}
@@ -297,7 +297,7 @@ func (Type) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "overrides the type for this field (which defaults to the equivalent of the Go type). ",
-			Details: " This generally must be paired with custom serialization.  For example, the metav1.Time field would be marked as \"type: string\" and \"format: date-time\".",
+			Details: "This generally must be paired with custom serialization.  For example, the metav1.Time field would be marked as \"type: string\" and \"format: date-time\".",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}

--- a/pkg/crd/zz_generated.markerhelp.go
+++ b/pkg/crd/zz_generated.markerhelp.go
@@ -34,11 +34,11 @@ func (Generator) Help() *markers.DefinitionHelp {
 		FieldHelp: map[string]markers.DetailedHelp{
 			"TrivialVersions": markers.DetailedHelp{
 				Summary: "indicates that we should produce a single-version CRD. ",
-				Details: " Single \"trivial-version\" CRDs are compatible with older (pre 1.13) Kubernetes API servers.  The storage version's schema will be used as the CRD's schema.",
+				Details: "Single \"trivial-version\" CRDs are compatible with older (pre 1.13) Kubernetes API servers.  The storage version's schema will be used as the CRD's schema.",
 			},
 			"MaxDescLen": markers.DetailedHelp{
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
-				Details: " 0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
+				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},
 		},
 	}

--- a/pkg/genall/zz_generated.markerhelp.go
+++ b/pkg/genall/zz_generated.markerhelp.go
@@ -40,7 +40,7 @@ func (OutputArtifacts) Help() *markers.DefinitionHelp {
 		Category: "",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "outputs artifacts to different locations, depending on whether they're package-associated or not. ",
-			Details: " Non-package associated artifacts are output to the Config directory, while package-associated ones are output to their package's source files' directory, unless an alternate path is specified in Code.",
+			Details: "Non-package associated artifacts are output to the Config directory, while package-associated ones are output to their package's source files' directory, unless an alternate path is specified in Code.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Config": markers.DetailedHelp{
@@ -82,7 +82,7 @@ func (outputToStdout) Help() *markers.DefinitionHelp {
 		Category: "",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "outputs everything to standard-out, with no separation. ",
-			Details: " Generally useful for single-artifact outputs.",
+			Details: "Generally useful for single-artifact outputs.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}

--- a/pkg/webhook/zz_generated.markerhelp.go
+++ b/pkg/webhook/zz_generated.markerhelp.go
@@ -29,16 +29,16 @@ func (Config) Help() *markers.DefinitionHelp {
 		Category: "Webhook",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies how a webhook should be served. ",
-			Details: " It specifies only the details that are intrinsic to the application serving it (e.g. the resources it can handle, or the path it serves on).",
+			Details: "It specifies only the details that are intrinsic to the application serving it (e.g. the resources it can handle, or the path it serves on).",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Mutating": markers.DetailedHelp{
 				Summary: "marks this as a mutating webhook (it's validating only if false) ",
-				Details: " Mutating webhooks are allowed to change the object in their response, and are called *after* all validating webhooks.  Mutating webhooks may choose to reject an object, similarly to a validating webhook.",
+				Details: "Mutating webhooks are allowed to change the object in their response, and are called *after* all validating webhooks.  Mutating webhooks may choose to reject an object, similarly to a validating webhook.",
 			},
 			"FailurePolicy": markers.DetailedHelp{
 				Summary: "specifies what should happen if the API server cannot reach the webhook. ",
-				Details: " It may be either \"ignore\" (to skip the webhook and continue on) or \"fail\" (to reject the object in question).",
+				Details: "It may be either \"ignore\" (to skip the webhook and continue on) or \"fail\" (to reject the object in question).",
 			},
 			"Groups": markers.DetailedHelp{
 				Summary: "specifies the API groups that this webhook receives requests for.",
@@ -50,7 +50,7 @@ func (Config) Help() *markers.DefinitionHelp {
 			},
 			"Verbs": markers.DetailedHelp{
 				Summary: "specifies the Kubernetes API verbs that this webhook receives requests for. ",
-				Details: " Only modification-like verbs may be specified. May be \"create\", \"update\", \"delete\", \"connect\", or \"*\" (for all).",
+				Details: "Only modification-like verbs may be specified. May be \"create\", \"update\", \"delete\", \"connect\", or \"*\" (for all).",
 			},
 			"Versions": markers.DetailedHelp{
 				Summary: "specifies the API versions that this webhook receives requests for.",


### PR DESCRIPTION
Trim leading space from generated marker help `Details` field