### PR TITLE
:bug: use map in FindKubeKinds

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -104,7 +104,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		crdVersions = []string{"v1beta1"}
 	}
 
-	for _, groupKind := range kubeKinds {
+	for groupKind := range kubeKinds {
 		parser.NeedCRDFor(groupKind, g.MaxDescLen)
 		crdRaw := parser.CustomResourceDefinitions[groupKind]
 		addAttribution(&crdRaw)
@@ -206,9 +206,9 @@ func FindMetav1(roots []*loader.Package) *loader.Package {
 // FindKubeKinds locates all types that contain TypeMeta and ObjectMeta
 // (and thus may be a Kubernetes object), and returns the corresponding
 // group-kinds.
-func FindKubeKinds(parser *Parser, metav1Pkg *loader.Package) []schema.GroupKind {
+func FindKubeKinds(parser *Parser, metav1Pkg *loader.Package) map[schema.GroupKind]struct{} {
 	// TODO(directxman12): technically, we should be finding metav1 per-package
-	var kubeKinds []schema.GroupKind
+	kubeKinds := map[schema.GroupKind]struct{}{}
 	for typeIdent, info := range parser.Types {
 		hasObjectMeta := false
 		hasTypeMeta := false
@@ -257,7 +257,7 @@ func FindKubeKinds(parser *Parser, metav1Pkg *loader.Package) []schema.GroupKind
 			Group: parser.GroupVersions[pkg].Group,
 			Kind:  typeIdent.Name,
 		}
-		kubeKinds = append(kubeKinds, groupKind)
+		kubeKinds[groupKind] = struct{}{}
 	}
 
 	return kubeKinds

--- a/pkg/schemapatcher/gen.go
+++ b/pkg/schemapatcher/gen.go
@@ -115,7 +115,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) (result error) {
 	}
 
 	// generate schemata for the types we care about, and save them to be written later.
-	for _, groupKind := range crdgen.FindKubeKinds(parser, metav1Pkg) {
+	for groupKind := range crdgen.FindKubeKinds(parser, metav1Pkg) {
 		existingSet, wanted := partialCRDSets[groupKind]
 		if !wanted {
 			continue


### PR DESCRIPTION
It makes more sense to return a hash set instead of a list, since hash set help de-duplicate group-kind.
