### PR TITLE
:bug: Marker comment block incorrectly parsed when it last comment block and surrounded by godoc

### DIFF
--- a/pkg/markers/collect.go
+++ b/pkg/markers/collect.go
@@ -213,7 +213,7 @@ func (c markerComment) Text() string {
 	return strings.TrimSpace(c.Comment.Text[2:])
 }
 
-// markerVisistor visits AST nodes, recording markers associated with each node.
+// markerVisitor visits AST nodes, recording markers associated with each node.
 type markerVisitor struct {
 	allComments []*ast.CommentGroup
 	commentInd  int
@@ -238,7 +238,7 @@ func isMarkerComment(comment string) bool {
 	return true
 }
 
-// markersBetween grabs the markers between the given indicies in the list of all comments.
+// markersBetween grabs the markers between the given indices in the list of all comments.
 func (v *markerVisitor) markersBetween(fromGodoc bool, start, end int) []markerComment {
 	if start < 0 || end < 0 {
 		return nil
@@ -319,9 +319,10 @@ func (v markerSubVisitor) Visit(node ast.Node) ast.Visitor {
 		var docGroup *ast.CommentGroup
 		docGroup, v.lastLineCommentGroup = associatedCommentsFor(node)
 
-		// find the last comment group that's not godoc
+		// find the last comment group that's not godoc or contains marker comment
 		markerCommentInd := lastCommentInd
-		if docGroup != nil && v.allComments[markerCommentInd].Pos() == docGroup.Pos() {
+		hasMarkerInGroup := len(v.markersBetween(false, markerCommentInd, markerCommentInd+1)) > 0
+		if docGroup != nil && (v.allComments[markerCommentInd].Pos() == docGroup.Pos() || hasMarkerInGroup) {
 			markerCommentInd--
 		}
 

--- a/pkg/webhook/testdata/webhook.go
+++ b/pkg/webhook/testdata/webhook.go
@@ -26,9 +26,9 @@ func (c *CronJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		For(c).
 		Complete()
 }
-
 // +kubebuilder:webhook:verbs=create;update,path=/validate-testdata-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=validation.cronjob.testdata.kubebuilder.io,sideEffects=Some
 // +kubebuilder:webhook:verbs=create;update,path=/mutate-testdata-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=default.cronjob.testdata.kubebuilder.io,sideEffects=None
+// A godoc comment after marker comment
 
 var _ webhook.Defaulter = &CronJob{}
 var _ webhook.Validator = &CronJob{}


### PR DESCRIPTION
When marker comment(s) surrounded by or finished with godoc and placed as last comment in the package they are skipped and not placed to the pkgMarkers.

Fixes #436 