### PR TITLE
🐛 Don't generate description on metadata of CRD structural schema

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -161,10 +161,14 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 
 		for i, crd := range versionedCRDs {
-			// defaults are not allowed to be specified in v1beta1 CRDs, so strip them
-			// before writing to a file
+			// defaults are not allowed to be specified in v1beta1 CRDs and
+			// decriptions are not allowed on the metadata regardless of version
+			// strip them before writing to a file
 			if crdVersions[i] == "v1beta1" {
 				removeDefaultsFromSchemas(crd.(*apiextlegacy.CustomResourceDefinition))
+				removeDescriptionFromMetadataLegacy(crd.(*apiextlegacy.CustomResourceDefinition))
+			} else {
+				removeDescriptionFromMetadata(crd.(*apiext.CustomResourceDefinition))
 			}
 			var fileName string
 			if i == 0 {
@@ -179,6 +183,49 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	}
 
 	return nil
+}
+
+func removeDescriptionFromMetadata(crd *apiext.CustomResourceDefinition) {
+	for _, versionSpec := range crd.Spec.Versions {
+		if versionSpec.Schema != nil {
+			removeDescriptionFromMetadataProps(versionSpec.Schema.OpenAPIV3Schema)
+		}
+	}
+}
+
+func removeDescriptionFromMetadataProps(v *apiext.JSONSchemaProps) {
+	if m, ok := v.Properties["metadata"]; ok {
+		meta := &m
+		if meta.Description != "" {
+			fmt.Fprintf(os.Stderr, "Warning: metadata description unsupported. Removing description: %s\n", meta.Description)
+			meta.Description = ""
+			v.Properties["metadata"] = m
+
+		}
+	}
+}
+
+func removeDescriptionFromMetadataLegacy(crd *apiextlegacy.CustomResourceDefinition) {
+	if crd.Spec.Validation != nil {
+		removeDescriptionFromMetadataPropsLegacy(crd.Spec.Validation.OpenAPIV3Schema)
+	}
+	for _, versionSpec := range crd.Spec.Versions {
+		if versionSpec.Schema != nil {
+			removeDescriptionFromMetadataPropsLegacy(versionSpec.Schema.OpenAPIV3Schema)
+		}
+	}
+}
+
+func removeDescriptionFromMetadataPropsLegacy(v *apiextlegacy.JSONSchemaProps) {
+	if m, ok := v.Properties["metadata"]; ok {
+		meta := &m
+		if meta.Description != "" {
+			fmt.Fprintf(os.Stderr, "Warning: metadata description unsupported. Removing description: %s\n", meta.Description)
+			meta.Description = ""
+			v.Properties["metadata"] = m
+
+		}
+	}
 }
 
 // removeDefaultsFromSchemas will remove all instances of default values being

--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -197,7 +197,6 @@ func removeDescriptionFromMetadataProps(v *apiext.JSONSchemaProps) {
 	if m, ok := v.Properties["metadata"]; ok {
 		meta := &m
 		if meta.Description != "" {
-			fmt.Fprintf(os.Stderr, "Warning: metadata description unsupported. Removing description: %s\n", meta.Description)
 			meta.Description = ""
 			v.Properties["metadata"] = m
 
@@ -220,7 +219,6 @@ func removeDescriptionFromMetadataPropsLegacy(v *apiextlegacy.JSONSchemaProps) {
 	if m, ok := v.Properties["metadata"]; ok {
 		meta := &m
 		if meta.Description != "" {
-			fmt.Fprintf(os.Stderr, "Warning: metadata description unsupported. Removing description: %s\n", meta.Description)
 			meta.Description = ""
 			v.Properties["metadata"] = m
 

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -67,7 +67,7 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		}
 	})
 
-	It("should strip v1beta1 CRDs of default fields", func() {
+	It("should strip v1beta1 CRDs of default fields and metadata description", func() {
 		By("calling Generate")
 		gen := &crd.Generator{
 			CRDVersions: []string{"v1beta1"},
@@ -84,7 +84,7 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 
 	})
 
-	It("should not strip v1 CRDs of default fields", func() {
+	It("should not strip v1 CRDs of default fields and metadata description", func() {
 		By("calling Generate")
 		gen := &crd.Generator{
 			CRDVersions: []string{"v1"},

--- a/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
@@ -27,6 +27,7 @@ spec:
         metadata:
           type: object
         spec:
+          description: Spec comments SHOULD appear in the CRD spec
           properties:
             defaultedString:
               description: This tests that defaulted fields are stripped for v1beta1, but not for v1
@@ -35,6 +36,7 @@ spec:
           - defaultedString
           type: object
         status:
+          description: Status comments SHOULD appear in the CRD spec
           type: object
       type: object
   version: foo

--- a/pkg/crd/testdata/gen/bar.example.com_foos.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.yaml
@@ -29,6 +29,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: Spec comments SHOULD appear in the CRD spec
             properties:
               defaultedString:
                 default: fooDefaultString
@@ -38,6 +39,7 @@ spec:
             - defaultedString
             type: object
           status:
+            description: Status comments SHOULD appear in the CRD spec
             type: object
         type: object
     served: true

--- a/pkg/crd/testdata/gen/foo_types.go
+++ b/pkg/crd/testdata/gen/foo_types.go
@@ -33,9 +33,13 @@ type FooSpec struct {
 type FooStatus struct{}
 
 type Foo struct {
-	metav1.TypeMeta   `json:",inline"`
+	// TypeMeta comments should NOT appear in the CRD spec
+	metav1.TypeMeta `json:",inline"`
+	// ObjectMeta comments should NOT appear in the CRD spec
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   FooSpec   `json:"spec,omitempty"`
+	// Spec comments SHOULD appear in the CRD spec
+	Spec FooSpec `json:"spec,omitempty"`
+	// Status comments SHOULD appear in the CRD spec
 	Status FooStatus `json:"status,omitempty"`
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
### What

Ensures that generated CRDs do not have a description generated from godoc comments on the ObjectMeta of the corresponding go type.

### Why

Fixes #386 

CRD structural schema requires that if metadata is specified, then only restrictions on metadata.name and metadata.generateName are allowed.

metadata.description is not allowed

xref: kubernetes/kubernetes#86800
