### PR TITLE
:bug: keep name in ObjectMeta for volumeClaimTemplates

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -38,6 +38,13 @@ var KnownPackages = map[string]PackageOverride{
 		// generate validation for it.
 		p.Schemata[TypeIdent{Name: "ObjectMeta", Package: pkg}] = apiext.JSONSchemaProps{
 			Type: "object",
+			// The name property is an exception, it has a special role volumeClaimTemplates
+			// so it has to be kept, otherwise it won't be propagated.
+			Properties: map[string]apiext.JSONSchemaProps{
+				"name": {
+					Type: "string",
+				},
+			},
 		}
 		p.Schemata[TypeIdent{Name: "Time", Package: pkg}] = apiext.JSONSchemaProps{
 			Type:   "string",

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -33,6 +33,9 @@ spec:
             type: string
           metadata:
             type: object
+            properties:
+              name:
+                type: string
           spec:
             description: CronJobSpec defines the desired state of CronJob
             properties:
@@ -133,6 +136,9 @@ spec:
                     description: 'Standard object''s metadata of the jobs created
                       from this template. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
                     type: object
+                    properties:
+                      name:
+                        type: string
                   spec:
                     description: 'Specification of the desired behavior of the job.
                       More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
@@ -233,6 +239,9 @@ spec:
                             description: 'Standard object''s metadata. More info:
                               https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
                             type: object
+                            properties:
+                              name:
+                                type: string
                           spec:
                             description: 'Specification of the desired behavior of
                               the pod. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'

--- a/pkg/schemapatcher/testdata/expected/kubebuilder-example-crd.v1.yaml
+++ b/pkg/schemapatcher/testdata/expected/kubebuilder-example-crd.v1.yaml
@@ -31,6 +31,9 @@ spec:
             type: string
           metadata:
             type: object
+            properties:
+              name:
+                type: string
           spec:
             type: object
             required:

--- a/pkg/schemapatcher/testdata/expected/kubebuilder-example-crd.yaml
+++ b/pkg/schemapatcher/testdata/expected/kubebuilder-example-crd.yaml
@@ -30,6 +30,9 @@ spec:
           type: string
         metadata:
           type: object
+          properties:
+            name:
+              type: string
         spec:
           type: object
           required:

--- a/pkg/schemapatcher/testdata/expected/kubebuilder-unchanged-crd.v1beta1.yaml
+++ b/pkg/schemapatcher/testdata/expected/kubebuilder-unchanged-crd.v1beta1.yaml
@@ -30,6 +30,9 @@ spec:
           type: string
         metadata:
           type: object
+          properties:
+            name:
+              type: string
         spec:
           type: object
           required:

--- a/pkg/schemapatcher/testdata/expected/kubebuilder-unchanged-crd.yaml
+++ b/pkg/schemapatcher/testdata/expected/kubebuilder-unchanged-crd.yaml
@@ -31,6 +31,9 @@ spec:
             type: string
           metadata:
             type: object
+            properties:
+              name:
+                type: string
           spec:
             type: object
             required:

--- a/pkg/schemapatcher/testdata/expected/legacy-example-crd.yaml
+++ b/pkg/schemapatcher/testdata/expected/legacy-example-crd.yaml
@@ -34,6 +34,9 @@ spec:
           type: string
         metadata:
           type: object
+          properties:
+            name:
+              type: string
         spec:
           type: object
           required:

--- a/pkg/schemapatcher/testdata/expected/legacy-unchanged-crd.yaml
+++ b/pkg/schemapatcher/testdata/expected/legacy-unchanged-crd.yaml
@@ -35,6 +35,9 @@ spec:
           type: string
         metadata:
           type: object
+          properties:
+            name:
+              type: string
         spec:
           type: object
           required:


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

I have a CRD which will become a StatefuleSet (amongst many other things) at the end with the help of an operator, and it is possible to define `volumeClaimTemplates` as well for that StatefuleSet. The issue is when I'm using the CRD generator for this type, the `PersistentVolumeClaim.metadata.name` field gets removed from the generated CRD YAML, which makes the parsed type miss this name values as well, which has a defined meaning in this case and should be present, otherwise, the statefulset won't produce any pods. With this PR I'm trying to heal this situation (and hopefully won't break other things), I know it adds the metadata.name for other types as well, but that seems to do no harm.

Tested locally and the vault-operator seems to be working this way.

https://github.com/banzaicloud/bank-vaults/blob/master/operator/pkg/apis/vault/v1alpha1/vault_types.go#L314