### PR TITLE
✨ Add kubebuilder:unservedversion CRD marker

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -45,6 +45,9 @@ var CRDMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("kubebuilder:skipversion", markers.DescribesType, SkipVersion{})).
 		WithHelp(SkipVersion{}.Help()),
+
+	must(markers.MakeDefinition("kubebuilder:unservedversion", markers.DescribesType, UnservedVersion{})).
+		WithHelp(UnservedVersion{}.Help()),
 }
 
 // TODO: categories and singular used to be annotations types
@@ -287,6 +290,25 @@ func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version s
 		crd.Scope = apiext.ResourceScope(s.Scope)
 	}
 
+	return nil
+}
+
+// +controllertools:marker:generateHelp:category=CRD
+
+// UnservedVersion does not serve this version.
+//
+// This is useful if you need to drop support for a version in favor of a newer version.
+type UnservedVersion struct{}
+
+func (s UnservedVersion) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error {
+	for i := range crd.Versions {
+		ver := &crd.Versions[i]
+		if ver.Name != version {
+			continue
+		}
+		ver.Served = false
+		break
+	}
 	return nil
 }
 

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -374,6 +374,17 @@ func (UniqueItems) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (UnservedVersion) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "does not serve this version. ",
+			Details: "This is useful if you need to drop support for a version in favor of a newer version.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (XEmbeddedResource) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -151,6 +151,19 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind, maxDescLen *int) {
 		packages[0].AddError(fmt.Errorf("CRD for %s has no storage version", groupKind))
 	}
 
+	served := false
+	for _, ver := range crd.Spec.Versions {
+		if ver.Served {
+			served = true
+			break
+		}
+	}
+	if !served {
+		// just add the error to the first relevant package for this CRD,
+		// since there's no specific error location
+		packages[0].AddError(fmt.Errorf("CRD for %s with version(s) %v does not serve any version", groupKind, crd.Spec.Versions))
+	}
+
 	// NB(directxman12): CRD's status doesn't have omitempty markers, which means things
 	// get serialized as null, which causes the validator to freak out.  Manually set
 	// these to empty till we get a better solution.


### PR DESCRIPTION
Used to set `served=false` for an apiversion.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
