### PR TITLE
🐛 WIP: Force preserveUnknownFields=false for v1 CRDs

### DIFF
--- a/pkg/crd/crd_alias_types.go
+++ b/pkg/crd/crd_alias_types.go
@@ -1,0 +1,69 @@
+package crd
+
+import (
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// v1AliasCRD is an alias of v1.CustomResourceDefinition.
+// It has identical fields, the only difference is the json tag
+// on spec.PreserveUnknownFields does not contain omitempty.
+//
+// The source of truth of v1.CustomResourceDefinition lives at
+// https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apis/apiextensions/v1/types.go
+//
+// This is used in order to force controller-gen to generate
+// v1 CRD yamls with preserveUnknownFields=false explicitly, because
+// otherwise controller will omit it which becomes problematic for users
+// upgrading existing CRDs from v1beta to v1
+//
+// See https://github.com/kubernetes-sigs/controller-tools/issues/476
+type v1AliasCRD struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+
+	// spec describes how the user wants the resources to appear
+	Spec v1AliasCRDSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
+	// status indicates the actual state of the CustomResourceDefinition
+	// +optional
+	Status apiext.CustomResourceDefinitionStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+}
+
+// v1AliasCRDSpec is an alias of v1.CustomResourceDefinitionSpec.
+// It has identical fields, the only difference is the json tag
+// on PreserveUnknownFields does not contain omitempty.
+//
+// The source of truth of v1.CustomResourceDefinitionSpec lives at
+// https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apis/apiextensions/v1/types.go
+type v1AliasCRDSpec struct {
+	// group is the API group of the defined custom resource.
+	// The custom resources are served under `/apis/<group>/...`.
+	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
+	// names specify the resource and kind names for the custom resource.
+	Names apiext.CustomResourceDefinitionNames `json:"names" protobuf:"bytes,3,opt,name=names"`
+	// scope indicates whether the defined custom resource is cluster- or namespace-scoped.
+	// Allowed values are `Cluster` and `Namespaced`.
+	Scope apiext.ResourceScope `json:"scope" protobuf:"bytes,4,opt,name=scope,casttype=ResourceScope"`
+	// versions is the list of all API versions of the defined custom resource.
+	// Version names are used to compute the order in which served versions are listed in API discovery.
+	// If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
+	// lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
+	// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+	// by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing
+	// major version, then minor version. An example sorted list of versions:
+	// v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+	Versions []apiext.CustomResourceDefinitionVersion `json:"versions" protobuf:"bytes,7,rep,name=versions"`
+
+	// conversion defines conversion settings for the CRD.
+	// +optional
+	Conversion *apiext.CustomResourceConversion `json:"conversion,omitempty" protobuf:"bytes,9,opt,name=conversion"`
+
+	// preserveUnknownFields indicates that object fields which are not specified
+	// in the OpenAPI schema should be preserved when persisting to storage.
+	// apiVersion, kind, metadata and known fields inside metadata are always preserved.
+	// This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`.
+	// See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
+	// +optional
+	PreserveUnknownFields bool `json:"preserveUnknownFields" protobuf:"varint,10,opt,name=preserveUnknownFields"`
+}

--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -24,7 +24,6 @@ import (
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextlegacy "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 
@@ -34,50 +33,6 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/markers"
 	"sigs.k8s.io/controller-tools/pkg/version"
 )
-
-type HackyCRD struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-
-	// spec describes how the user wants the resources to appear
-	Spec HackyCRDSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
-	// status indicates the actual state of the CustomResourceDefinition
-	// +optional
-	Status apiext.CustomResourceDefinitionStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
-}
-
-type HackyCRDSpec struct {
-	// group is the API group of the defined custom resource.
-	// The custom resources are served under `/apis/<group>/...`.
-	// Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
-	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
-	// names specify the resource and kind names for the custom resource.
-	Names apiext.CustomResourceDefinitionNames `json:"names" protobuf:"bytes,3,opt,name=names"`
-	// scope indicates whether the defined custom resource is cluster- or namespace-scoped.
-	// Allowed values are `Cluster` and `Namespaced`.
-	Scope apiext.ResourceScope `json:"scope" protobuf:"bytes,4,opt,name=scope,casttype=ResourceScope"`
-	// versions is the list of all API versions of the defined custom resource.
-	// Version names are used to compute the order in which served versions are listed in API discovery.
-	// If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered
-	// lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version),
-	// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
-	// by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing
-	// major version, then minor version. An example sorted list of versions:
-	// v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
-	Versions []apiext.CustomResourceDefinitionVersion `json:"versions" protobuf:"bytes,7,rep,name=versions"`
-
-	// conversion defines conversion settings for the CRD.
-	// +optional
-	Conversion *apiext.CustomResourceConversion `json:"conversion,omitempty" protobuf:"bytes,9,opt,name=conversion"`
-
-	// preserveUnknownFields indicates that object fields which are not specified
-	// in the OpenAPI schema should be preserved when persisting to storage.
-	// apiVersion, kind, metadata and known fields inside metadata are always preserved.
-	// This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`.
-	// See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
-	// +optional
-	PreserveUnknownFields bool `json:"preserveUnknownFields" protobuf:"varint,10,opt,name=preserveUnknownFields"`
-}
 
 // The default CustomResourceDefinition version to generate.
 const defaultVersion = "v1"
@@ -219,45 +174,36 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 
 		for i, crd := range versionedCRDs {
-			var fileName string
-			if i == 0 {
-				fileName = fmt.Sprintf("%s_%s.yaml", crdRaw.Spec.Group, crdRaw.Spec.Names.Plural)
-			} else {
-				fileName = fmt.Sprintf("%s_%s.%s.yaml", crdRaw.Spec.Group, crdRaw.Spec.Names.Plural, crdVersions[i])
-			}
 			// defaults are not allowed to be specified in v1beta1 CRDs and
 			// decriptions are not allowed on the metadata regardless of version
 			// strip them before writing to a file
 			if crdVersions[i] == "v1beta1" {
 				removeDefaultsFromSchemas(crd.(*apiextlegacy.CustomResourceDefinition))
 				removeDescriptionFromMetadataLegacy(crd.(*apiextlegacy.CustomResourceDefinition))
-				//v1beta1crd := crd.(*apiextlegacy.CustomResourceDefinition)
-				//fmt.Printf("v1beta1crd = %+v\n", v1beta1crd)
-				if err := ctx.WriteYAML(fileName, crd); err != nil {
-					return err
-				}
 			} else {
 				removeDescriptionFromMetadata(crd.(*apiext.CustomResourceDefinition))
-				v1crd := crd.(*apiext.CustomResourceDefinition)
-				//v1crd.Spec.PreserveUnknownFields = true
 
-				newCRD := &HackyCRD{}
+				// transform crd from type apiext.CustomResourceDefinition
+				// into a v1AliasCRD whose only difference is that it does not
+				// omit "preserveUnknownFields=false" from the final generated yaml.
+				v1crd := crd.(*apiext.CustomResourceDefinition)
+				newCRD := &v1AliasCRD{}
 				yamlContent, err := yaml.Marshal(v1crd)
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal crd: %v", err)
 				}
 				yaml.Unmarshal(yamlContent, newCRD)
-				fmt.Printf("gen yamlContent = %+v\n", string(yamlContent))
-				if err := ctx.WriteYAML(fileName, newCRD); err != nil {
-					return err
-				}
-
-				//fmt.Printf("v1crd = %+v\n", v1crd)
+				crd = newCRD
 			}
-			//fmt.Printf("crdRaw = %+v\n", crdRaw)
-			//if err := ctx.WriteYAML(fileName, crd); err != nil {
-			//	return err
-			//}
+			var fileName string
+			if i == 0 {
+				fileName = fmt.Sprintf("%s_%s.yaml", crdRaw.Spec.Group, crdRaw.Spec.Names.Plural)
+			} else {
+				fileName = fmt.Sprintf("%s_%s.%s.yaml", crdRaw.Spec.Group, crdRaw.Spec.Names.Plural, crdVersions[i])
+			}
+			if err := ctx.WriteYAML(fileName, crd); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -67,10 +67,12 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		}
 	})
 
-	It("should strip v1beta1 CRDs of default fields and metadata description", func() {
+	FIt("should strip v1beta1 CRDs of default fields and metadata description", func() {
 		By("calling Generate")
+		b := false
 		gen := &crd.Generator{
-			CRDVersions: []string{"v1beta1"},
+			CRDVersions:           []string{"v1beta1"},
+			PreserveUnknownFields: &b,
 		}
 		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
 
@@ -84,10 +86,12 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 
 	})
 
-	It("should not strip v1 CRDs of default fields and metadata description", func() {
+	FIt("should not strip v1 CRDs of default fields and metadata description", func() {
 		By("calling Generate")
+		b := false
 		gen := &crd.Generator{
-			CRDVersions: []string{"v1"},
+			CRDVersions:           []string{"v1"},
+			PreserveUnknownFields: &b,
 		}
 		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
 

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -67,7 +67,7 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		}
 	})
 
-	FIt("should strip v1beta1 CRDs of default fields and metadata description", func() {
+	It("should strip v1beta1 CRDs of default fields and metadata description", func() {
 		By("calling Generate")
 		b := false
 		gen := &crd.Generator{
@@ -86,7 +86,7 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 
 	})
 
-	FIt("should not strip v1 CRDs of default fields and metadata description", func() {
+	It("should not strip v1 CRDs of default fields and metadata description", func() {
 		By("calling Generate")
 		b := false
 		gen := &crd.Generator{

--- a/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: FooList
     plural: foos
     singular: foo
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/pkg/crd/testdata/gen/bar.example.com_foos.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.yaml
@@ -14,6 +14,7 @@ spec:
     listKind: FooList
     plural: foos
     singular: foo
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: foo

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -129,7 +129,9 @@ func (g GenerationContext) WriteYAML(itemPath string, objs ...interface{}) error
 	defer out.Close()
 
 	for _, obj := range objs {
+		fmt.Printf("obj = %+v\n", obj)
 		yamlContent, err := yaml.Marshal(obj)
+		fmt.Printf("yamlContent = %+v\n", string(yamlContent))
 		if err != nil {
 			return err
 		}

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -129,9 +129,7 @@ func (g GenerationContext) WriteYAML(itemPath string, objs ...interface{}) error
 	defer out.Close()
 
 	for _, obj := range objs {
-		fmt.Printf("obj = %+v\n", obj)
 		yamlContent, err := yaml.Marshal(obj)
-		fmt.Printf("yamlContent = %+v\n", string(yamlContent))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This is a proof-of-concept of how to force controller-gen to explicitly set "preserveUnknownFields=false" for v1 CRDs. We should always be setting this field, because the default value has flipped from true to false between CRD api version v1beta1 and v1.

Fixes #476 
Related: https://kubernetes.slack.com/archives/CAR30FCJZ/p1611919182225100

The way this works is by creating a new type that is identical to `apiext.CustomResourceDefinition` with the one exception being that the json tag for `Spec.PreserveUnknownFields` does not contain omitempty.

It feels pretty hacky to have to create a separate type that duplicates most of the CRD type, so I am definitely open to alternative ways of doing this.

Some other approaches could be:
* trying to dynamically edit the json tag of `apiext.CustomResourceDefinition`
* post-processing the yaml that gets written out to add the field on afterwards.

Both of these options have their own drawbacks and I went with this one because it seemed like the quickest way to get a working POC so that I could get a discussion started at least.


