### PR TITLE
:sparkles: Remove status from generated CRDs

### DIFF
--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -164,11 +164,7 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind, maxDescLen *int) {
 		packages[0].AddError(fmt.Errorf("CRD for %s with version(s) %v does not serve any version", groupKind, crd.Spec.Versions))
 	}
 
-	// NB(directxman12): CRD's status doesn't have omitempty markers, which means things
-	// get serialized as null, which causes the validator to freak out.  Manually set
-	// these to empty till we get a better solution.
-	crd.Status.Conditions = []apiext.CustomResourceDefinitionCondition{}
-	crd.Status.StoredVersions = []string{}
+	crd.Status = apiext.CustomResourceDefinitionStatus{}
 
 	p.CustomResourceDefinitions[groupKind] = crd
 }

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -5178,9 +5178,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
This sets the CRDs status to empty so it is no longer generated in CRD yamls.

This was originally added in https://github.com/kubernetes-sigs/controller-tools/pull/203 which confuses me because v1beta1 has had the optional marker for awhile https://github.com/kubernetes/kubernetes/pull/66102/files#diff-3029a18192feb70af52de676209da9b6R206

This is currently a problem because continuous delivery tools cant converge when applying them against the updated server set properties 