### PR TITLE
Revert "Resolve reference in order to remove $ref which is not supported by k8s"

### DIFF
--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -248,7 +248,7 @@ func (f *Flattener) loadUnflattenedSchema(typ TypeIdent) (*apiext.JSONSchemaProp
 	if !found {
 		return nil, fmt.Errorf("unable to locate schema for type %s", typ)
 	}
-	return f.FlattenSchema(baseSchema, typ.Package), nil
+	return &baseSchema, nil
 }
 
 // FlattenType flattens the given pre-loaded type, removing any references from it.


### PR DESCRIPTION
The fix was untested, and not in the correct place.

Reverts kubernetes-sigs/controller-tools#412