### PR TITLE
:book: CRD scope

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -288,9 +288,9 @@ type Resource struct {
 	// The singular form is otherwise defaulted off the plural (path).
 	Singular string `marker:",optional"`
 
-	// Scope overrides the scope of the CRD (cluster vs namespaced).
+	// Scope overrides the scope of the CRD (Cluster vs Namespaced).
 	//
-	// Scope defaults to "namespaced".  Cluster-scoped ("cluster") resources
+	// Scope defaults to "Namespaced".  Cluster-scoped ("Cluster") resources
 	// don't exist in namespaces.
 	Scope string `marker:",optional"`
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
 
 following the kubebuilder docs to setup 
`+kubebuilder:resource:scope=cluster` marker to generate manifests will have following error messages when install the generated CRD object 
```
The CustomResourceDefinition "stagerolebindings.cloudnative.example.com" is invalid: spec.scope: Unsupported value: "cluster": supported values: "Cluster", "Namespaced"
```

Current marker document CRD generation https://kubebuilder.io/reference/markers/crd.html use lower cased "namespaced" or "cluster" for CRD scope, which should be upper case in first letter according to https://godoc.org/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions#ResourceScope
