### PR TITLE
:book: update URL in README.md

### DIFF
--- a/pkg/crd/testdata/README.md
+++ b/pkg/crd/testdata/README.md
@@ -6,7 +6,7 @@ specially.
 
 The `cronjob_types.go` file contains the input types, and is loosely based
 on the CronJob tutorial from the [KubeBuilder
-Book](https://book.kubebuilder.io/cronjob-tutorial.html), but with added
+Book](https://book.kubebuilder.io/cronjob-tutorial/cronjob-tutorial.html), but with added
 fields to test additional markers and generation behavior.
 
 If you add a new marker, re-generate the golden output file,

--- a/pkg/deepcopy/testdata/README.md
+++ b/pkg/deepcopy/testdata/README.md
@@ -6,7 +6,7 @@ specially.
 
 The `cronjob_types.go` file contains the input types, and is loosely based
 on the CronJob tutorial from the [KubeBuilder
-Book](https://book.kubebuilder.io/cronjob-tutorial.html), but with added
+Book](https://book.kubebuilder.io/cronjob-tutorial/cronjob-tutorial.html), but with added
 fields to test additional DeepCopy cases.
 
 If you for some reason need to change deepcopy generation, you can


### PR DESCRIPTION
 The url “https://book.kubebuilder.io/cronjob-tutorial.html” has been changed to  “https://book.kubebuilder.io/cronjob-tutorial/cronjob-tutorial.html”