### PR TITLE
✨ Add header and year options for yaml generator

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -21,6 +21,7 @@ import (
 	"go/ast"
 	"go/types"
 	"sort"
+	"strings"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -78,6 +79,12 @@ type Generator struct {
 
 	// GenerateEmbeddedObjectMeta specifies if any embedded ObjectMeta in the CRD should be generated
 	GenerateEmbeddedObjectMeta *bool `marker:",optional"`
+
+	// HeaderFile specifies the header text (e.g. license) to prepend to generated files.
+	HeaderFile string `marker:",optional"`
+
+	// Year specifies the year to substitute for " YEAR" in the header file.
+	Year string `marker:",optional"`
 }
 
 func (Generator) CheckFilter() loader.NodeFilter {
@@ -128,6 +135,17 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		crdVersions = []string{defaultVersion}
 	}
 
+	var headerText string
+
+	if g.HeaderFile != "" {
+		headerBytes, err := ctx.ReadFile(g.HeaderFile)
+		if err != nil {
+			return err
+		}
+		headerText = string(headerBytes)
+	}
+	headerText = strings.ReplaceAll(headerText, " YEAR", " "+g.Year)
+
 	for _, groupKind := range kubeKinds {
 		parser.NeedCRDFor(groupKind, g.MaxDescLen)
 		crdRaw := parser.CustomResourceDefinitions[groupKind]
@@ -153,7 +171,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			} else {
 				fileName = fmt.Sprintf("%s_%s.%s.yaml", crdRaw.Spec.Group, crdRaw.Spec.Names.Plural, crdVersions[i])
 			}
-			if err := ctx.WriteYAML(fileName, []interface{}{crd}, genall.WithTransform(transformRemoveCRDStatus)); err != nil {
+			if err := ctx.WriteYAML(fileName, headerText, []interface{}{crd}, genall.WithTransform(transformRemoveCRDStatus)); err != nil {
 				return err
 			}
 		}

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -136,12 +136,17 @@ func WithTransform(transform func(obj map[string]interface{}) error) *WriteYAMLO
 // WriteYAML writes the given objects out, serialized as YAML, using the
 // context's OutputRule.  Objects are written as separate documents, separated
 // from each other by `---` (as per the YAML spec).
-func (g GenerationContext) WriteYAML(itemPath string, objs []interface{}, options ...*WriteYAMLOptions) error {
+func (g GenerationContext) WriteYAML(itemPath, headerText string, objs []interface{}, options ...*WriteYAMLOptions) error {
 	out, err := g.Open(nil, itemPath)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
+
+	_, err = out.Write([]byte(headerText))
+	if err != nil {
+		return err
+	}
 
 	for _, obj := range objs {
 		yamlContent, err := yamlMarshal(obj, options...)

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -149,6 +149,12 @@ func (r *Rule) ToRule() rbacv1.PolicyRule {
 type Generator struct {
 	// RoleName sets the name of the generated ClusterRole.
 	RoleName string
+
+	// HeaderFile specifies the header text (e.g. license) to prepend to generated files.
+	HeaderFile string `marker:",optional"`
+
+	// Year specifies the year to substitute for " YEAR" in the header file.
+	Year string `marker:",optional"`
 }
 
 func (Generator) RegisterMarkers(into *markers.Registry) error {
@@ -263,5 +269,15 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		return nil
 	}
 
-	return ctx.WriteYAML("role.yaml", objs)
+	var headerText string
+	if g.HeaderFile != "" {
+		headerBytes, err := ctx.ReadFile(g.HeaderFile)
+		if err != nil {
+			return err
+		}
+		headerText = string(headerBytes)
+	}
+	headerText = strings.ReplaceAll(headerText, " YEAR", " "+g.Year)
+
+	return ctx.WriteYAML("role.yaml", headerText, objs)
 }


### PR DESCRIPTION
This patch adds headerFile and year options to CRD, RBAC and Webhook generator

Currently headerFile and year options are available on only generate option.
This patch adds the option for YAMLs.

e.g. generate the crd with headerfile
```
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   crd:crdVersions=v1,year=2021,headerFile="${PATH_TO_YOUR_BOILDER_PLATE}" \
   output:crd:artifacts:config=config/crd/bases \
   paths=./...
```

Fix https://github.com/kubernetes-sigs/controller-tools/issues/464
