### PR TITLE
🐛Fix singular argument for resource marker

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -277,6 +277,9 @@ func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version s
 	if s.Path != "" {
 		crd.Names.Plural = s.Path
 	}
+	if s.Singular != "" {
+		crd.Names.Singular = s.Singular
+	}
 	crd.Names.ShortNames = s.ShortName
 	crd.Names.Categories = s.Categories
 

--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -120,7 +120,7 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind, maxDescLen *int) {
 		}
 	}
 
-	// fix the name if the plural was changed (this is the form the name *has* to take, so no harm in chaning it).
+	// fix the name if the plural was changed (this is the form the name *has* to take, so no harm in changing it).
 	crd.Name = crd.Spec.Names.Plural + "." + groupKind.Group
 
 	// nothing to actually write

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -227,7 +227,7 @@ type CronJobStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource
+// +kubebuilder:resource:singular=mycronjob
 
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -13,7 +13,7 @@ spec:
     kind: CronJob
     listKind: CronJobList
     plural: cronjobs
-    singular: cronjob
+    singular: mycronjob
   scope: Namespaced
   versions:
   - name: v1


### PR DESCRIPTION
Singular argument on `+kubebuilder:resource` marker was never actually applied to CRD. This PR fixes it.

Fixes https://github.com/kubernetes-sigs/controller-tools/issues/343

Also fixes a small typo 🙃