### PR TITLE
:bug: Correct the YAML separator emission logic.

### DIFF
--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -102,12 +102,21 @@ func (g GenerationContext) WriteYAML(itemPath string, objs ...interface{}) error
 	}
 	defer out.Close()
 
-	for _, obj := range objs {
+	for i, obj := range objs {
 		yamlContent, err := yaml.Marshal(obj)
 		if err != nil {
 			return err
 		}
-		n, err := out.Write(append([]byte("\n---\n"), yamlContent...))
+		if i != 0 {
+			n, err := out.Write([]byte("\n---\n"))
+			if err != nil {
+				return err
+			}
+			if n < 5 {
+				return io.ErrShortWrite
+			}
+		}
+		n, err := out.Write(yamlContent)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes: #377 

See that issue for more details.

Unfortunately we cannot use the nice Encoder API from the
gopkg.io/yaml.v3 package which encapsulates this logic already, because
we need to first emit JSON and then convert it to YAML (I always
wondered why it is so. It turns out because there are no `yaml:` tags on
k8s objects.)