### PR TITLE
:bug: controller-gen panics when encountering an import loop

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -243,6 +243,9 @@ func (l *loader) typeCheck(pkg *Package) {
 
 		// The imports map is keyed by import path.
 		importedPkg := pkg.Imports()[path]
+		if importedPkg == nil {
+			return nil, fmt.Errorf("package %q possibly creates an import loop", path)
+		}
 
 		// it's possible to have a call to check in parallel to a call to this
 		// if one package in the package graph gets its dependency filtered out,
@@ -254,10 +257,6 @@ func (l *loader) typeCheck(pkg *Package) {
 		// importedPkg.Types.
 		importedPkg.Lock()
 		defer importedPkg.Unlock()
-
-		if importedPkg == nil {
-			return nil, fmt.Errorf("no package information for %q", path)
-		}
 
 		if importedPkg.Types != nil && importedPkg.Types.Complete() {
 			return importedPkg.Types, nil


### PR DESCRIPTION
This fixed an issue where `controller-gen` panics when encountering an import loop. This is especially problematic because when running `make` as part of the default Kubebuilder build `controller-gen` runs before the compiler, thus an import loop can be hard to detect.

