### PR TITLE
🐛Fix panic on anonymous nested struct in CRD

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -319,7 +319,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 		Properties: make(map[string]apiext.JSONSchemaProps),
 	}
 
-	if ctx.info.RawSpec.Type != structType {
+	if ctx.info.Name == "" || ctx.info.RawSpec == nil || ctx.info.RawSpec.Type != structType {
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("encountered non-top-level struct (possibly embedded), those aren't allowed"), structType))
 		return props
 	}


### PR DESCRIPTION
Anonymous nested structs are not allowed according to the error message, but the code was panicking because for such struct `ctx.info.RawSpec` is nil.

This change adds extra checks so that struct name must be present and spec must not be nil.

Fixes https://github.com/kubernetes-sigs/controller-tools/issues/340 (which was closed recently by bot)

---

Not sure if it is possible to add a test for this somewhere 🤔. I tested locally:

```go
type ZugaSpec struct {
	NestedStruct ZugaNestedStruct `json:"nestedStruct,omitempty"`

	NestedAnonymousStruct struct {
		Bar string `json:"bar"`
	} `json:"nestedAnonymousStruct"`
}

type ZugaNestedStruct struct {
	Foo string `json:"foo"`
}
```

Running `make manifests` on master:

```
λ make manifests
/Users/hypnoglow/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x16678cc]

goroutine 1 [running]:
sigs.k8s.io/controller-tools/pkg/crd.structToSchema(0xc001263440, 0xc0003e4460, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:322 +0x9c
sigs.k8s.io/controller-tools/pkg/crd.typeToSchema(0xc001263440, 0x19aaf60, 0xc0003e4460, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:164 +0x3a6
sigs.k8s.io/controller-tools/pkg/crd.structToSchema(0xc000a860b0, 0xc0003e44a0, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:375 +0x491
sigs.k8s.io/controller-tools/pkg/crd.typeToSchema(0xc000a860b0, 0x19aaf60, 0xc0003e44a0, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:164 +0x3a6
sigs.k8s.io/controller-tools/pkg/crd.infoToSchema(...)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:107
sigs.k8s.io/controller-tools/pkg/crd.(*Parser).NeedSchemaFor(0xc00010c0f0, 0xc0003b2b40, 0xc000984040, 0x8)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/parser.go:174 +0x321
sigs.k8s.io/controller-tools/pkg/crd.(*schemaContext).requestSchema(0xc001263290, 0x0, 0x0, 0xc000984040, 0x8)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:99 +0x9e
sigs.k8s.io/controller-tools/pkg/crd.localNamedToSchema(0xc001263290, 0xc0003e4840, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:220 +0x1b1
sigs.k8s.io/controller-tools/pkg/crd.typeToSchema(0xc001263290, 0x19aab20, 0xc0003e4840, 0x1f)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:154 +0x2e9
sigs.k8s.io/controller-tools/pkg/crd.structToSchema(0xc000a86aa8, 0xc0003e4900, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:375 +0x491
sigs.k8s.io/controller-tools/pkg/crd.typeToSchema(0xc000a86aa8, 0x19aaf60, 0xc0003e4900, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:164 +0x3a6
sigs.k8s.io/controller-tools/pkg/crd.infoToSchema(...)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/schema.go:107
sigs.k8s.io/controller-tools/pkg/crd.(*Parser).NeedSchemaFor(0xc00010c0f0, 0xc0003b2b40, 0xc0009840f4, 0x4)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/parser.go:174 +0x321
sigs.k8s.io/controller-tools/pkg/crd.(*Parser).NeedFlattenedSchemaFor(0xc00010c0f0, 0xc0003b2b40, 0xc0009840f4, 0x4)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/parser.go:186 +0xd8
sigs.k8s.io/controller-tools/pkg/crd.(*Parser).NeedCRDFor(0xc00010c0f0, 0xc00099a03e, 0x1c, 0xc0009840f4, 0x4, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/spec.go:85 +0x615
sigs.k8s.io/controller-tools/pkg/crd.Generator.Generate(0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc00010c0a0, 0x199bee0, 0x199bee0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/crd/gen.go:108 +0x356
sigs.k8s.io/controller-tools/pkg/genall.(*Runtime).Run(0xc00022b300, 0xc00010fc70)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/pkg/genall/genall.go:171 +0x15e
main.main.func1(0xc000177b80, 0xc00010fc70, 0x5, 0x5, 0x0, 0x0)
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/cmd/controller-gen/main.go:176 +0xa6
github.com/spf13/cobra.(*Command).execute(0xc000177b80, 0xc0000d20d0, 0x5, 0x5, 0xc000177b80, 0xc0000d20d0)
	/Users/hypnoglow/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc000177b80, 0xc00000fb60, 0x4, 0x0)
	/Users/hypnoglow/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/hypnoglow/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/Users/hypnoglow/sources/github.com/kubernetes-sigs/controller-tools/cmd/controller-gen/main.go:200 +0x37e
make: *** [manifests] Error 2
```

Running `make manifests` with this PR applied:

```
λ make manifests
/Users/hypnoglow/go/bin/controller-gen "crd:trivialVersions=true" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Users/hypnoglow/sources/github.com/hypnoglow/nonsense-operator/api/v1alpha1/zuga_types.go:39:24: encountered non-top-level struct (possibly embedded), those aren't allowed
Error: not all generators ran successfully
run `controller-gen crd:trivialVersions=true rbac:roleName=manager-role webhook paths=./... output:crd:artifacts:config=config/crd/bases -w` to see all available markers, or `controller-gen crd:trivialVersions=true rbac:roleName=manager-role webhook paths=./... output:crd:artifacts:config=config/crd/bases -h` for usage
make: *** [manifests] Error 1
```