### PR TITLE
:sparkles: Add a --version option to controller-gen

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/markers"
 	"sigs.k8s.io/controller-tools/pkg/rbac"
 	"sigs.k8s.io/controller-tools/pkg/schemapatcher"
+	"sigs.k8s.io/controller-tools/pkg/version"
 	"sigs.k8s.io/controller-tools/pkg/webhook"
 )
 
@@ -124,6 +125,7 @@ type noUsageError struct{ error }
 func main() {
 	helpLevel := 0
 	whichLevel := 0
+	showVersion := false
 
 	cmd := &cobra.Command{
 		Use:   "controller-gen",
@@ -146,6 +148,12 @@ func main() {
 	controller-gen crd -ww
 `,
 		RunE: func(c *cobra.Command, rawOpts []string) error {
+			// print version if asked for it
+			if showVersion {
+				version.Print()
+				return nil
+			}
+
 			// print the help if we asked for it (since we've got a different help flag :-/), then bail
 			if helpLevel > 0 {
 				return c.Usage()
@@ -175,6 +183,7 @@ func main() {
 	}
 	cmd.Flags().CountVarP(&whichLevel, "which-markers", "w", "print out all markers available with the requested generators\n(up to -www for the most detailed output, or -wwww for json output)")
 	cmd.Flags().CountVarP(&helpLevel, "detailed-help", "h", "print out more detailed help\n(up to -hhh for the most detailed output, or -hhhh for json output)")
+	cmd.Flags().BoolVar(&showVersion, "version", false, "show version")
 	cmd.Flags().Bool("help", false, "print out usage and a summary of options")
 	oldUsage := cmd.UsageFunc()
 	cmd.SetUsageFunc(func(c *cobra.Command) error {

--- a/cmd/type-scaffold/main.go
+++ b/cmd/type-scaffold/main.go
@@ -35,7 +35,7 @@ func main() {
 		Long: `Quickly scaffold out the structure of a type for a Kubernetes kind and associated types.
 Produces:
 
-- a root type with approparite metadata fields
+- a root type with appropriate metadata fields
 - Spec and Status types
 - a list type
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,34 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// version returns the version of the main module
+func version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		// binary has not been built with module support
+		return "(unknown)"
+	}
+	return info.Main.Version
+}
+
+// Print prints the main module version on stdout.
+//
+// Print will display either:
+//
+// - "Version: v0.2.1" when the program has been compiled with:
+//
+//   $ go get github.com/controller-tools/cmd/controller-gen@v0.2.1
+//
+//   Note: go modules requires the usage of semver compatible tags starting with
+//        'v' to have nice human-readable versions.
+//
+// - "Version: (devel)" when the program is compiled from a local git checkout.
+//
+// - "Version: (unknown)" when not using go modules.
+func Print() {
+	fmt.Printf("Version: %s\n", version())
+}


### PR DESCRIPTION
It's useful to know the version of a `controller-gen` binary lying around. We could write checks in the kubebuilder `Makefile` to upgrade `controller-gen` when needed, or at least warn about it.

Fixes: #259 

I checked that this indeed worked with main modules when using `go get`: https://github.com/dlespiau/go-main-module-version.