### PR TITLE
✨Deprecate the duplicated kubebuilder:validation:XPreserveUnknownFields marker.

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -78,10 +78,18 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 	must(markers.MakeAnyTypeDefinition("kubebuilder:default", markers.DescribesField, Default{})).
 		WithHelp(Default{}.Help()),
 
-	must(markers.MakeDefinition("kubebuilder:pruning:PreserveUnknownFields", markers.DescribesField, XPreserveUnknownFields{})).
-		WithHelp(XPreserveUnknownFields{}.Help()),
 	must(markers.MakeDefinition("kubebuilder:validation:EmbeddedResource", markers.DescribesField, XEmbeddedResource{})).
 		WithHelp(XEmbeddedResource{}.Help()),
+}
+
+// ValidationIshMarkers are field-and-type markers that don't fall under the
+// :validation: prefix, and/or don't have a name that directly matches their
+// type.
+var ValidationIshMarkers = []*definitionWithHelp{
+	must(markers.MakeDefinition("kubebuilder:pruning:PreserveUnknownFields", markers.DescribesField, XPreserveUnknownFields{})).
+		WithHelp(XPreserveUnknownFields{}.Help()),
+	must(markers.MakeDefinition("kubebuilder:pruning:PreserveUnknownFields", markers.DescribesType, XPreserveUnknownFields{})).
+		WithHelp(XPreserveUnknownFields{}.Help()),
 }
 
 func init() {
@@ -99,6 +107,7 @@ func init() {
 	}
 
 	AllDefinitions = append(AllDefinitions, FieldOnlyMarkers...)
+	AllDefinitions = append(AllDefinitions, ValidationIshMarkers...)
 }
 
 // +controllertools:marker:generateHelp:category="CRD validation"
@@ -191,6 +200,10 @@ type Default struct {
 // if nested  properties or additionalProperties are specified in the schema.
 // This can either be true or undefined. False
 // is forbidden.
+//
+// NB: The kubebuilder:validation:XPreserveUnknownFields variant is deprecated
+// in favor of the kubebuilder:pruning:PreserveUnknownFields variant.  They function
+// identically.
 type XPreserveUnknownFields struct{}
 
 // +controllertools:marker:generateHelp:category="CRD validation"

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -401,7 +401,7 @@ func (XPreserveUnknownFields) Help() *markers.DefinitionHelp {
 		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "PreserveUnknownFields stops the apiserver from pruning fields which are not specified. ",
-			Details: "By default the apiserver drops unknown fields from the request payload during the decoding step. This marker stops the API server from doing so. It affects fields recursively, but switches back to normal pruning behaviour if nested  properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.",
+			Details: "By default the apiserver drops unknown fields from the request payload during the decoding step. This marker stops the API server from doing so. It affects fields recursively, but switches back to normal pruning behaviour if nested  properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden. \n NB: The kubebuilder:validation:XPreserveUnknownFields variant is deprecated in favor of the kubebuilder:pruning:PreserveUnknownFields variant.  They function identically.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -5090,6 +5090,15 @@ spec:
                 type: object
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
+              unprunedFomType:
+                description: This tests that a type-level pruning maker works.
+                properties:
+                  concreteField:
+                    type: string
+                required:
+                - concreteField
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               unprunedJSON:
                 properties:
                   bar:
@@ -5117,6 +5126,7 @@ spec:
             - twoOfAKindPart0
             - twoOfAKindPart1
             - unprunedEmbeddedResource
+            - unprunedFomType
             - unprunedJSON
             type: object
           status:

--- a/pkg/rbac/zz_generated.markerhelp.go
+++ b/pkg/rbac/zz_generated.markerhelp.go
@@ -57,8 +57,8 @@ func (Rule) Help() *markers.DefinitionHelp {
 				Details: "",
 			},
 			"ResourceNames": markers.DetailedHelp{
-				Summary: "specifies the names of the API resources that this rule encompasses. Create requests cannot be restricted by resourcename, as the object's name is not known at authorization time.",
-				Details: "",
+				Summary: "specifies the names of the API resources that this rule encompasses. ",
+				Details: "Create requests cannot be restricted by resourcename, as the object's name is not known at authorization time.",
 			},
 			"Verbs": markers.DetailedHelp{
 				Summary: "specifies the (lowercase) kubernetes API verbs that this rule encompasses.",


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Remove the duplicated kubebuilder:validation:XPreserveUnknownFields marker.
Fixes #380 