### PR TITLE
✨ Generate schema for types with custom JSON marshaling as Any type

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -19,6 +19,7 @@ package crd
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
 	"strings"
 
@@ -104,6 +105,11 @@ func (c *schemaContext) requestSchema(pkgPath, typeName string) {
 
 // infoToSchema creates a schema for the type in the given set of type information.
 func infoToSchema(ctx *schemaContext) *apiext.JSONSchemaProps {
+	if obj := ctx.pkg.Types.Scope().Lookup(ctx.info.Name); obj != nil && implementsJSONMarshaler(obj.Type()) {
+		schema := &apiext.JSONSchemaProps{Type: "Any"}
+		applyMarkers(ctx, ctx.info.Markers, schema, ctx.info.RawSpec.Type)
+		return schema
+	}
 	return typeToSchema(ctx, ctx.info.RawSpec.Type)
 }
 
@@ -418,4 +424,17 @@ func builtinToType(basic *types.Basic) (typ string, format string, err error) {
 	}
 
 	return typ, format, nil
+}
+
+// Open coded go/types representation of encoding/json.Marshaller
+var jsonMarshaler = types.NewInterfaceType([]*types.Func{
+	types.NewFunc(token.NoPos, nil, "MarshalJSON",
+		types.NewSignature(nil, nil,
+			types.NewTuple(
+				types.NewVar(token.NoPos, nil, "", types.NewSlice(types.Universe.Lookup("byte").Type())),
+				types.NewVar(token.NoPos, nil, "", types.Universe.Lookup("error").Type())), false)),
+}, nil).Complete()
+
+func implementsJSONMarshaler(typ types.Type) bool {
+	return types.Implements(typ, jsonMarshaler) || types.Implements(types.NewPointer(typ), jsonMarshaler)
 }

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -5167,6 +5167,14 @@ spec:
                       type: string
                   type: object
                 type: array
+              lastActiveLogURL:
+                description: LastActiveLogURL specifies the logging url for the last
+                  started job
+                type: string
+              lastActiveLogURL2:
+                description: LastActiveLogURL2 specifies the logging url for the last
+                  started job
+                type: string
               lastScheduleMicroTime:
                 description: Information about the last time the job was successfully
                   scheduled, with microsecond precision.


### PR DESCRIPTION
Currently controller-gen complains about structs with missing json tags even
when those structs implement custom JSON marshalling.

With this change we check if a type implements custom JSON marshalling and if it
does, we output schema for Any type. This still allows the validation type to
overriden with a marker.

Fixes #391
