### PR TITLE
🐛 Fix flattening chains of references to references

### DIFF
--- a/pkg/crd/flatten_type_test.go
+++ b/pkg/crd/flatten_type_test.go
@@ -38,7 +38,9 @@ var _ = Describe("General Schema Flattening", func() {
 
 		rootType        = crd.TypeIdent{Name: "RootType", Package: rootPkg}
 		subtypeWithRefs = crd.TypeIdent{Name: "SubtypeWithRefs", Package: rootPkg}
+		leafAliasType   = crd.TypeIdent{Name: "LeafAlias", Package: rootPkg}
 		leafType        = crd.TypeIdent{Name: "LeafType", Package: otherPkg}
+		inPkgLeafType   = crd.TypeIdent{Name: "InPkgLeafType", Package: rootPkg}
 	)
 
 	BeforeEach(func() {
@@ -70,6 +72,76 @@ var _ = Describe("General Schema Flattening", func() {
 
 			},
 		}
+	})
+
+	Context("when dealing with reference chains", func() {
+		It("should flatten them", func() {
+			By("setting up a RootType, LeafAlias --> Alias --> Int")
+			toLeafAlias := crd.TypeRefLink("", leafAliasType.Name)
+			toLeaf := crd.TypeRefLink("other", leafType.Name)
+			fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
+				rootType: apiext.JSONSchemaProps{
+					Properties: map[string]apiext.JSONSchemaProps{
+						"refProp": apiext.JSONSchemaProps{Ref: &toLeafAlias},
+					},
+				},
+				leafAliasType: apiext.JSONSchemaProps{Ref: &toLeaf},
+				leafType: apiext.JSONSchemaProps{
+					Type:    "string",
+					Pattern: "^[abc]$",
+				},
+			}
+
+			By("flattening the type hierarchy")
+			// flattenAllOf to avoid the normalize the all-of forms to what we
+			// really want (instead of caring about nested all-ofs)
+			outSchema := crd.FlattenEmbedded(fl.FlattenType(rootType), rootPkg)
+			Expect(rootPkg.Errors).To(HaveLen(0))
+			Expect(otherPkg.Errors).To(HaveLen(0))
+
+			By("verifying that it was flattened to have no references")
+			Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
+				Properties: map[string]apiext.JSONSchemaProps{
+					"refProp": apiext.JSONSchemaProps{
+						Type: "string", Pattern: "^[abc]$",
+					},
+				},
+			}))
+		})
+
+		It("should not infinite-loop on circular references", func() {
+			By("setting up a RootType, LeafAlias --> Alias --> LeafAlias")
+			toLeafAlias := crd.TypeRefLink("", leafAliasType.Name)
+			toLeaf := crd.TypeRefLink("", inPkgLeafType.Name)
+			fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
+				rootType: apiext.JSONSchemaProps{
+					Properties: map[string]apiext.JSONSchemaProps{
+						"refProp": apiext.JSONSchemaProps{Ref: &toLeafAlias},
+					},
+				},
+				leafAliasType: apiext.JSONSchemaProps{Ref: &toLeaf},
+				inPkgLeafType: apiext.JSONSchemaProps{Ref: &toLeafAlias},
+			}
+
+			By("flattening the type hierarchy")
+			// flattenAllOf to avoid the normalize the all-of forms to what we
+			// really want (instead of caring about nested all-ofs)
+			outSchema := crd.FlattenEmbedded(fl.FlattenType(rootType), rootPkg)
+
+			// This should *finish* to some degree, leaving the circular reference in
+			// place.  It should be fine to error on circular references in the future, though.
+			Expect(rootPkg.Errors).To(HaveLen(0))
+			Expect(otherPkg.Errors).To(HaveLen(0))
+
+			By("verifying that it was flattened to *something*")
+			Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
+				Properties: map[string]apiext.JSONSchemaProps{
+					"refProp": apiext.JSONSchemaProps{
+						Ref: &toLeafAlias,
+					},
+				},
+			}))
+		})
 	})
 
 	It("should flatten a hierarchy of references", func() {

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -145,12 +145,18 @@ type CronJobSpec struct {
 	// A struct that can only be entirely replaced
 	// +structType=atomic
 	StructWithSeveralFields NestedObject `json:"structWithSeveralFields"`
+
+	// This tests that type references are properly flattened
+	// +kubebuilder:validation:optional
+	JustNestedObject *JustNestedObject `json:"justNestedObject,omitempty"`
 }
 
 type NestedObject struct {
 	Foo string `json:"foo"`
 	Bar bool   `json:"bar"`
 }
+
+type JustNestedObject NestedObject
 
 type RootObject struct {
 	Nested NestedObject `json:"nested"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -5022,6 +5022,17 @@ spec:
                     - template
                     type: object
                 type: object
+              justNestedObject:
+                description: This tests that type references are properly flattened
+                properties:
+                  bar:
+                    type: boolean
+                  foo:
+                    type: string
+                required:
+                - bar
+                - foo
+                type: object
               mapOfInfo:
                 additionalProperties:
                   format: byte


### PR DESCRIPTION
Without this change running controller-gen on Knative's APIs
results in unexpanded reference for the Conditions[1] type in
the generated OpenAPI schema:

    conditions:
      $ref: '#/definitions/knative.dev~1pkg~1apis~0Conditions'

After this change Conditions gets properly flattened and no references
are present in the resulting schema.

Fixes #324

[1] https://github.com/knative/pkg/blob/ce05a3de31ed80e98862a0ea024977097fd0e4a5/apis/duck/v1/status_types.go#L34
