### PR TITLE
🐛 markers: Allow floats inside markers

### DIFF
--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -755,7 +755,7 @@ func (d *Definition) loadFields() error {
 func parserScanner(raw string, err func(*sc.Scanner, string)) *sc.Scanner {
 	scanner := &sc.Scanner{}
 	scanner.Init(bytes.NewBufferString(raw))
-	scanner.Mode = sc.ScanIdents | sc.ScanInts | sc.ScanStrings | sc.ScanRawStrings | sc.SkipComments
+	scanner.Mode = sc.ScanFloats | sc.ScanIdents | sc.ScanInts | sc.ScanStrings | sc.ScanRawStrings | sc.SkipComments
 	scanner.Error = err
 
 	return scanner


### PR DESCRIPTION
This fixes the following error when controller-gen is invoked as

```
$ controller-gen crd paths=./crds output:crd:artifacts:config=/tmp/0x123
```

```
Error: unable to parse option
"output:crd:artifacts:config=/tmp/tmp.0x123": [hexadecimal literal has no digits (at <input>:1:17)]
```

Signed-off-by: Chris Tarazi <tarazichris@gmail.com>
