### PR TITLE
🐛 do not error when webhook matchpolicy unset

### DIFF
--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -194,6 +194,8 @@ func (c Config) matchPolicy() (*admissionreg.MatchPolicyType, error) {
 		matchPolicy = admissionreg.Exact
 	case strings.ToLower(string(admissionreg.Equivalent)):
 		matchPolicy = admissionreg.Equivalent
+	case "":
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unknown value %q for matchPolicy", c.MatchPolicy)
 	}


### PR DESCRIPTION
This handles the case where the matchpolicy is not set using a webhook
marker.

Fixes #417 