### PR TITLE
✨ Add deprecated marker for versions

### DIFF
--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -40,6 +40,22 @@ func (Default) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (DeprecatedVersion) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "marks this version as deprecated.",
+			Details: "",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{
+			"Warning": markers.DetailedHelp{
+				Summary: "message to be shown on the deprecated version",
+				Details: "",
+			},
+		},
+	}
+}
+
 func (Enum) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -63,9 +63,9 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
 
 		By("loading the roots")
-		pkgs, err := loader.LoadRoots(".")
+		pkgs, err := loader.LoadRoots("./", "./unserved", "./deprecated")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(pkgs).To(HaveLen(1))
+		Expect(pkgs).To(HaveLen(3))
 		cronJobPkg := pkgs[0]
 
 		By("setting up the parser")
@@ -77,8 +77,10 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 		}
 		crd.AddKnownTypes(parser)
 
-		By("requesting that the package be parsed")
-		parser.NeedPackage(cronJobPkg)
+		By("requesting that the packages be parsed")
+		for _, pkg := range pkgs {
+			parser.NeedPackage(pkg)
+		}
 
 		By("requesting that the CRD be generated")
 		groupKind := schema.GroupKind{Kind: "CronJob", Group: "testdata.kubebuilder.io"}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 // TODO(directxman12): test this across both versions (right now we're just
 // trusting k/k conversion, which is probably fine though)
 
-//go:generate ../../../.run-controller-gen.sh crd paths=. output:dir=.
+//go:generate ../../../.run-controller-gen.sh crd paths=./;./deprecated;./unserved output:dir=.
 
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1
@@ -288,6 +288,7 @@ type CronJobStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:singular=mycronjob
+// +kubebuilder:storageversion
 
 // CronJob is the Schema for the cronjobs API
 type CronJob struct {

--- a/pkg/crd/testdata/deprecated/types.go
+++ b/pkg/crd/testdata/deprecated/types.go
@@ -1,0 +1,44 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1beta2
+package deprecated
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=mycronjob
+// +kubebuilder:deprecatedversion:warning="use v1 instead, this version causes your data center to catch fire when used on Tuesdays"
+
+// CronJob is the Schema for the cronjobs API
+type CronJob struct {
+	/*
+	 */
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// CronJobList contains a list of CronJob
+type CronJobList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CronJob `json:"items"`
+}

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -4097,6 +4097,44 @@ spec:
     storage: true
     subresources:
       status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CronJob is the Schema for the cronjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: use v1 instead, this version causes your data center to catch fire when used on Tuesdays
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: CronJob is the Schema for the cronjobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/crd/testdata/unserved/types.go
+++ b/pkg/crd/testdata/unserved/types.go
@@ -1,0 +1,44 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1beta1
+package unserved
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=mycronjob
+// +kubebuilder:unservedversion
+
+// CronJob is the Schema for the cronjobs API
+type CronJob struct {
+	/*
+	 */
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// CronJobList contains a list of CronJob
+type CronJobList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CronJob `json:"items"`
+}


### PR DESCRIPTION
This PR introduces the marker `deprecated` which would mark a CRD version as deprecated in the generated output, it supports a deprecation warning message

Example  usage: 
```
// +kubebuilder:deprecated:warning="This version is deprecated in favor of other.crd.com/v2"
```

the result is that the version that has this marker would include the following fields
```
deprecated: true
deprecatedWarning: "This version is deprecated in favor of other.crd.com/v2"
```