### PR TITLE
:warning: pkg/crd: default CRD version to v1

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -31,6 +31,9 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/version"
 )
 
+// The default CustomResourceDefinition version to generate.
+const defaultVersion = "v1"
+
 // +controllertools:marker:generateHelp
 
 // Generator generates CustomResourceDefinition objects.
@@ -71,7 +74,7 @@ type Generator struct {
 	MaxDescLen *int `marker:",optional"`
 
 	// CRDVersions specifies the target API versions of the CRD type itself to
-	// generate.  Defaults to v1beta1.
+	// generate. Defaults to v1.
 	//
 	// The first version listed will be assumed to be the "default" version and
 	// will not get a version suffix in the output filename.
@@ -113,7 +116,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	crdVersions := g.CRDVersions
 
 	if len(crdVersions) == 0 {
-		crdVersions = []string{"v1beta1"}
+		crdVersions = []string{defaultVersion}
 	}
 
 	for groupKind := range kubeKinds {

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 // TODO(directxman12): test this across both versions (right now we're just
 // trusting k/k conversion, which is probably fine though)
 
-//go:generate ../../../.run-controller-gen.sh crd:crdVersions=v1 paths=. output:dir=.
+//go:generate ../../../.run-controller-gen.sh paths=. output:dir=.
 
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1

--- a/pkg/crd/zz_generated.markerhelp.go
+++ b/pkg/crd/zz_generated.markerhelp.go
@@ -49,7 +49,7 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},
 			"CRDVersions": markers.DetailedHelp{
-				Summary: "specifies the target API versions of the CRD type itself to generate.  Defaults to v1beta1. ",
+				Summary: "specifies the target API versions of the CRD type itself to generate. Defaults to v1. ",
 				Details: "The first version listed will be assumed to be the \"default\" version and will not get a version suffix in the output filename. \n You'll need to use \"v1\" to get support for features like defaulting, along with an API server that supports it (Kubernetes 1.16+).",
 			},
 		},


### PR DESCRIPTION
v1beta1 CRDs are deprecated in k8s v1.19 in favor of v1. To prepare for a release with deps upgraded to this k8s version, the default generated CRD version should be v1.

/cc @DirectXMan12 @vincepri @joelanford 