### PR TITLE
 ✨ Do not create empty webhook/manifests.yaml file

### DIFF
--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -242,8 +242,8 @@ func (Generator) Generate(ctx *genall.GenerationContext) error {
 
 	}
 
-	if err := ctx.WriteYAML("manifests.yaml", objs...); err != nil {
-		return err
+	if len(objs) > 0 {
+		return ctx.WriteYAML("manifests.yaml", objs...)
 	}
 
 	return nil


### PR DESCRIPTION
Even if there are no webhooks an empty webhook/manifests.yaml file is created.
The PR first checks if there are webhooks and only then calls WriteYAML.
