### PR TITLE
:seedling: Fix some gofmt warnings

### DIFF
--- a/cmd/helpgen/main.go
+++ b/cmd/helpgen/main.go
@@ -105,7 +105,7 @@ func (Generator) RegisterMarkers(reg *markers.Registry) error {
 			Details: "Type-level godoc becomes general marker summary (first line) and details (other lines).  Field-level godoc similarly becomes marker field help.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Category": markers.DetailedHelp{
+			"Category": {
 				Summary: "indicates the general category to which this marker belongs",
 			},
 		},
@@ -197,8 +197,8 @@ func (Generator) Help() *markers.DefinitionHelp {
 			Summary: "generates marker help using godoc, based on the presence of a particular marker",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"HeaderFile": markers.DetailedHelp{Summary: "the file containing the header to use for generated files"},
-			"Year":       markers.DetailedHelp{Summary: "replace \" YEAR\" in the header with this value."},
+			"HeaderFile": {Summary: "the file containing the header to use for generated files"},
+			"Year":       {Summary: "replace \" YEAR\" in the header with this value."},
 		},
 	}
 }

--- a/cmd/helpgen/main.go
+++ b/cmd/helpgen/main.go
@@ -134,7 +134,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 
 			for _, field := range info.Fields {
 				summary, details := godocToDetails(field.Name, field.Doc)
-				fmt.Fprintf(outContent, "%[1]q: markers.DetailedHelp{\nSummary: %[2]q,\n Details: %[3]q,\n},\n", field.Name, summary, details)
+				fmt.Fprintf(outContent, "%[1]q: {\nSummary: %[2]q,\n Details: %[3]q,\n},\n", field.Name, summary, details)
 			}
 
 			summary, details := godocToDetails(info.Name, info.Doc)

--- a/pkg/crd/crd_spec_test.go
+++ b/pkg/crd/crd_spec_test.go
@@ -38,7 +38,7 @@ var _ = Describe("CRD Generation", func() {
 									OpenAPIV3Schema: &apiextlegacy.JSONSchemaProps{
 										Required:   []string{"foo"},
 										Type:       "object",
-										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": apiextlegacy.JSONSchemaProps{Type: "string"}},
+										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": {Type: "string"}},
 									},
 								},
 							},
@@ -50,7 +50,7 @@ var _ = Describe("CRD Generation", func() {
 					OpenAPIV3Schema: &apiextlegacy.JSONSchemaProps{
 						Required:   []string{"foo"},
 						Type:       "object",
-						Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": apiextlegacy.JSONSchemaProps{Type: "string"}},
+						Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": {Type: "string"}},
 					},
 				}))
 				Expect(spec.Spec.Versions).To(Equal([]apiextlegacy.CustomResourceDefinitionVersion{
@@ -67,7 +67,7 @@ var _ = Describe("CRD Generation", func() {
 									OpenAPIV3Schema: &apiextlegacy.JSONSchemaProps{
 										Required:   []string{"foo"},
 										Type:       "object",
-										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": apiextlegacy.JSONSchemaProps{Type: "string"}},
+										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": {Type: "string"}},
 									},
 								},
 							},
@@ -78,7 +78,7 @@ var _ = Describe("CRD Generation", func() {
 									OpenAPIV3Schema: &apiextlegacy.JSONSchemaProps{
 										Required:   []string{"foo"},
 										Type:       "object",
-										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": apiextlegacy.JSONSchemaProps{Type: "string"}},
+										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": {Type: "string"}},
 									},
 								},
 							},
@@ -90,7 +90,7 @@ var _ = Describe("CRD Generation", func() {
 					OpenAPIV3Schema: &apiextlegacy.JSONSchemaProps{
 						Required:   []string{"foo"},
 						Type:       "object",
-						Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": apiextlegacy.JSONSchemaProps{Type: "string"}},
+						Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": {Type: "string"}},
 					},
 				}))
 				Expect(spec.Spec.Versions).To(Equal([]apiextlegacy.CustomResourceDefinitionVersion{
@@ -107,7 +107,7 @@ var _ = Describe("CRD Generation", func() {
 								Schema: &apiextlegacy.CustomResourceValidation{
 									OpenAPIV3Schema: &apiextlegacy.JSONSchemaProps{
 										Type:       "object",
-										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": apiextlegacy.JSONSchemaProps{Type: "string"}},
+										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": {Type: "string"}},
 									},
 								},
 							},
@@ -118,7 +118,7 @@ var _ = Describe("CRD Generation", func() {
 									OpenAPIV3Schema: &apiextlegacy.JSONSchemaProps{
 										Required:   []string{"foo"},
 										Type:       "object",
-										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": apiextlegacy.JSONSchemaProps{Type: "string"}},
+										Properties: map[string]apiextlegacy.JSONSchemaProps{"foo": {Type: "string"}},
 									},
 								},
 							},

--- a/pkg/crd/desc_visitor_test.go
+++ b/pkg/crd/desc_visitor_test.go
@@ -31,7 +31,7 @@ var _ = Describe("TruncateDescription", func() {
 		schema := &apiext.JSONSchemaProps{
 			Description: "top level description",
 			Properties: map[string]apiext.JSONSchemaProps{
-				"Spec": apiext.JSONSchemaProps{
+				"Spec": {
 					Description: "specification for the API type",
 				},
 			},
@@ -39,7 +39,7 @@ var _ = Describe("TruncateDescription", func() {
 		crd.TruncateDescription(schema, 0)
 		Expect(schema).To(Equal(&apiext.JSONSchemaProps{
 			Properties: map[string]apiext.JSONSchemaProps{
-				"Spec": apiext.JSONSchemaProps{},
+				"Spec": {},
 			},
 		}))
 
@@ -49,7 +49,7 @@ var _ = Describe("TruncateDescription", func() {
 		schema := &apiext.JSONSchemaProps{
 			Description: "top level description of the root object.",
 			Properties: map[string]apiext.JSONSchemaProps{
-				"Spec": apiext.JSONSchemaProps{
+				"Spec": {
 					Description: "specification of a field",
 				},
 			},

--- a/pkg/crd/flatten_all_of_test.go
+++ b/pkg/crd/flatten_all_of_test.go
@@ -49,7 +49,7 @@ var _ = Describe("AllOf Flattening", func() {
 			By("flattening a schema with at one branch set as Nullable")
 			original := &apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"multiNullable": apiext.JSONSchemaProps{
+					"multiNullable": {
 						AllOf: []apiext.JSONSchemaProps{
 							{Nullable: true}, {Nullable: false}, {Nullable: false},
 						},
@@ -62,7 +62,7 @@ var _ = Describe("AllOf Flattening", func() {
 			By("ensuring that the result has no branches and is nullable")
 			Expect(flattened).To(Equal(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"multiNullable": apiext.JSONSchemaProps{Nullable: true},
+					"multiNullable": {Nullable: true},
 				},
 			}))
 		})
@@ -71,7 +71,7 @@ var _ = Describe("AllOf Flattening", func() {
 			By("flattening a schema with at no branches set as Nullable")
 			original := &apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"multiNullable": apiext.JSONSchemaProps{
+					"multiNullable": {
 						AllOf: []apiext.JSONSchemaProps{
 							{Nullable: false}, {Nullable: false}, {Nullable: false},
 						},
@@ -84,7 +84,7 @@ var _ = Describe("AllOf Flattening", func() {
 			By("ensuring that the result has no branches and is not nullable")
 			Expect(flattened).To(Equal(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"multiNullable": apiext.JSONSchemaProps{Nullable: false},
+					"multiNullable": {Nullable: false},
 				},
 			}))
 		})
@@ -113,7 +113,7 @@ var _ = Describe("AllOf Flattening", func() {
 			defOne := int64(1)
 			original := &apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"multiAdditionalProps": apiext.JSONSchemaProps{
+					"multiAdditionalProps": {
 						AllOf: []apiext.JSONSchemaProps{
 							{
 								AdditionalProperties: &apiext.JSONSchemaPropsOrBool{Schema: &apiext.JSONSchemaProps{
@@ -145,7 +145,7 @@ var _ = Describe("AllOf Flattening", func() {
 			By("ensuring that the result has the minimal set of AllOf branches required, pushed inside AdditionalProperites")
 			Expect(flattened).To(Equal(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"multiAdditionalProps": apiext.JSONSchemaProps{
+					"multiAdditionalProps": {
 						AdditionalProperties: &apiext.JSONSchemaPropsOrBool{Schema: &apiext.JSONSchemaProps{
 							Nullable:  true,
 							MaxLength: &defSeven,
@@ -164,7 +164,7 @@ var _ = Describe("AllOf Flattening", func() {
 			By("flattening a schema with a single property with two different types")
 			crd.FlattenEmbedded(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"multiType": apiext.JSONSchemaProps{AllOf: []apiext.JSONSchemaProps{{Type: "string"}, {Type: "int"}}},
+					"multiType": {AllOf: []apiext.JSONSchemaProps{{Type: "string"}, {Type: "int"}}},
 				},
 			}, errRec)
 
@@ -202,21 +202,21 @@ var _ = Describe("AllOf Flattening", func() {
 				AllOf: []apiext.JSONSchemaProps{
 					{
 						Properties: map[string]apiext.JSONSchemaProps{
-							"nonConflicting":    apiext.JSONSchemaProps{Type: "string"},
-							"conflicting1":      apiext.JSONSchemaProps{Type: "string", Format: "date-time"},
-							"nonConflictingDup": apiext.JSONSchemaProps{Type: "bool"},
+							"nonConflicting":    {Type: "string"},
+							"conflicting1":      {Type: "string", Format: "date-time"},
+							"nonConflictingDup": {Type: "bool"},
 						},
 					},
 					{
 						Properties: map[string]apiext.JSONSchemaProps{
-							"conflicting1": apiext.JSONSchemaProps{Type: "string", MinLength: &defOne},
-							"conflicting2": apiext.JSONSchemaProps{Type: "int", MultipleOf: &defSeven},
+							"conflicting1": {Type: "string", MinLength: &defOne},
+							"conflicting2": {Type: "int", MultipleOf: &defSeven},
 						},
 					},
 					{
 						Properties: map[string]apiext.JSONSchemaProps{
-							"conflicting2":      apiext.JSONSchemaProps{Type: "int", MultipleOf: &defEight},
-							"nonConflictingDup": apiext.JSONSchemaProps{Type: "bool"},
+							"conflicting2":      {Type: "int", MultipleOf: &defEight},
+							"nonConflictingDup": {Type: "bool"},
 						},
 					},
 				},
@@ -227,14 +227,14 @@ var _ = Describe("AllOf Flattening", func() {
 			By("ensuring that the result has the minimal set of AllOf branches required, pushed inside Properties")
 			Expect(flattened).To(Equal(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"nonConflicting":    apiext.JSONSchemaProps{Type: "string"},
-					"nonConflictingDup": apiext.JSONSchemaProps{Type: "bool"},
-					"conflicting1": apiext.JSONSchemaProps{
+					"nonConflicting":    {Type: "string"},
+					"nonConflictingDup": {Type: "bool"},
+					"conflicting1": {
 						Type:      "string",
 						Format:    "date-time",
 						MinLength: &defOne,
 					},
-					"conflicting2": apiext.JSONSchemaProps{
+					"conflicting2": {
 						Type:  "int",
 						AllOf: []apiext.JSONSchemaProps{{MultipleOf: &defSeven}, {MultipleOf: &defEight}},
 					},
@@ -297,9 +297,9 @@ var _ = Describe("AllOf Flattening", func() {
 				AllOf: []apiext.JSONSchemaProps{
 					{
 						Properties: map[string]apiext.JSONSchemaProps{
-							"prop1": apiext.JSONSchemaProps{
+							"prop1": {
 								Properties: map[string]apiext.JSONSchemaProps{
-									"prop2": apiext.JSONSchemaProps{
+									"prop2": {
 										Type:    "string",
 										Pattern: "^[abc]+$",
 									},
@@ -309,9 +309,9 @@ var _ = Describe("AllOf Flattening", func() {
 					},
 					{
 						Properties: map[string]apiext.JSONSchemaProps{
-							"prop1": apiext.JSONSchemaProps{
+							"prop1": {
 								Properties: map[string]apiext.JSONSchemaProps{
-									"prop2": apiext.JSONSchemaProps{
+									"prop2": {
 										Pattern: "^(bc)+$",
 									},
 								},
@@ -326,9 +326,9 @@ var _ = Describe("AllOf Flattening", func() {
 			By("ensuring that the result has the minimal AllOf branches possible")
 			Expect(flattened).To(Equal(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"prop1": apiext.JSONSchemaProps{
+					"prop1": {
 						Properties: map[string]apiext.JSONSchemaProps{
-							"prop2": apiext.JSONSchemaProps{
+							"prop2": {
 								Type:  "string",
 								AllOf: []apiext.JSONSchemaProps{{Pattern: "^[abc]+$"}, {Pattern: "^(bc)+$"}},
 							},

--- a/pkg/crd/flatten_type_test.go
+++ b/pkg/crd/flatten_type_test.go
@@ -80,13 +80,13 @@ var _ = Describe("General Schema Flattening", func() {
 			toLeafAlias := crd.TypeRefLink("", leafAliasType.Name)
 			toLeaf := crd.TypeRefLink("other", leafType.Name)
 			fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
-				rootType: apiext.JSONSchemaProps{
+				rootType: {
 					Properties: map[string]apiext.JSONSchemaProps{
-						"refProp": apiext.JSONSchemaProps{Ref: &toLeafAlias},
+						"refProp": {Ref: &toLeafAlias},
 					},
 				},
-				leafAliasType: apiext.JSONSchemaProps{Ref: &toLeaf},
-				leafType: apiext.JSONSchemaProps{
+				leafAliasType: {Ref: &toLeaf},
+				leafType: {
 					Type:    "string",
 					Pattern: "^[abc]$",
 				},
@@ -102,7 +102,7 @@ var _ = Describe("General Schema Flattening", func() {
 			By("verifying that it was flattened to have no references")
 			Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"refProp": apiext.JSONSchemaProps{
+					"refProp": {
 						Type: "string", Pattern: "^[abc]$",
 					},
 				},
@@ -114,13 +114,13 @@ var _ = Describe("General Schema Flattening", func() {
 			toLeafAlias := crd.TypeRefLink("", leafAliasType.Name)
 			toLeaf := crd.TypeRefLink("", inPkgLeafType.Name)
 			fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
-				rootType: apiext.JSONSchemaProps{
+				rootType: {
 					Properties: map[string]apiext.JSONSchemaProps{
-						"refProp": apiext.JSONSchemaProps{Ref: &toLeafAlias},
+						"refProp": {Ref: &toLeafAlias},
 					},
 				},
-				leafAliasType: apiext.JSONSchemaProps{Ref: &toLeaf},
-				inPkgLeafType: apiext.JSONSchemaProps{Ref: &toLeafAlias},
+				leafAliasType: {Ref: &toLeaf},
+				inPkgLeafType: {Ref: &toLeafAlias},
 			}
 
 			By("flattening the type hierarchy")
@@ -136,7 +136,7 @@ var _ = Describe("General Schema Flattening", func() {
 			By("verifying that it was flattened to *something*")
 			Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
 				Properties: map[string]apiext.JSONSchemaProps{
-					"refProp": apiext.JSONSchemaProps{
+					"refProp": {
 						Ref: &toLeafAlias,
 					},
 				},
@@ -149,19 +149,19 @@ var _ = Describe("General Schema Flattening", func() {
 		toSubtype := crd.TypeRefLink("", subtypeWithRefs.Name)
 		toLeaf := crd.TypeRefLink("other", leafType.Name)
 		fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
-			rootType: apiext.JSONSchemaProps{
+			rootType: {
 				Properties: map[string]apiext.JSONSchemaProps{
-					"refProp": apiext.JSONSchemaProps{Ref: &toSubtype},
+					"refProp": {Ref: &toSubtype},
 				},
 			},
-			subtypeWithRefs: apiext.JSONSchemaProps{
+			subtypeWithRefs: {
 				AdditionalProperties: &apiext.JSONSchemaPropsOrBool{
 					Schema: &apiext.JSONSchemaProps{
 						Ref: &toLeaf,
 					},
 				},
 			},
-			leafType: apiext.JSONSchemaProps{
+			leafType: {
 				Type:    "string",
 				Pattern: "^[abc]$",
 			},
@@ -175,7 +175,7 @@ var _ = Describe("General Schema Flattening", func() {
 		By("verifying that it was flattened to have no references")
 		Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
 			Properties: map[string]apiext.JSONSchemaProps{
-				"refProp": apiext.JSONSchemaProps{
+				"refProp": {
 					AllOf: []apiext.JSONSchemaProps{
 						{
 							AdditionalProperties: &apiext.JSONSchemaPropsOrBool{
@@ -200,26 +200,26 @@ var _ = Describe("General Schema Flattening", func() {
 		defThree := int64(3)
 		toLeaf := crd.TypeRefLink("other", leafType.Name)
 		fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
-			rootType: apiext.JSONSchemaProps{
+			rootType: {
 				Properties: map[string]apiext.JSONSchemaProps{
-					"useWithOtherPattern": apiext.JSONSchemaProps{
+					"useWithOtherPattern": {
 						Ref:         &toLeaf,
 						Pattern:     "^[cde]$",
 						Description: "has other pattern",
 					},
-					"useWithMinLen": apiext.JSONSchemaProps{
+					"useWithMinLen": {
 						Ref:         &toLeaf,
 						MinLength:   &defOne,
 						Description: "has min len",
 					},
-					"useWithMaxLen": apiext.JSONSchemaProps{
+					"useWithMaxLen": {
 						Ref:         &toLeaf,
 						MaxLength:   &defThree,
 						Description: "has max len",
 					},
 				},
 			},
-			leafType: apiext.JSONSchemaProps{
+			leafType: {
 				Type:    "string",
 				Pattern: "^[abc]$",
 			},
@@ -233,21 +233,21 @@ var _ = Describe("General Schema Flattening", func() {
 		By("verifying that each use has its own properties set in allof branches")
 		Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
 			Properties: map[string]apiext.JSONSchemaProps{
-				"useWithOtherPattern": apiext.JSONSchemaProps{
+				"useWithOtherPattern": {
 					AllOf: []apiext.JSONSchemaProps{
 						{Type: "string", Pattern: "^[abc]$"},
 						{Pattern: "^[cde]$"},
 					},
 					Description: "has other pattern",
 				},
-				"useWithMinLen": apiext.JSONSchemaProps{
+				"useWithMinLen": {
 					AllOf: []apiext.JSONSchemaProps{
 						{Type: "string", Pattern: "^[abc]$"},
 						{MinLength: &defOne},
 					},
 					Description: "has min len",
 				},
-				"useWithMaxLen": apiext.JSONSchemaProps{
+				"useWithMaxLen": {
 					AllOf: []apiext.JSONSchemaProps{
 						{Type: "string", Pattern: "^[abc]$"},
 						{MaxLength: &defThree},
@@ -262,19 +262,19 @@ var _ = Describe("General Schema Flattening", func() {
 		By("setting up a series of types RootType --> LeafType with 3 doc-only uses")
 		toLeaf := crd.TypeRefLink("other", leafType.Name)
 		fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
-			rootType: apiext.JSONSchemaProps{
+			rootType: {
 				Properties: map[string]apiext.JSONSchemaProps{
-					"hasTitle": apiext.JSONSchemaProps{
+					"hasTitle": {
 						Ref:         &toLeaf,
 						Description: "has title",
 						Title:       "some title",
 					},
-					"hasExample": apiext.JSONSchemaProps{
+					"hasExample": {
 						Ref:         &toLeaf,
 						Description: "has example",
 						Example:     &apiext.JSON{Raw: []byte("[42]")},
 					},
-					"hasExternalDocs": apiext.JSONSchemaProps{
+					"hasExternalDocs": {
 						Ref:         &toLeaf,
 						Description: "has external docs",
 						ExternalDocs: &apiext.ExternalDocumentation{
@@ -284,7 +284,7 @@ var _ = Describe("General Schema Flattening", func() {
 					},
 				},
 			},
-			leafType: apiext.JSONSchemaProps{
+			leafType: {
 				Type:    "string",
 				Pattern: "^[abc]$",
 			},
@@ -298,17 +298,17 @@ var _ = Describe("General Schema Flattening", func() {
 		By("verifying that each use has its own properties set in allof branches")
 		Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
 			Properties: map[string]apiext.JSONSchemaProps{
-				"hasTitle": apiext.JSONSchemaProps{
+				"hasTitle": {
 					AllOf:       []apiext.JSONSchemaProps{{Type: "string", Pattern: "^[abc]$"}, {}},
 					Description: "has title",
 					Title:       "some title",
 				},
-				"hasExample": apiext.JSONSchemaProps{
+				"hasExample": {
 					AllOf:       []apiext.JSONSchemaProps{{Type: "string", Pattern: "^[abc]$"}, {}},
 					Description: "has example",
 					Example:     &apiext.JSON{Raw: []byte("[42]")},
 				},
-				"hasExternalDocs": apiext.JSONSchemaProps{
+				"hasExternalDocs": {
 					AllOf:       []apiext.JSONSchemaProps{{Type: "string", Pattern: "^[abc]$"}, {}},
 					Description: "has external docs",
 					ExternalDocs: &apiext.ExternalDocumentation{
@@ -325,27 +325,27 @@ var _ = Describe("General Schema Flattening", func() {
 		toLeaf := crd.TypeRefLink("other", leafType.Name)
 		toSubtype := crd.TypeRefLink("", subtypeWithRefs.Name)
 		fl.Parser.Schemata = map[crd.TypeIdent]apiext.JSONSchemaProps{
-			rootType: apiext.JSONSchemaProps{
+			rootType: {
 				Properties: map[string]apiext.JSONSchemaProps{
-					"isRef": apiext.JSONSchemaProps{
+					"isRef": {
 						Ref: &toSubtype,
 					},
-					"notRef": apiext.JSONSchemaProps{
+					"notRef": {
 						Type: "int",
 					},
 				},
 			},
-			subtypeWithRefs: apiext.JSONSchemaProps{
+			subtypeWithRefs: {
 				Properties: map[string]apiext.JSONSchemaProps{
-					"leafRef": apiext.JSONSchemaProps{
+					"leafRef": {
 						Ref: &toLeaf,
 					},
-					"alsoNotRef": apiext.JSONSchemaProps{
+					"alsoNotRef": {
 						Type: "bool",
 					},
 				},
 			},
-			leafType: apiext.JSONSchemaProps{
+			leafType: {
 				Type:    "string",
 				Pattern: "^[abc]$",
 			},
@@ -359,16 +359,16 @@ var _ = Describe("General Schema Flattening", func() {
 		By("verifying that each use has its own properties set in allof branches")
 		Expect(outSchema).To(Equal(&apiext.JSONSchemaProps{
 			Properties: map[string]apiext.JSONSchemaProps{
-				"isRef": apiext.JSONSchemaProps{
+				"isRef": {
 					AllOf: []apiext.JSONSchemaProps{
 						{
 							Properties: map[string]apiext.JSONSchemaProps{
-								"leafRef": apiext.JSONSchemaProps{
+								"leafRef": {
 									AllOf: []apiext.JSONSchemaProps{
 										{Type: "string", Pattern: "^[abc]$"}, {},
 									},
 								},
-								"alsoNotRef": apiext.JSONSchemaProps{
+								"alsoNotRef": {
 									Type: "bool",
 								},
 							},
@@ -376,7 +376,7 @@ var _ = Describe("General Schema Flattening", func() {
 						{},
 					},
 				},
-				"notRef": apiext.JSONSchemaProps{
+				"notRef": {
 					Type: "int",
 				},
 			},

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -123,13 +123,13 @@ var ObjectMetaPackages = map[string]PackageOverride{
 		p.Schemata[TypeIdent{Name: "ObjectMeta", Package: pkg}] = apiext.JSONSchemaProps{
 			Type: "object",
 			Properties: map[string]apiext.JSONSchemaProps{
-				"name": apiext.JSONSchemaProps{
+				"name": {
 					Type: "string",
 				},
-				"namespace": apiext.JSONSchemaProps{
+				"namespace": {
 					Type: "string",
 				},
-				"annotations": apiext.JSONSchemaProps{
+				"annotations": {
 					Type: "object",
 					AdditionalProperties: &apiext.JSONSchemaPropsOrBool{
 						Schema: &apiext.JSONSchemaProps{
@@ -137,7 +137,7 @@ var ObjectMetaPackages = map[string]PackageOverride{
 						},
 					},
 				},
-				"labels": apiext.JSONSchemaProps{
+				"labels": {
 					Type: "object",
 					AdditionalProperties: &apiext.JSONSchemaPropsOrBool{
 						Schema: &apiext.JSONSchemaProps{
@@ -145,7 +145,7 @@ var ObjectMetaPackages = map[string]PackageOverride{
 						},
 					},
 				},
-				"finalizers": apiext.JSONSchemaProps{
+				"finalizers": {
 					Type: "array",
 					Items: &apiext.JSONSchemaPropsOrArray{
 						Schema: &apiext.JSONSchemaProps{

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -32,7 +32,7 @@ func (Default) Help() *markers.DefinitionHelp {
 			Details: "A default value will be accepted as any value valid for the field. Formatting for common types include: boolean: `true`, string: `Cluster`, numerical: `1.24`, array: `{1,2}`, object: `{policy: \"delete\"}`). Defaults should be defined in pruned form, and only best-effort validation will be performed. Full validation of a default requires submission of the containing CRD to an apiserver.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Value": markers.DetailedHelp{
+			"Value": {
 				Summary: "",
 				Details: "",
 			},
@@ -246,27 +246,27 @@ func (PrintColumn) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Name": markers.DetailedHelp{
+			"Name": {
 				Summary: "specifies the name of the column.",
 				Details: "",
 			},
-			"Type": markers.DetailedHelp{
+			"Type": {
 				Summary: "indicates the type of the column. ",
 				Details: "It may be any OpenAPI data type listed at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.",
 			},
-			"JSONPath": markers.DetailedHelp{
+			"JSONPath": {
 				Summary: "specifies the jsonpath expression used to extract the value of the column.",
 				Details: "",
 			},
-			"Description": markers.DetailedHelp{
+			"Description": {
 				Summary: "specifies the help/description for this column.",
 				Details: "",
 			},
-			"Format": markers.DetailedHelp{
+			"Format": {
 				Summary: "specifies the format of the column. ",
 				Details: "It may be any OpenAPI data format corresponding to the type, listed at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.",
 			},
-			"Priority": markers.DetailedHelp{
+			"Priority": {
 				Summary: "indicates how important it is that this column be displayed. ",
 				Details: "Lower priority (*higher* numbered) columns will be hidden if the terminal width is too small.",
 			},
@@ -282,23 +282,23 @@ func (Resource) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Path": markers.DetailedHelp{
+			"Path": {
 				Summary: "specifies the plural \"resource\" for this CRD. ",
 				Details: "It generally corresponds to a plural, lower-cased version of the Kind. See https://book.kubebuilder.io/cronjob-tutorial/gvks.html.",
 			},
-			"ShortName": markers.DetailedHelp{
+			"ShortName": {
 				Summary: "specifies aliases for this CRD. ",
 				Details: "Short names are often used when people have work with your resource over and over again.  For instance, \"rs\" for \"replicaset\" or \"crd\" for customresourcedefinition.",
 			},
-			"Categories": markers.DetailedHelp{
+			"Categories": {
 				Summary: "specifies which group aliases this resource is part of. ",
 				Details: "Group aliases are used to work with groups of resources at once. The most common one is \"all\" which covers about a third of the base resources in Kubernetes, and is generally used for \"user-facing\" resources.",
 			},
-			"Singular": markers.DetailedHelp{
+			"Singular": {
 				Summary: "overrides the singular form of your resource. ",
 				Details: "The singular form is otherwise defaulted off the plural (path).",
 			},
-			"Scope": markers.DetailedHelp{
+			"Scope": {
 				Summary: "overrides the scope of the CRD (Cluster vs Namespaced). ",
 				Details: "Scope defaults to \"Namespaced\".  Cluster-scoped (\"Cluster\") resources don't exist in namespaces.",
 			},
@@ -358,15 +358,15 @@ func (SubresourceScale) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"SpecPath": markers.DetailedHelp{
+			"SpecPath": {
 				Summary: "specifies the jsonpath to the replicas field for the scale's spec.",
 				Details: "",
 			},
-			"StatusPath": markers.DetailedHelp{
+			"StatusPath": {
 				Summary: "specifies the jsonpath to the replicas field for the scale's status.",
 				Details: "",
 			},
-			"SelectorPath": markers.DetailedHelp{
+			"SelectorPath": {
 				Summary: "specifies the jsonpath to the pod label selector field for the scale's status. ",
 				Details: "The selector field must be the *string* form (serialized form) of a selector. Setting a pod label selector is necessary for your type to work with the HorizontalPodAutoscaler.",
 			},

--- a/pkg/crd/zz_generated.markerhelp.go
+++ b/pkg/crd/zz_generated.markerhelp.go
@@ -32,27 +32,27 @@ func (Generator) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"TrivialVersions": markers.DetailedHelp{
+			"TrivialVersions": {
 				Summary: "indicates that we should produce a single-version CRD. ",
 				Details: "Single \"trivial-version\" CRDs are compatible with older (pre 1.13) Kubernetes API servers.  The storage version's schema will be used as the CRD's schema. \n Only works with the v1beta1 CRD version.",
 			},
-			"PreserveUnknownFields": markers.DetailedHelp{
+			"PreserveUnknownFields": {
 				Summary: "indicates whether or not we should turn off pruning. ",
 				Details: "Left unspecified, it'll default to true when only a v1beta1 CRD is generated (to preserve compatibility with older versions of this tool), or false otherwise. \n It's required to be false for v1 CRDs.",
 			},
-			"AllowDangerousTypes": markers.DetailedHelp{
+			"AllowDangerousTypes": {
 				Summary: "allows types which are usually omitted from CRD generation because they are not recommended. ",
 				Details: "Currently the following additional types are allowed when this is true: float32 float64 \n Left unspecified, the default is false",
 			},
-			"MaxDescLen": markers.DetailedHelp{
+			"MaxDescLen": {
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},
-			"CRDVersions": markers.DetailedHelp{
+			"CRDVersions": {
 				Summary: "specifies the target API versions of the CRD type itself to generate. Defaults to v1. ",
 				Details: "The first version listed will be assumed to be the \"default\" version and will not get a version suffix in the output filename. \n You'll need to use \"v1\" to get support for features like defaulting, along with an API server that supports it (Kubernetes 1.16+).",
 			},
-			"GenerateEmbeddedObjectMeta": markers.DetailedHelp{
+			"GenerateEmbeddedObjectMeta": {
 				Summary: "specifies if any embedded ObjectMeta in the CRD should be generated",
 				Details: "",
 			},

--- a/pkg/deepcopy/zz_generated.markerhelp.go
+++ b/pkg/deepcopy/zz_generated.markerhelp.go
@@ -32,11 +32,11 @@ func (Generator) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"HeaderFile": markers.DetailedHelp{
+			"HeaderFile": {
 				Summary: "specifies the header text (e.g. license) to prepend to generated files.",
 				Details: "",
 			},
-			"Year": markers.DetailedHelp{
+			"Year": {
 				Summary: "specifies the year to substitute for \" YEAR\" in the header file.",
 				Details: "",
 			},

--- a/pkg/genall/zz_generated.markerhelp.go
+++ b/pkg/genall/zz_generated.markerhelp.go
@@ -43,11 +43,11 @@ func (OutputArtifacts) Help() *markers.DefinitionHelp {
 			Details: "Non-package associated artifacts are output to the Config directory, while package-associated ones are output to their package's source files' directory, unless an alternate path is specified in Code.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Config": markers.DetailedHelp{
+			"Config": {
 				Summary: "points to the directory to which to write configuration.",
 				Details: "",
 			},
-			"Code": markers.DetailedHelp{
+			"Code": {
 				Summary: "overrides the directory in which to write new code (defaults to where the existing code lives).",
 				Details: "",
 			},

--- a/pkg/rbac/zz_generated.markerhelp.go
+++ b/pkg/rbac/zz_generated.markerhelp.go
@@ -32,7 +32,7 @@ func (Generator) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"RoleName": markers.DetailedHelp{
+			"RoleName": {
 				Summary: "sets the name of the generated ClusterRole.",
 				Details: "",
 			},
@@ -48,27 +48,27 @@ func (Rule) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Groups": markers.DetailedHelp{
+			"Groups": {
 				Summary: "specifies the API groups that this rule encompasses.",
 				Details: "",
 			},
-			"Resources": markers.DetailedHelp{
+			"Resources": {
 				Summary: "specifies the API resources that this rule encompasses.",
 				Details: "",
 			},
-			"ResourceNames": markers.DetailedHelp{
+			"ResourceNames": {
 				Summary: "specifies the names of the API resources that this rule encompasses. ",
 				Details: "Create requests cannot be restricted by resourcename, as the object's name is not known at authorization time.",
 			},
-			"Verbs": markers.DetailedHelp{
+			"Verbs": {
 				Summary: "specifies the (lowercase) kubernetes API verbs that this rule encompasses.",
 				Details: "",
 			},
-			"URLs": markers.DetailedHelp{
+			"URLs": {
 				Summary: "URL specifies the non-resource URLs that this rule encompasses.",
 				Details: "",
 			},
-			"Namespace": markers.DetailedHelp{
+			"Namespace": {
 				Summary: "specifies the scope of the Rule. If not set, the Rule belongs to the generated ClusterRole. If set, the Rule belongs to a Role, whose namespace is specified by this field.",
 				Details: "",
 			},

--- a/pkg/schemapatcher/gen.go
+++ b/pkg/schemapatcher/gen.go
@@ -434,7 +434,7 @@ func crdsFromDirectory(ctx *genall.GenerationContext, dir string) (map[schema.Gr
 		groupKind := schema.GroupKind{Group: actualCRD.Spec.Group, Kind: actualCRD.Spec.Names.Kind}
 		var versions map[string]struct{}
 		if len(actualCRD.Spec.Versions) == 0 {
-			versions = map[string]struct{}{actualCRD.Spec.Version: struct{}{}}
+			versions = map[string]struct{}{actualCRD.Spec.Version: {}}
 		} else {
 			versions = make(map[string]struct{}, len(actualCRD.Spec.Versions))
 			for _, ver := range actualCRD.Spec.Versions {

--- a/pkg/schemapatcher/zz_generated.markerhelp.go
+++ b/pkg/schemapatcher/zz_generated.markerhelp.go
@@ -32,11 +32,11 @@ func (Generator) Help() *markers.DefinitionHelp {
 			Details: "For legacy (v1beta1) single-version CRDs, it will simply replace the global schema. \n For legacy (v1beta1) multi-version CRDs, and any v1 CRDs, it will replace schemata of existing versions and *clear the schema* from any versions not specified in the Go code.  It will *not* add new versions, or remove old ones. \n For legacy multi-version CRDs with identical schemata, it will take care of lifting the per-version schema up to the global schema. \n It will generate output for each \"CRD Version\" (API version of the CRD type itself) , e.g. apiextensions/v1beta1 and apiextensions/v1) available.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"ManifestsPath": markers.DetailedHelp{
+			"ManifestsPath": {
 				Summary: "contains the CustomResourceDefinition YAML files.",
 				Details: "",
 			},
-			"MaxDescLen": markers.DetailedHelp{
+			"MaxDescLen": {
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},

--- a/pkg/webhook/zz_generated.markerhelp.go
+++ b/pkg/webhook/zz_generated.markerhelp.go
@@ -32,51 +32,51 @@ func (Config) Help() *markers.DefinitionHelp {
 			Details: "It specifies only the details that are intrinsic to the application serving it (e.g. the resources it can handle, or the path it serves on).",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Mutating": markers.DetailedHelp{
+			"Mutating": {
 				Summary: "marks this as a mutating webhook (it's validating only if false) ",
 				Details: "Mutating webhooks are allowed to change the object in their response, and are called *before* all validating webhooks.  Mutating webhooks may choose to reject an object, similarly to a validating webhook.",
 			},
-			"FailurePolicy": markers.DetailedHelp{
+			"FailurePolicy": {
 				Summary: "specifies what should happen if the API server cannot reach the webhook. ",
 				Details: "It may be either \"ignore\" (to skip the webhook and continue on) or \"fail\" (to reject the object in question).",
 			},
-			"MatchPolicy": markers.DetailedHelp{
+			"MatchPolicy": {
 				Summary: "defines how the \"rules\" list is used to match incoming requests. Allowed values are \"Exact\" (match only if it exactly matches the specified rule) or \"Equivalent\" (match a request if it modifies a resource listed in rules, even via another API group or version).",
 				Details: "",
 			},
-			"SideEffects": markers.DetailedHelp{
+			"SideEffects": {
 				Summary: "specify whether calling the webhook will have side effects. This has an impact on dry runs and `kubectl diff`: if the sideEffect is \"Unknown\" (the default) or \"Some\", then the API server will not call the webhook on a dry-run request and fails instead. If the value is \"None\", then the webhook has no side effects and the API server will call it on dry-run. If the value is \"NoneOnDryRun\", then the webhook is responsible for inspecting the \"dryRun\" property of the AdmissionReview sent in the request, and avoiding side effects if that value is \"true.\"",
 				Details: "",
 			},
-			"Groups": markers.DetailedHelp{
+			"Groups": {
 				Summary: "specifies the API groups that this webhook receives requests for.",
 				Details: "",
 			},
-			"Resources": markers.DetailedHelp{
+			"Resources": {
 				Summary: "specifies the API resources that this webhook receives requests for.",
 				Details: "",
 			},
-			"Verbs": markers.DetailedHelp{
+			"Verbs": {
 				Summary: "specifies the Kubernetes API verbs that this webhook receives requests for. ",
 				Details: "Only modification-like verbs may be specified. May be \"create\", \"update\", \"delete\", \"connect\", or \"*\" (for all).",
 			},
-			"Versions": markers.DetailedHelp{
+			"Versions": {
 				Summary: "specifies the API versions that this webhook receives requests for.",
 				Details: "",
 			},
-			"Name": markers.DetailedHelp{
+			"Name": {
 				Summary: "indicates the name of this webhook configuration. Should be a domain with at least three segments separated by dots",
 				Details: "",
 			},
-			"Path": markers.DetailedHelp{
+			"Path": {
 				Summary: "specifies that path that the API server should connect to this webhook on. Must be prefixed with a '/validate-' or '/mutate-' depending on the type, and followed by $GROUP-$VERSION-$KIND where all values are lower-cased and the periods in the group are substituted for hyphens. For example, a validating webhook path for type batch.tutorial.kubebuilder.io/v1,Kind=CronJob would be /validate-batch-tutorial-kubebuilder-io-v1-cronjob",
 				Details: "",
 			},
-			"WebhookVersions": markers.DetailedHelp{
+			"WebhookVersions": {
 				Summary: "specifies the target API versions of the {Mutating,Validating}WebhookConfiguration objects itself to generate.  Defaults to v1.",
 				Details: "",
 			},
-			"AdmissionReviewVersions": markers.DetailedHelp{
+			"AdmissionReviewVersions": {
 				Summary: "is an ordered list of preferred `AdmissionReview` versions the Webhook expects. For generating v1 {Mutating,Validating}WebhookConfiguration, this is mandatory. For generating v1beta1 {Mutating,Validating}WebhookConfiguration, this is optional, and default to v1beta1.",
 				Details: "",
 			},

--- a/test.sh
+++ b/test.sh
@@ -128,6 +128,7 @@ golangci-lint run --disable-all \
     --enable=misspell \
     --enable=gocyclo \
     --enable=gosec \
+    --enable=gofmt \
     --deadline=5m \
     ./pkg/... ./cmd/...
 


### PR DESCRIPTION
There's a bunch of files that have changes when `gofmt -s -w`-ed,
this fixes all of them.

Updated helpgen to produce these results, and enabled gofmt in our lints.

Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>