### PR TITLE
🐛 Treat net.IP as a normal string

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -111,6 +111,14 @@ var KnownPackages = map[string]PackageOverride{
 		}
 		p.AddPackage(pkg) // get the rest of the types
 	},
+
+	"net": func(p *Parser, pkg *loader.Package) {
+		// Unlike normal []byte, net.IP has it's own Marshal/Unmarshal rules, it should be treated as a normal string
+		p.Schemata[TypeIdent{Name: "IP", Package: pkg}] = apiext.JSONSchemaProps{
+			Type: "string",
+		}
+		p.AddPackage(pkg)
+	},
 }
 
 func boolPtr(b bool) *bool {


### PR DESCRIPTION
In the current code, controller-tools treats `net.IP` as a normal `[]byte` type:

```go
type IP []byte
```

This generates the following schema:

```yaml
theIP:
  format: byte
  type: string
```

But unlike normal `[]byte`, `net.IP` has it's own `Marshal/Unmarshal` rules, we need to use string value in yaml not the base64-encoded string:

```yaml
# Correct, will be unmarshaled to `net.IP`
theIP: 192.168.1.1

# Wrong, can't be unmarshaled to `net.IP`: invalid IP address
theIP: MTkyLjE2OC4xLjE=
```

If the above schema is used, we will get an error in CR creation (`theIP in body must be of type byte`), so this PR adds `net.IP` to known_types to treat it as a normal string.

PS: if we can specify the format to `string` would also solve the problem, I try to use the `// +kubebuilder:validation:Format=string` marker but it's not working, it generates the following schema:

```yaml
theIP:
  allOf:
  - format: byte
  - format: string
  type: string
```

I'm not so sure what the reason is for generating `allOf` here, so I chose a simpler and more thorough solution to solve this problem.