### PR TITLE
✨ Change Quantity type to int-or-string

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -60,7 +60,7 @@ var KnownPackages = map[string]PackageOverride{
 				{Type: "integer"},
 				{Type: "string"},
 			},
-			Pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+			Pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
 		}
 		// No point in calling AddPackage, this is the sole inhabitant
 	},

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -60,6 +60,7 @@ var KnownPackages = map[string]PackageOverride{
 				{Type: "integer"},
 				{Type: "string"},
 			},
+			Pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
 		}
 		// No point in calling AddPackage, this is the sole inhabitant
 	},

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -55,7 +55,11 @@ var KnownPackages = map[string]PackageOverride{
 	"k8s.io/apimachinery/pkg/api/resource": func(p *Parser, pkg *loader.Package) {
 		p.Schemata[TypeIdent{Name: "Quantity", Package: pkg}] = apiext.JSONSchemaProps{
 			// TODO(directxman12): regexp validation for this (or get kube to support it as a format value)
-			Type: "string",
+			XIntOrString: true,
+			AnyOf: []apiext.JSONSchemaProps{
+				{Type: "integer"},
+				{Type: "string"},
+			},
 		}
 		// No point in calling AddPackage, this is the sole inhabitant
 	},

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -1109,6 +1109,7 @@ spec:
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
@@ -1773,6 +1774,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
@@ -1783,6 +1785,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Requests describes the minimum
                                             amount of compute resources required.
@@ -2315,6 +2318,7 @@ spec:
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
@@ -2979,6 +2983,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
@@ -2989,6 +2994,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Requests describes the minimum
                                             amount of compute resources required.
@@ -3953,6 +3959,7 @@ spec:
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
@@ -3992,6 +3999,7 @@ spec:
                                             a pod. The default is nil which means
                                             that the limit is undefined. More info:
                                             http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     fc:
@@ -4555,6 +4563,7 @@ spec:
                                                                 the output format
                                                                 of the exposed resources,
                                                                 defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
                                                               description: 'Required:

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -1103,10 +1103,13 @@ spec:
                                                       for env vars'
                                                     type: string
                                                   divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
-                                                    type: string
+                                                    x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
                                                       to select'
@@ -1767,14 +1770,20 @@ spec:
                                       properties:
                                         limits:
                                           additionalProperties:
-                                            type: string
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
                                             info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                           type: object
                                         requests:
                                           additionalProperties:
-                                            type: string
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           description: 'Requests describes the minimum
                                             amount of compute resources required.
                                             If Requests is omitted for a container,
@@ -2300,10 +2309,13 @@ spec:
                                                       for env vars'
                                                     type: string
                                                   divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
-                                                    type: string
+                                                    x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
                                                       to select'
@@ -2964,14 +2976,20 @@ spec:
                                       properties:
                                         limits:
                                           additionalProperties:
-                                            type: string
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
                                             info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                           type: object
                                         requests:
                                           additionalProperties:
-                                            type: string
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
                                           description: 'Requests describes the minimum
                                             amount of compute resources required.
                                             If Requests is omitted for a container,
@@ -3929,10 +3947,13 @@ spec:
                                                       for env vars'
                                                     type: string
                                                   divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
-                                                    type: string
+                                                    x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
                                                       to select'
@@ -3958,6 +3979,9 @@ spec:
                                             or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                           type: string
                                         sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
                                           description: 'Total amount of local storage
                                             required for this EmptyDir volume. The
                                             size limit is also applicable for memory
@@ -3968,7 +3992,7 @@ spec:
                                             a pod. The default is nil which means
                                             that the limit is undefined. More info:
                                             http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                          type: string
+                                          x-kubernetes-int-or-string: true
                                       type: object
                                     fc:
                                       description: FC represents a Fibre Channel resource
@@ -4524,11 +4548,14 @@ spec:
                                                                 for env vars'
                                                               type: string
                                                             divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
                                                               description: Specifies
                                                                 the output format
                                                                 of the exposed resources,
                                                                 defaults to "1"
-                                                              type: string
+                                                              x-kubernetes-int-or-string: true
                                                             resource:
                                                               description: 'Required:
                                                                 resource to select'
@@ -4987,12 +5014,13 @@ spec:
                     type: object
                 type: object
               mapOfInfo:
-                description: A map that allows different actors to manage different fields
-                type: object
-                x-kubernetes-map-type: granular
                 additionalProperties:
                   format: byte
                   type: string
+                description: A map that allows different actors to manage different
+                  fields
+                type: object
+                x-kubernetes-map-type: granular
               noReallySuspend:
                 description: This flag is like suspend, but for when you really mean
                   it. It helps test the +kubebuilder:validation:Type marker.
@@ -5019,8 +5047,6 @@ spec:
                 type: object
               structWithSeveralFields:
                 description: A struct that can only be entirely replaced
-                type: object
-                x-kubernetes-map-type: atomic
                 properties:
                   bar:
                     type: boolean
@@ -5029,6 +5055,8 @@ spec:
                 required:
                 - bar
                 - foo
+                type: object
+                x-kubernetes-map-type: atomic
               successfulJobsHistoryLimit:
                 description: The number of successful finished jobs to retain. This
                   is a pointer to distinguish between explicit zero and not specified.

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -1109,7 +1109,7 @@ spec:
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
@@ -1774,7 +1774,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
@@ -1785,7 +1785,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Requests describes the minimum
                                             amount of compute resources required.
@@ -2318,7 +2318,7 @@ spec:
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
@@ -2983,7 +2983,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Limits describes the maximum
                                             amount of compute resources allowed. More
@@ -2994,7 +2994,7 @@ spec:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           description: 'Requests describes the minimum
                                             amount of compute resources required.
@@ -3959,7 +3959,7 @@ spec:
                                                     description: Specifies the output
                                                       format of the exposed resources,
                                                       defaults to "1"
-                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                     x-kubernetes-int-or-string: true
                                                   resource:
                                                     description: 'Required: resource
@@ -3999,7 +3999,7 @@ spec:
                                             a pod. The default is nil which means
                                             that the limit is undefined. More info:
                                             http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     fc:
@@ -4563,7 +4563,7 @@ spec:
                                                                 the output format
                                                                 of the exposed resources,
                                                                 defaults to "1"
-                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTIE]i)|[mkMGTPE]|((\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                               x-kubernetes-int-or-string: true
                                                             resource:
                                                               description: 'Required:


### PR DESCRIPTION
This PR address the issue #328 

We need this because we want to use the `controller-gen` tool to start managing our CRDs. But the generated CRD only allows `string` types for `Quantity`. 
