### PR TITLE
✨ Set default value for corev1.Protocol type if not already specified

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -24,6 +24,14 @@ import (
 // KnownPackages overrides types in some comment packages that have custom validation
 // but don't have validation markers on them (since they're from core Kubernetes).
 var KnownPackages = map[string]PackageOverride{
+	"k8s.io/api/core/v1": func(p *Parser, pkg *loader.Package) {
+		// Explicit defaulting for the corev1.Protocol type in lieu of https://github.com/kubernetes/enhancements/pull/1928
+		p.Schemata[TypeIdent{Name: "Protocol", Package: pkg}] = apiext.JSONSchemaProps{
+			Type:    "string",
+			Default: &apiext.JSON{Raw: []byte(`"TCP"`)},
+		}
+		p.AddPackage(pkg)
+	},
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1": func(p *Parser, pkg *loader.Package) {
 		// ObjectMeta is managed by the Kubernetes API server, so no need to

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -1619,6 +1619,7 @@ spec:
                                               can be referred to by services.
                                             type: string
                                           protocol:
+                                            default: TCP
                                             description: Protocol for port. Must be
                                               UDP, TCP, or SCTP. Defaults to "TCP".
                                             type: string
@@ -2828,6 +2829,7 @@ spec:
                                               can be referred to by services.
                                             type: string
                                           protocol:
+                                            default: TCP
                                             description: Protocol for port. Must be
                                               UDP, TCP, or SCTP. Defaults to "TCP".
                                             type: string


### PR DESCRIPTION
Mitigation to help resolve #444 whilst waiting for https://github.com/kubernetes/enhancements/pull/1928 to merge.

This patch will cause resources that embed e.g. `ServiceSpec` or `PodSpec` to have the `default` field set for the `protocol` field:

```yaml
                          ports:
                            items:
                              properties:
                                appProtocol:
                                  type: string
                                name:
                                  type: string
                                nodePort:
                                  format: int32
                                  type: integer
                                port:
                                  format: int32
                                  type: integer
                                protocol:
                                  default: TCP
                                  type: string
                                targetPort:
                                  anyOf:
                                  - type: integer
                                  - type: string
                                  x-kubernetes-int-or-string: true
                              required:
                              - port
                              type: object
                            type: array
                            x-kubernetes-list-map-keys:
                            - port
                            - protocol
                            x-kubernetes-list-type: map
```

This will workaround the issue described in #444, and can be easily extended to new fields/types as they are discovered.

We should probably also consider fixing #445 as well, as this may cause some users that are not specifying `// +kubebuilder:default` annotations in their resources to begin specifying a `default` field (if they utilise this `Protocol` type), which will cause `kubectl` client side validation errors (which will require users to add `--validate=false` to their `kubectl create` usages)

/cc @pwittrock @tamalsaha  