### PR TITLE
🐛 Correctly parse and set Scope

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -48,6 +48,9 @@ var CRDMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("kubebuilder:unservedversion", markers.DescribesType, UnservedVersion{})).
 		WithHelp(UnservedVersion{}.Help()),
+
+	must(markers.MakeDefinition("genclient:nonNamespaced", markers.DescribesType, ClusterScope{})).
+		WithHelp(ClusterScope{}.Help()),
 }
 
 // TODO: categories and singular used to be annotations types
@@ -176,6 +179,19 @@ func (s SkipVersion) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, versio
 		versions = append(versions, ver)
 	}
 	crd.Versions = versions
+	return nil
+}
+
+// +controllertools:marker:generateHelp:category=CRD
+
+// ClusterScope sets the CRD `Scope` to "Cluster" if genclient:nonNamespaced is present.
+//
+// This field is needed in case `genclient:nonNamespaced` is defined, meaning:
+// the CRD has Scope: Cluster.
+type ClusterScope struct{}
+
+func (s ClusterScope) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error {
+	crd.Scope = apiext.ClusterScoped
 	return nil
 }
 

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -24,6 +24,17 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 
+func (ClusterScope) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "sets the CRD `Scope` to \"Cluster\" if genclient:nonNamespaced is present. ",
+			Details: "This field is needed in case `genclient:nonNamespaced` is defined, meaning: the CRD has Scope: Cluster.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (Default) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",


### PR DESCRIPTION
Depending on the existance of `genclient:nonNamespaced` set the CRD's scope value to the correct one. 

`genclient:nonNamespaced` is currently a supported field by `informer-gen` and all the likes. However `controller-gen` does not take the annotation into account and consistently overrides the `.Scope` with `Namespaced` whereas the presence of such a field such indicate and set that field to `Cluster`.  
