### PR TITLE
:running: Clean up OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
-owners:
-  - directxman12
-  - droot
-  - pwittrock
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
 approvers:
   - controller-tools-admins
+  - controller-tools-approvers
 reviewers:
+  - controller-tools-reviewers
   - controller-tools-admins
+  - controller-tools-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,7 +1,22 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 aliases:
+  # active folks who can be contacted to perform admin-related
+  # tasks on the repo, or otherwise approve any PRS.
   controller-tools-admins:
     - directxman12
     - droot
-    - pwittrock
+    - mengqiy
+
+  # non-admin folks who can approve any PRs in the repo
+  controller-tools-approvers: []
+
+  # folks who can review and LGTM any PRs in the repo (doesn't
+  # include approvers & admins -- those count too via the OWNERS
+  # file)
+  controller-tools-reviewers: []
+
+  # folks who may have context on ancient history,
+  # but are no longer directly involved
+  controller-tools-emeritus-maintainers:
+  - pwittrock


### PR DESCRIPTION
This cleans up the OWNERS file, making sure only active project members
are listed and the links are in line with the latest docs.
