### PR TITLE
:book: fix module path info in the  comment in pkg/version/version.go 

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -36,7 +36,7 @@ func Version() string {
 //
 // - "Version: v0.2.1" when the program has been compiled with:
 //
-//   $ go get github.com/controller-tools/cmd/controller-gen@v0.2.1
+//   $ go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.1
 //
 //   Note: go modules requires the usage of semver compatible tags starting with
 //        'v' to have nice human-readable versions.


### PR DESCRIPTION
**Description**
The path to get this module is wrong in pkg/version/version.go. Fix the path. 

**Motivation**
Guess who has two thumbs and copied the command without reading it? 👍 👨‍💻 👍 