### PR TITLE
:sparkles: add controller-gen attribution info to CRD

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
+	"sigs.k8s.io/controller-tools/pkg/version"
 )
 
 // +controllertools:marker:generateHelp
@@ -81,6 +82,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		if g.TrivialVersions {
 			toTrivialVersions(&crd)
 		}
+		addAttribution(&crd)
 		fileName := fmt.Sprintf("%s_%s.yaml", crd.Spec.Group, crd.Spec.Names.Plural)
 		if err := ctx.WriteYAML(fileName, crd); err != nil {
 			return err
@@ -114,6 +116,15 @@ func toTrivialVersions(crd *apiext.CustomResourceDefinition) {
 	crd.Spec.Validation = canonicalSchema
 	crd.Spec.Subresources = canonicalSubresources
 	crd.Spec.AdditionalPrinterColumns = canonicalColumns
+}
+
+// addAttribution adds attribution info to indicate controller-gen tool was used
+// to generate this CRD definition along with the version info.
+func addAttribution(crd *apiext.CustomResourceDefinition) {
+	if crd.ObjectMeta.Annotations == nil {
+		crd.ObjectMeta.Annotations = map[string]string{}
+	}
+	crd.ObjectMeta.Annotations["controller-gen.kubebuilder.io/version"] = version.Version()
 }
 
 // FindMetav1 locates the actual package representing metav1 amongst

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package version
 
 import (
@@ -5,8 +20,8 @@ import (
 	"runtime/debug"
 )
 
-// version returns the version of the main module
-func version() string {
+// Version returns the version of the main module
+func Version() string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		// binary has not been built with module support
@@ -30,5 +45,5 @@ func version() string {
 //
 // - "Version: (unknown)" when not using go modules.
 func Print() {
-	fmt.Printf("Version: %s\n", version())
+	fmt.Printf("Version: %s\n", Version())
 }


### PR DESCRIPTION
Generated CRDs will be annotated with the version info of the controller-gen.
The annotation is `controller-gen.kubebuilder.io/version` and values will be `v0.2.2` is v0.2.2 version was used.

This annotation will help us with:

- Debugging CRD generation issues for ex. we can determine what version of controller-gen was used to generate a particular CRD
- Analyze generated CRDs in the field using Github queries to determine the distribution of controller-gen version. That can help in dropping deprecated features etc.
