### PR TITLE
Extend webhook marker documentation

### DIFF
--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -70,9 +70,15 @@ type Config struct {
 	// Versions specifies the API versions that this webhook receives requests for.
 	Versions []string
 
-	// Name indicates the name of this webhook configuration.
+	// Name indicates the name of this webhook configuration. Should be a domain with at least three segments separated by dots
 	Name string
-	// Path specifies that path that the API server should connect to this webhook on.
+
+	// Path specifies that path that the API server should connect to this webhook on. Must be
+	// prefixed with a '/validate-' or '/mutate-' depending on the type, and followed by
+	// $GROUP-$VERSION-$KIND where all values are lower-cased and the periods in the group
+	// are substituted for hyphens. For example, a validating webhook path for type
+	// batch.tutorial.kubebuilder.io/v1,Kind=CronJob would be
+	// /validate-batch-tutorial-kubebuilder-io-v1-cronjob
 	Path string
 }
 


### PR DESCRIPTION
Extends the marker documentation for webhook generation for `name` and `path`.

The OpenAPI specs for webhooks require the name is a domain name.

The path is handled specially by controller-runtime, so this adds documentation on how controller-runtime handles it here:
https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/builder/webhook.go#L158

Otherwise the webhook configuration generated by controller-tools will not match what actually runs with controller-runtime