### PR TITLE
Update helper functions for Scope, PreserveUnknownFields

### DIFF
--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -244,8 +244,8 @@ func (Resource) Help() *markers.DefinitionHelp {
 				Details: "The singular form is otherwise defaulted off the plural (path).",
 			},
 			"Scope": markers.DetailedHelp{
-				Summary: "overrides the scope of the CRD (cluster vs namespaced). ",
-				Details: "Scope defaults to \"namespaced\".  Cluster-scoped (\"cluster\") resources don't exist in namespaces.",
+				Summary: "overrides the scope of the CRD (Cluster vs Namespaced). ",
+				Details: "Scope defaults to \"Namespaced\".  Cluster-scoped (\"Cluster\") resources don't exist in namespaces.",
 			},
 		},
 	}

--- a/pkg/crd/zz_generated.markerhelp.go
+++ b/pkg/crd/zz_generated.markerhelp.go
@@ -36,6 +36,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "indicates that we should produce a single-version CRD. ",
 				Details: "Single \"trivial-version\" CRDs are compatible with older (pre 1.13) Kubernetes API servers.  The storage version's schema will be used as the CRD's schema. \n Only works with the v1beta1 CRD version.",
 			},
+			"PreserveUnknownFields": markers.DetailedHelp{
+				Summary: "indicates whether or not we should turn off pruning. ",
+				Details: "Left unspecified, it'll default to true when only a v1beta1 CRD is generated (to preserve compatibility with older versions of this tool), or false otherwise. \n It's required to be false for v1 CRDs.",
+			},
 			"MaxDescLen": markers.DetailedHelp{
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",


### PR DESCRIPTION
This PR adds the updated, autogenerated helper functions for Scope and PreserveUnknownFields, which were changed by https://github.com/kubernetes-sigs/controller-tools/commit/64c9bf947355b254ee360805608f68d6b0cf4028 (https://github.com/kubernetes-sigs/controller-tools/pull/355) and https://github.com/kubernetes-sigs/controller-tools/commit/6eb7baf89e3f2d8dc6c650a06089bb8fefcc447c (https://github.com/kubernetes-sigs/controller-tools/pull/362) respectively.