### PR TITLE
✨  Warn about things that we strongly recommend avoiding

### DIFF
--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -37,6 +37,15 @@ type ErrorRecorder interface {
 	AddError(error)
 }
 
+// WarningRecorder knows how to record errors. It wraps the part of
+// pkg/loader.Package that we need to record errors in places were it might not
+// make sense to have a loader.Package
+type WarningRecorder interface {
+	// AddWarning records that the given error occurred.
+	// See the documentation on loader.Package.AddWarning for more information.
+	AddWarning(error)
+}
+
 // isOrNil checks if val is nil if val is of a nillable type, otherwise,
 // it compares val to valInt (which should probably be the zero value).
 func isOrNil(val reflect.Value, valInt interface{}, zeroInt interface{}) bool {

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -304,6 +304,7 @@ func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiext.JSONSchemaPro
 			return &apiext.JSONSchemaProps{}
 		}
 	case *ast.StarExpr:
+		ctx.pkg.AddWarning(loader.ErrFromNode(fmt.Errorf("map values should be a named type, not %T", mapType.Value), mapType.Value))
 		valSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), val)
 	default:
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map values must be a named type, not %T", mapType.Value), mapType.Value))

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -173,6 +173,8 @@ func (r *Runtime) Run() bool {
 		}
 	}
 
+	loader.PrintWarnings(r.Roots)
+
 	// skip TypeErrors -- they're probably just from partial typechecking in crd-gen
 	return loader.PrintErrors(r.Roots, packages.TypeError)
 }


### PR DESCRIPTION
I created a guestbook kubebuilder init project and added a *ast.StarExpr to guestbook struct

type Env struct {
	A int    `json:"a"`
	B string `json:"b"`
}

// Guestbook is the Schema for the guestbooks API
type Guestbook struct {
	metav1.TypeMeta   `json:",inline"`
	metav1.ObjectMeta `json:"metadata,omitempty"`

	Spec   GuestbookSpec   `json:"spec,omitempty"`
	Status GuestbookStatus `json:"status,omitempty"`
	Envs   map[string]*Env `json:"envs,omitempty"`
}
my patch:

./controller-gen crd object:headerFile="hack/boilerplate.go.txt" paths="./..." output:crd:stdout

---
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: (devel)
  creationTimestamp: null
  name: guestbooks.webapp.my.domain
spec:
  group: webapp.my.domain
  names:
    kind: Guestbook
    listKind: GuestbookList
    plural: guestbooks
    singular: guestbook
  scope: Namespaced
  validation:
    openAPIV3Schema:
      description: Guestbook is the Schema for the guestbooks API
      properties:
        apiVersion:
          description: 'APIVersion defines the versioned schema of this representation
            of an object. Servers should convert recognized schemas to the latest
            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
          type: string
        envs:
          additionalProperties:
            properties:
              a:
                type: integer
              b:
                type: string
            required:
            - a
            - b
            type: object
          type: object
        kind:
          description: 'Kind is a string value representing the REST resource this
            object represents. Servers may infer this from the endpoint the client
            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
          type: string
        metadata:
          type: object
        spec:
          description: GuestbookSpec defines the desired state of Guestbook
          properties:
            foo:
              description: Foo is an example field of Guestbook. Edit Guestbook_types.go
                to remove/update
              type: string
          type: object
        status:
          description: GuestbookStatus defines the observed state of Guestbook
          type: object
      type: object
  version: v1
  versions:
  - name: v1
    served: true
    storage: true
status:
  acceptedNames:
    kind: ""
    plural: ""
  conditions: null
  storedVersions: null
/go/src/example/api/v1/guestbook_types.go:55:20: map values should be a named type, not *ast.StarExpr
controller-gen prints warning at the end like /go/src/example/api/v1/guestbook_types.go:55:20: map values should be a named type, not *ast.StarExpr.
