### PR TITLE
⚠ Generate Embedded ObjectMeta in the CRDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,4 @@ require (
 	k8s.io/apimachinery v0.20.2
 	sigs.k8s.io/yaml v1.2.0
 )
+

--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -84,6 +84,9 @@ type Generator struct {
 	// You'll need to use "v1" to get support for features like defaulting,
 	// along with an API server that supports it (Kubernetes 1.16+).
 	CRDVersions []string `marker:"crdVersions,optional"`
+
+	// GenerateEmbeddedObjectMeta specifies if any embedded ObjectMeta in the CRD should be generated
+	GenerateEmbeddedObjectMeta *bool `marker:",optional"`
 }
 
 func (Generator) CheckFilter() loader.NodeFilter {
@@ -98,6 +101,8 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		Checker:   ctx.Checker,
 		// Perform defaulting here to avoid ambiguity later
 		AllowDangerousTypes: g.AllowDangerousTypes != nil && *g.AllowDangerousTypes == true,
+		// Indicates the parser on whether to register the ObjectMeta type or not
+		GenerateEmbeddedObjectMeta: g.GenerateEmbeddedObjectMeta != nil && *g.GenerateEmbeddedObjectMeta == true,
 	}
 
 	AddKnownTypes(parser)
@@ -128,6 +133,9 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		parser.NeedCRDFor(groupKind, g.MaxDescLen)
 		crdRaw := parser.CustomResourceDefinitions[groupKind]
 		addAttribution(&crdRaw)
+
+		// Prevent the top level metadata for the CRD to be generate regardless of the intention in the arguments
+		FixTopLevelMetadata(crdRaw)
 
 		versionedCRDs := make([]interface{}, len(crdVersions))
 		for i, ver := range crdVersions {
@@ -267,6 +275,20 @@ func removeDefaultsFromSchemaProps(v *apiextlegacy.JSONSchemaProps) {
 			v.Items.JSONSchemas[i] = props
 		}
 	}
+}
+
+// FixTopLevelMetadata resets the schema for the top-level metadata field which is needed for CRD validation
+func FixTopLevelMetadata(crd apiext.CustomResourceDefinition) {
+	for _, v := range crd.Spec.Versions {
+		if v.Schema != nil && v.Schema.OpenAPIV3Schema != nil && v.Schema.OpenAPIV3Schema.Properties != nil {
+			schemaProperties := v.Schema.OpenAPIV3Schema.Properties
+			if _, ok := schemaProperties["metadata"]; ok {
+				schemaProperties["metadata"] = apiext.JSONSchemaProps{Type: "object"}
+			}
+		}
+
+	}
+
 }
 
 // toTrivialVersions strips out all schemata except for the storage schema,

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -34,8 +34,6 @@ var KnownPackages = map[string]PackageOverride{
 	},
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1": func(p *Parser, pkg *loader.Package) {
-		// ObjectMeta is managed by the Kubernetes API server, so no need to
-		// generate validation for it.
 		p.Schemata[TypeIdent{Name: "ObjectMeta", Package: pkg}] = apiext.JSONSchemaProps{
 			Type: "object",
 		}
@@ -113,6 +111,52 @@ var KnownPackages = map[string]PackageOverride{
 	},
 }
 
+// ObjectMetaPackages overrides the ObjectMeta in all types
+var ObjectMetaPackages = map[string]PackageOverride{
+	"k8s.io/apimachinery/pkg/apis/meta/v1": func(p *Parser, pkg *loader.Package) {
+		// execute the KnowPackages for `k8s.io/apimachinery/pkg/apis/meta/v1` if any
+		if f, ok := KnownPackages["k8s.io/apimachinery/pkg/apis/meta/v1"]; ok {
+			f(p, pkg)
+		}
+		// This is a allow-listed set of properties of ObjectMeta, other runtime properties are not part of this list
+		p.Schemata[TypeIdent{Name: "ObjectMeta", Package: pkg}] = apiext.JSONSchemaProps{
+			Type: "object",
+			Properties: map[string]apiext.JSONSchemaProps{
+				"name": apiext.JSONSchemaProps{
+					Type: "string",
+				},
+				"namespace": apiext.JSONSchemaProps{
+					Type: "string",
+				},
+				"annotations": apiext.JSONSchemaProps{
+					Type: "object",
+					AdditionalProperties: &apiext.JSONSchemaPropsOrBool{
+						Schema: &apiext.JSONSchemaProps{
+							Type: "string",
+						},
+					},
+				},
+				"labels": apiext.JSONSchemaProps{
+					Type: "object",
+					AdditionalProperties: &apiext.JSONSchemaPropsOrBool{
+						Schema: &apiext.JSONSchemaProps{
+							Type: "string",
+						},
+					},
+				},
+				"finalizers": apiext.JSONSchemaProps{
+					Type: "array",
+					Items: &apiext.JSONSchemaPropsOrArray{
+						Schema: &apiext.JSONSchemaProps{
+							Type: "string",
+						},
+					},
+				},
+			},
+		}
+	},
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }
@@ -124,5 +168,11 @@ func AddKnownTypes(parser *Parser) {
 	parser.init()
 	for pkgName, override := range KnownPackages {
 		parser.PackageOverrides[pkgName] = override
+	}
+	// if we want to generate the embedded ObjectMeta in the CRD we need to add the ObjectMetaPackages
+	if parser.GenerateEmbeddedObjectMeta {
+		for pkgName, override := range ObjectMetaPackages {
+			parser.PackageOverrides[pkgName] = override
+		}
 	}
 }

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -119,6 +119,7 @@ var ObjectMetaPackages = map[string]PackageOverride{
 			f(p, pkg)
 		}
 		// This is a allow-listed set of properties of ObjectMeta, other runtime properties are not part of this list
+		// please refer to https://github.com/kubernetes-sigs/controller-tools/pull/395#issuecomment-691919433s
 		p.Schemata[TypeIdent{Name: "ObjectMeta", Package: pkg}] = apiext.JSONSchemaProps{
 			Type: "object",
 			Properties: map[string]apiext.JSONSchemaProps{

--- a/pkg/crd/parser.go
+++ b/pkg/crd/parser.go
@@ -86,6 +86,9 @@ type Parser struct {
 	//       because the implementation is too difficult/clunky to promote them to category 3.
 	// TODO: Should we have a more formal mechanism for putting "type patterns" in each of the above categories?
 	AllowDangerousTypes bool
+
+	// GenerateEmbeddedObjectMeta specifies if any embedded ObjectMeta should be generated
+	GenerateEmbeddedObjectMeta bool
 }
 
 func (p *Parser) init() {

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -84,6 +84,9 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 		groupKind := schema.GroupKind{Kind: "CronJob", Group: "testdata.kubebuilder.io"}
 		parser.NeedCRDFor(groupKind, nil)
 
+		By("fixing top level ObjectMeta on the CRD")
+		crd.FixTopLevelMetadata(parser.CustomResourceDefinitions[groupKind])
+
 		By("checking that no errors occurred along the way (expect for type errors)")
 		Expect(packageErrors(cronJobPkg, packages.TypeError)).NotTo(HaveOccurred())
 
@@ -132,6 +135,9 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 		By("requesting that the CRD be generated")
 		groupKind := schema.GroupKind{Kind: "TestQuota", Group: "plural.example.com"}
 		parser.NeedCRDFor(groupKind, nil)
+
+		By("fixing top level ObjectMeta on the CRD")
+		crd.FixTopLevelMetadata(parser.CustomResourceDefinitions[groupKind])
 
 		By("loading the desired YAML")
 		expectedFile, err := ioutil.ReadFile("plural.example.com_testquotas.yaml")

--- a/pkg/crd/zz_generated.markerhelp.go
+++ b/pkg/crd/zz_generated.markerhelp.go
@@ -52,6 +52,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "specifies the target API versions of the CRD type itself to generate. Defaults to v1. ",
 				Details: "The first version listed will be assumed to be the \"default\" version and will not get a version suffix in the output filename. \n You'll need to use \"v1\" to get support for features like defaulting, along with an API server that supports it (Kubernetes 1.16+).",
 			},
+			"GenerateEmbeddedObjectMeta": markers.DetailedHelp{
+				Summary: "specifies if any embedded ObjectMeta in the CRD should be generated",
+				Details: "",
+			},
 		},
 	}
 }


### PR DESCRIPTION
This PR makes it so embedded `ObjectMeta` in the CRD get's properly generated if the generator option `generateEmbeddedObjectMeta=true` is passed, this is needed because if a CRD has embedded `ObjectMeta` in any field and `preserveUnknowFields` is set to false, all the metadata will be lost when doing conversion between versions.

An example on how to have the embedded ObjectMeta generated in the resulting CRD

```
controller-gen crd:maxDescLen=0,generateEmbeddedObjectMeta=true paths=. output:dir=.
```

This PR makes it so by default any embedded `ObjectMeta` is not generated in the resulting CRD, however the top level `ObjectMeta` belonging to the CRD itself is never generated as the kubernetes API disallows changes to the CRD metadata between conversions.

The generated `ObjectMeta` is also only a subset of the original set of fields inside `ObjectMeta` this is due to the fact that other runtime fields are problematic if they are being traded with the kubernetes API, such as `creationTimeStamp` (https://github.com/rancher/rancher/issues/23857) so this only generates `name, namespace, labels, annotations and finalizers` which from a design perspective should be enough. This follows the recommendation by @sttts who recommended a `EmbeddedObjectMeta` but instead of using a different type, we have a reduced set of fields that are "just enough" for a CRD design.

An example of why we need this is for example if a CRD had a `volumeClaimTemplate` (for an underlying statefulset) which include `ObjectMeta` such as Labels, Annotations and/org name which are meant to be passed to the PVC where getting lost between conversions.


This PR is based on the work by @arjunrn and @champak following the discussion on #448 and the PR #498 and it's also similar to #395 as it addressed the same problem, but adds the type casting for `FieldsV1` and the requested argument to control this feature (per @DirectXMan12 on #395)

