### PR TITLE
:bug: schemapatcher: help should include all options

### DIFF
--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -48,7 +48,7 @@ func (DeprecatedVersion) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Warning": markers.DetailedHelp{
+			"Warning": {
 				Summary: "message to be shown on the deprecated version",
 				Details: "",
 			},

--- a/pkg/schemapatcher/zz_generated.markerhelp.go
+++ b/pkg/schemapatcher/zz_generated.markerhelp.go
@@ -40,6 +40,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},
+			"GenerateEmbeddedObjectMeta": {
+				Summary: "specifies if any embedded ObjectMeta in the CRD should be generated",
+				Details: "",
+			},
 		},
 	}
 }


### PR DESCRIPTION
While [generating testdata](https://github.com/kubernetes-sigs/controller-tools/tree/master/pkg/crd/testdata#crd-integration-test-testdata), I noticed that the generated code appears outdated. So I did a full regenerate throughout the project.

And it seems like help is not generated for a new option recently added to `schemapatcher`. This PR fixes this.