### PR TITLE
✨ feat: parse negative integers

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -106,7 +106,7 @@ func init() {
 type Maximum int
 
 // +controllertools:marker:generateHelp:category="CRD validation"
-// Minimum specifies the minimum numeric value that this field can have.
+// Minimum specifies the minimum numeric value that this field can have. Negative integers are supported.
 type Minimum int
 
 // +controllertools:marker:generateHelp:category="CRD validation"

--- a/pkg/markers/parse_test.go
+++ b/pkg/markers/parse_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Parsing", func() {
 		It("should support double-quoted strings", argParseTestCase{arg: Argument{Type: StringType}, raw: `"some; string, \nhere"`, output: "some; string, \nhere"}.Run)
 		It("should support raw strings", argParseTestCase{arg: Argument{Type: StringType}, raw: "`some; string, \\nhere`", output: `some; string, \nhere`}.Run)
 		It("should support integers", argParseTestCase{arg: Argument{Type: IntType}, raw: "42", output: 42}.Run)
-		XIt("should support negative integers", argParseTestCase{arg: Argument{Type: IntType}, raw: "-42", output: -42}.Run)
+		It("should support negative integers", argParseTestCase{arg: Argument{Type: IntType}, raw: "-42", output: -42}.Run)
 		It("should support false booleans", argParseTestCase{arg: Argument{Type: BoolType}, raw: "false", output: false}.Run)
 		It("should support true booleans", argParseTestCase{arg: Argument{Type: BoolType}, raw: "true", output: true}.Run)
 
@@ -194,7 +194,7 @@ var _ = Describe("Parsing", func() {
 			It("should support double-quoted strings", argParseTestCase{arg: anyArg, raw: `"some; string, \nhere"`, output: "some; string, \nhere"}.Run)
 			It("should support raw strings", argParseTestCase{arg: anyArg, raw: "`some; string, \\nhere`", output: `some; string, \nhere`}.Run)
 			It("should support integers", argParseTestCase{arg: anyArg, raw: "42", output: 42}.Run)
-			XIt("should support negative integers", argParseTestCase{arg: anyArg, raw: "-42", output: -42}.Run)
+			It("should support negative integers", argParseTestCase{arg: anyArg, raw: "-42", output: -42}.Run)
 			It("should support false booleans", argParseTestCase{arg: anyArg, raw: "false", output: false}.Run)
 			It("should support true booleans", argParseTestCase{arg: anyArg, raw: "true", output: true}.Run)
 


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

This adds support for negative integers in the marker syntax parser.  This is useful for markers like `+kubebuilder:validation:Minimum`