### PR TITLE
🐛 Add more apiextensions JSON type to known_types.go

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -90,6 +90,15 @@ var KnownPackages = map[string]PackageOverride{
 		p.Schemata[TypeIdent{Name: "JSON", Package: pkg}] = apiext.JSONSchemaProps{
 			XPreserveUnknownFields: boolPtr(true),
 		}
+		p.Schemata[TypeIdent{Name: "JSONSchemaPropsOrArray", Package: pkg}] = apiext.JSONSchemaProps{
+			XPreserveUnknownFields: boolPtr(true),
+		}
+		p.Schemata[TypeIdent{Name: "JSONSchemaPropsOrBool", Package: pkg}] = apiext.JSONSchemaProps{
+			XPreserveUnknownFields: boolPtr(true),
+		}
+		p.Schemata[TypeIdent{Name: "JSONSchemaPropsOrStringArray", Package: pkg}] = apiext.JSONSchemaProps{
+			XPreserveUnknownFields: boolPtr(true),
+		}
 		p.AddPackage(pkg) // get the rest of the types
 	},
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1": func(p *Parser, pkg *loader.Package) {
@@ -100,6 +109,7 @@ var KnownPackages = map[string]PackageOverride{
 	},
 }
 
+//nolint:unparam
 func boolPtr(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

<!-- What does this do, and why do we need it? -->

Without this I am getting the following error:

```
Generating CRD manifests
/go/pkg/mod/k8s.io/apiextensions-apiserver@v0.0.0-20191114105449-027877536833/pkg/apis/apiextensions/v1beta1/types_jsonschema.go:147:2: encountered struct field "Schema" without JSON tag in type "JSONSchemaPropsOrArray"
/go/pkg/mod/k8s.io/apiextensions-apiserver@v0.0.0-20191114105449-027877536833/pkg/apis/apiextensions/v1beta1/types_jsonschema.go:148:2: encountered struct field "JSONSchemas" without JSON tag in type "JSONSchemaPropsOrArray"
/go/pkg/mod/k8s.io/apiextensions-apiserver@v0.0.0-20191114105449-027877536833/pkg/apis/apiextensions/v1beta1/types_jsonschema.go:167:2: encountered struct field "Allows" without JSON tag in type "JSONSchemaPropsOrBool"
/go/pkg/mod/k8s.io/apiextensions-apiserver@v0.0.0-20191114105449-027877536833/pkg/apis/apiextensions/v1beta1/types_jsonschema.go:168:2: encountered struct field "Schema" without JSON tag in type "JSONSchemaPropsOrBool"
/go/pkg/mod/k8s.io/apiextensions-apiserver@v0.0.0-20191114105449-027877536833/pkg/apis/apiextensions/v1beta1/types_jsonschema.go:189:2: encountered struct field "Schema" without JSON tag in type "JSONSchemaPropsOrStringArray"
/go/pkg/mod/k8s.io/apiextensions-apiserver@v0.0.0-20191114105449-027877536833/pkg/apis/apiextensions/v1beta1/types_jsonschema.go:190:2: encountered struct field "Property" without JSON tag in type "JSONSchemaPropsOrStringArray"
Error: not all generators ran successfully
run `controller-gen crd:trivialVersions=true,preserveUnknownFields=false paths=./apis/... output:crd:artifacts:config=api/crds -w` to see all available markers, or `controller-gen crd:trivialVersions=true,preserveUnknownFields=false paths=./apis/... output:crd:artifacts:config=api/crds -h` for usage
Makefile:192: recipe for target 'gen-crds' failed
```

This is similar to https://github.com/kubernetes-sigs/controller-tools/pull/277