### PR TITLE
🐛 Fix validation errors happening in v1.18

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 package crd
 
 import (
+	"strconv"
+
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"sigs.k8s.io/controller-tools/pkg/loader"
@@ -100,6 +102,13 @@ var KnownPackages = map[string]PackageOverride{
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1": func(p *Parser, pkg *loader.Package) {
 		p.Schemata[TypeIdent{Name: "JSON", Package: pkg}] = apiext.JSONSchemaProps{
 			XPreserveUnknownFields: boolPtr(true),
+		}
+		p.AddPackage(pkg) // get the rest of the types
+	},
+	"k8s.io/api/core/v1": func(p *Parser, pkg *loader.Package) {
+		p.Schemata[TypeIdent{Name: "Protocol", Package: pkg}] = apiext.JSONSchemaProps{
+			Type:    "string",
+			Default: &apiext.JSON{Raw: []byte(strconv.Quote("TCP"))},
 		}
 		p.AddPackage(pkg) // get the rest of the types
 	},

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -110,7 +110,7 @@ type CronJobSpec struct {
 	DefaultedSlice []string `json:"defaultedSlice"`
 
 	// This tests that object defaulting can be performed.
-	// +kubebuilder:default={{nested: {foo: "baz", bar: true}},{nested: {bar: false}}}
+	// +kubebuilder:default={{nested: {foo: "baz", bar: true}},{nested: {foo: "baz", bar: false}}}
 	DefaultedObject []RootObject `json:"defaultedObject"`
 
 	// This tests that pattern validator is properly applied.
@@ -119,7 +119,7 @@ type CronJobSpec struct {
 
 	// +kubebuilder:validation:EmbeddedResource
 	// +kubebuilder:validation:nullable
-	EmbeddedResource runtime.RawExtension `json:"embeddedResource"`
+	EmbeddedResource NestedObject `json:"embeddedResource"`
 
 	// +kubebuilder:validation:nullable
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -88,6 +88,7 @@ spec:
                     foo: baz
                 - nested:
                     bar: false
+                    foo: baz
                 description: This tests that object defaulting can be performed.
                 items:
                   properties:
@@ -118,6 +119,14 @@ spec:
                 description: This tests that primitive defaulting can be performed.
                 type: string
               embeddedResource:
+                properties:
+                  bar:
+                    type: boolean
+                  foo:
+                    type: string
+                required:
+                - bar
+                - foo
                 type: object
                 x-kubernetes-embedded-resource: true
               failedJobsHistoryLimit:
@@ -1619,6 +1628,7 @@ spec:
                                               can be referred to by services.
                                             type: string
                                           protocol:
+                                            default: TCP
                                             description: Protocol for port. Must be
                                               UDP, TCP, or SCTP. Defaults to "TCP".
                                             type: string
@@ -2828,6 +2838,7 @@ spec:
                                               can be referred to by services.
                                             type: string
                                           protocol:
+                                            default: TCP
                                             description: Protocol for port. Must be
                                               UDP, TCP, or SCTP. Defaults to "TCP".
                                             type: string


### PR DESCRIPTION
This PR intends to fix validation errors happening when creating generated controllers in Kubernetes v1.18.

```
The CustomResourceDefinition "cronjobs.testdata.kubebuilder.io" is invalid: 
* spec.validation.openAPIV3Schema.properties[spec].properties[jobTemplate].properties[spec].properties[template].properties[spec].properties[containers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
* spec.validation.openAPIV3Schema.properties[spec].properties[jobTemplate].properties[spec].properties[template].properties[spec].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property
* spec.validation.openAPIV3Schema.properties[spec].properties[embeddedResource].properties: Required value: must not be empty if x-kubernetes-embedded-resource is true without x-kubernetes-preserve-unknown-fields
```

```
The CustomResourceDefinition "cronjobs.testdata.kubebuilder.io" is invalid:
* spec.validation.openAPIV3Schema.properties[spec].properties[defaultedObject].default.nested.foo: Required value
```

In order to fix embeddedResource, and defaultedObject required value errors, this PR adds the missing values inside of `cronjob_types.go`.

For the protocol validation errors, this PR injects the [default Protocol value](https://godoc.org/k8s.io/api/core/v1#ContainerPort) inside of the scheme.

Fixes #438