### PR TITLE
:sparkles: Add crd:validation:Schemaless marker

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,5 @@
 run:
+  modules-download-mode: readonly
   # Increase the default deadline from 1m as some module operations can take a
   # while if uncached!
   deadline: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 run:
-  modules-download-mode: readonly
-
   # Increase the default deadline from 1m as some module operations can take a
   # while if uncached!
   deadline: 5m

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -26,6 +26,10 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 
+const (
+	SchemalessName = "kubebuilder:validation:Schemaless"
+)
+
 // ValidationMarkers lists all available markers that affect CRD schema generation,
 // except for the few that don't make sense as type-level markers (see FieldOnlyMarkers).
 // All markers start with `+kubebuilder:validation:`, and continue with their type name.
@@ -82,6 +86,9 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("kubebuilder:validation:EmbeddedResource", markers.DescribesField, XEmbeddedResource{})).
 		WithHelp(XEmbeddedResource{}.Help()),
+
+	must(markers.MakeDefinition(SchemalessName, markers.DescribesField, Schemaless{})).
+		WithHelp(Schemaless{}.Help()),
 }
 
 // ValidationIshMarkers are field-and-type markers that don't fall under the
@@ -224,6 +231,16 @@ type XPreserveUnknownFields struct{}
 // running apiserver. It is not necessary to add any additional schema for these
 // field, yet it is possible. This can be combined with PreserveUnknownFields.
 type XEmbeddedResource struct{}
+
+// +controllertools:marker:generateHelp:category="CRD validation"
+// Schemaless marks a field as being a schemaless object.
+//
+// Schemaless objects are not introspected, so you must provide
+// any type and validation information yourself. One use for this
+// tag is for embedding fields that hold JSONSchema typed objects.
+// Because this field disables all type checking, it is recommended
+// to be used only as a last resort.
+type Schemaless struct{}
 
 func (m Maximum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	if schema.Type != "integer" {

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -306,6 +306,17 @@ func (Resource) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (Schemaless) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "marks a field as being a schemaless object. ",
+			Details: "Schemaless objects are not introspected, so you must provide any type and validation information yourself. One use for this tag is for embedding fields that hold JSONSchema typed objects. Because this field disables all type checking, it is recommended to be used only as a last resort.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (SkipVersion) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD",

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
@@ -378,7 +379,12 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 			}
 		}
 
-		propSchema := typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), field.RawField.Type)
+		var propSchema *apiext.JSONSchemaProps
+		if field.Markers.Get(crdmarkers.SchemalessName) != nil {
+			propSchema = &apiext.JSONSchemaProps{}
+		} else {
+			propSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), field.RawField.Type)
+		}
 		propSchema.Description = field.Doc
 
 		applyMarkers(ctx, field.Markers, propSchema, field.RawField)

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -154,14 +154,19 @@ type CronJobSpec struct {
 
 	// This tests that min/max properties work
 	MinMaxProperties MinMaxObject `json:"minMaxProperties,omitempty"`
+
+	// This tests that the schemaless marker works
+	// +kubebuilder:validation:Schemaless
+	Schemaless []byte `json:"schemaless,omitempty"`
 }
 
 // +kubebuilder:validation:Type=object
 // +kubebuilder:pruning:PreserveUnknownFields
 type Preserved struct {
-	ConcreteField string `json:"concreteField"`
-	Rest map[string]interface{} `json:"-"`
+	ConcreteField string                 `json:"concreteField"`
+	Rest          map[string]interface{} `json:"-"`
 }
+
 func (p *Preserved) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &p.Rest); err != nil {
 		return err

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -5071,6 +5071,8 @@ spec:
               schedule:
                 description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
                 type: string
+              schemaless:
+                description: This tests that the schemaless marker works
               startingDeadlineSeconds:
                 description: Optional deadline in seconds for starting the job if
                   it misses scheduled time for any reason.  Missed jobs executions

--- a/test.sh
+++ b/test.sh
@@ -107,12 +107,12 @@ fetch_kb_tools
 # setup testing env
 setup_envs
 
-header_text "running golangci-lint"
-
 header_text "generating marker help"
 pushd cmd/controller-gen > /dev/null
   go generate
 popd > /dev/null
+
+header_text "running golangci-lint"
 
 golangci-lint run --disable-all \
     --enable=misspell \


### PR DESCRIPTION
This marker will avoid trying to do any type detection on any struct field on which it is set. This gives users a safety valve when they hit an edge case where type inference does the wrong thing for them.

This fixes #291, which was recently re-broken by fixing #502

Signed-off-by: Max Smythe <smythe@google.com>
