### PR TITLE
:bug: Use pointers to generators everywhere

### DIFF
--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -30,13 +30,16 @@ import (
 )
 
 // Generators are a list of Generators.
-type Generators []Generator
+// NB(directxman12): this is a pointer so that we can uniquely identify each
+// instance of a generator, even if it's not hashable.  Different *instances*
+// of a generator are treated differently.
+type Generators []*Generator
 
 // RegisterMarkers registers all markers defined by each of the Generators in
 // this list into the given registry.
 func (g Generators) RegisterMarkers(reg *markers.Registry) error {
 	for _, gen := range g {
-		if err := gen.RegisterMarkers(reg); err != nil {
+		if err := (*gen).RegisterMarkers(reg); err != nil {
 			return err
 		}
 	}
@@ -162,8 +165,7 @@ func (r *Runtime) Run() bool {
 		return true
 	}
 
-	for i := range r.Generators {
-		gen := &r.Generators[i]    // don't take a reference to the loop variable
+	for _, gen := range r.Generators {
 		ctx := r.GenerationContext // make a shallow copy
 		ctx.OutputRule = r.OutputRules.ForGenerator(gen)
 		if err := (*gen).Generate(&ctx); err != nil {

--- a/pkg/genall/options.go
+++ b/pkg/genall/options.go
@@ -133,7 +133,7 @@ func protoFromOptions(optionsRegistry *markers.Registry, options []string) (prot
 
 		switch val := val.(type) {
 		case Generator:
-			gens = append(gens, val)
+			gens = append(gens, &val)
 			gensByName[defn.Name] = &val
 		case OutputRule:
 			_, genName := splitOutputRuleOption(defn.Name)

--- a/pkg/schemapatcher/gen_integration_test.go
+++ b/pkg/schemapatcher/gen_integration_test.go
@@ -41,10 +41,10 @@ var _ = Describe("CRD Patching From Parsing to Editing", func() {
 		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
 
 		By("loading the generation runtime")
-		crdSchemaGen := &Generator{
+		var crdSchemaGen genall.Generator = &Generator{
 			ManifestsPath: "./manifests",
 		}
-		rt, err := genall.Generators{crdSchemaGen}.ForRoots("./...")
+		rt, err := genall.Generators{&crdSchemaGen}.ForRoots("./...")
 		Expect(err).NotTo(HaveOccurred())
 
 		outputDir, err := ioutil.TempDir("", "controller-tools-test")


### PR DESCRIPTION
Since we changed genall to use pointers to generators to make them
comparable, we'll need to actually keep track of the specific instance
of a given generator in the Runtime, otherwise things like output rules
don't get applied correctly.
