### PR TITLE
:sparkles: Revert ":sparkles: Remove status from generated CRDs"

### DIFF
--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -164,7 +164,11 @@ func (p *Parser) NeedCRDFor(groupKind schema.GroupKind, maxDescLen *int) {
 		packages[0].AddError(fmt.Errorf("CRD for %s with version(s) %v does not serve any version", groupKind, crd.Spec.Versions))
 	}
 
-	crd.Status = apiext.CustomResourceDefinitionStatus{}
+	// NB(directxman12): CRD's status doesn't have omitempty markers, which means things
+	// get serialized as null, which causes the validator to freak out.  Manually set
+	// these to empty till we get a better solution.
+	crd.Status.Conditions = []apiext.CustomResourceDefinitionCondition{}
+	crd.Status.StoredVersions = []string{}
 
 	p.CustomResourceDefinitions[groupKind] = crd
 }

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -5202,3 +5202,9 @@ spec:
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Reverts kubernetes-sigs/controller-tools#433


In kubernetes-sigs/controller-tools#433 I attempted to drop the entire status block from generated CRDs for tools like ArgoCD. I wrongly assumed that the `omitempty` marker on the CRD status field made it so the status field would not be generated at all. This is not true due to it not being a pointer, causing it always to be generated. We will need to manually set these still to pass validation 