### PR TITLE
✨ Add support for AllowDangerousTypes crd flag (enables float support)

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -53,6 +53,16 @@ type Generator struct {
 	// It's required to be false for v1 CRDs.
 	PreserveUnknownFields *bool `marker:",optional"`
 
+	// AllowDangerousTypes allows types which are usually omitted from CRD generation
+	// because they are not recommended.
+	//
+	// Currently the following additional types are allowed when this is true:
+	// float32
+	// float64
+	//
+	// Left unspecified, the default is false
+	AllowDangerousTypes *bool `marker:",optional"`
+
 	// MaxDescLen specifies the maximum description length for fields in CRD's OpenAPI schema.
 	//
 	// 0 indicates drop the description for all fields completely.
@@ -78,6 +88,8 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	parser := &Parser{
 		Collector: ctx.Collector,
 		Checker:   ctx.Checker,
+		// Perform defaulting here to avoid ambiguity later
+		AllowDangerousTypes: g.AllowDangerousTypes != nil && *g.AllowDangerousTypes == true,
 	}
 
 	AddKnownTypes(parser)

--- a/pkg/crd/parser.go
+++ b/pkg/crd/parser.go
@@ -73,6 +73,20 @@ type Parser struct {
 	packages map[*loader.Package]struct{}
 
 	flattener *Flattener
+
+	// AllowDangerousTypes controls the handling of non-recommended types such as float. If
+	// false (the default), these types are not supported.
+	// There is a continuum here:
+	//    1. Types that are always supported.
+	//    2. Types that are allowed by default, but not recommended (warning emitted when they are encountered as per PR #443).
+	//       Possibly they are allowed by default for historical reasons and may even be "on their way out" at some point in the future.
+	//    3. Types that are not allowed by default, not recommended, but there are some legitimate reasons to need them in certain corner cases.
+	//       Possibly these types should also emit a warning as per PR #443 even when they are "switched on" (an integration point between
+	//       this feature and #443 if desired). This is the category that this flag deals with.
+	//    4. Types that are not allowed and will not be allowed, possibly because it just "doesn't make sense" or possibly
+	//       because the implementation is too difficult/clunky to promote them to category 3.
+	// TODO: Should we have a more formal mechanism for putting "type patterns" in each of the above categories?
+	AllowDangerousTypes bool
 }
 
 func (p *Parser) init() {
@@ -162,7 +176,7 @@ func (p *Parser) NeedSchemaFor(typ TypeIdent) {
 	// avoid tripping recursive schemata, like ManagedFields, by adding an empty WIP schema
 	p.Schemata[typ] = apiext.JSONSchemaProps{}
 
-	schemaCtx := newSchemaContext(typ.Package, p)
+	schemaCtx := newSchemaContext(typ.Package, p, p.AllowDangerousTypes)
 	ctxForInfo := schemaCtx.ForInfo(info)
 
 	pkgMarkers, err := markers.PackageMarkers(p.Collector, typ.Package)

--- a/pkg/crd/zz_generated.markerhelp.go
+++ b/pkg/crd/zz_generated.markerhelp.go
@@ -40,6 +40,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "indicates whether or not we should turn off pruning. ",
 				Details: "Left unspecified, it'll default to true when only a v1beta1 CRD is generated (to preserve compatibility with older versions of this tool), or false otherwise. \n It's required to be false for v1 CRDs.",
 			},
+			"AllowDangerousTypes": markers.DetailedHelp{
+				Summary: "allows types which are usually omitted from CRD generation because they are not recommended. ",
+				Details: "Currently the following additional types are allowed when this is true: float32 float64 \n Left unspecified, the default is false",
+			},
 			"MaxDescLen": markers.DetailedHelp{
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",


### PR DESCRIPTION
This can be used to enable `float32`/`float64` (go type) -> `number` (json schema) for CRDs. It is off by default because floats are not recommended in CRDs.

Discussion about this originated in #245 (which is now closed). @DirectXMan12 had suggested using a flag by this name to allow conditional supporting of floats. There's also at least one other issue asking about this (indirectly) at #93.