### PR TITLE
:book: Add versioning guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This project uses Go modules to manage its dependencies, so feel free to work fr
 of your `GOPATH`. However, if you'd like to continue to work from within your `GOPATH`, please
 export `GO111MODULE=on`.
 
+## Releasing and Versioning
+
+See [VERSIONING.md](VERSIONING.md).
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,27 @@
+# Versioning and Releasing in controller-tools
+
+We follow the [common KubeBuilder versioning guidelines][guidelines], and
+use the corresponding tooling.
+
+For the purposes of the aforementioned guidelines, controller-tools counts
+as a "library project", but otherwise follows the guidelines closely.
+
+[guidelines]: https://sigs.k8s.io/kubebuilder-release-tools/VERSIONING.md
+
+## Compatibility and Release Support
+
+For release branches, we generally do not support older branches.  This
+may change in the future.
+
+Compability-wise, remember that changes to generation defaults are
+breaking changes.
+
+## Updates to Other Projects on Release
+
+When you release, you'll need to perform updates in other KubeBuilder
+projects:
+
+- Update the controller-tools version used to generate the KubeBuilder
+  book at [docs/book/install-and-build.sh][book-script]
+
+[book-script]: https://sigs.k8s.io/kubebuilder/docs/book/install-and-build.sh


### PR DESCRIPTION
This adds versioning/releasing guidelines that reference the common
guidelines in kubebuilder-release-tools, with a few
controller-tools-specific reminders.