### PR TITLE
:running: feat(dockerfile): add binary image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY cmd/ ./cmd
 
 # build all of the binaries and show they were built
 RUN for binary_folder in $(find cmd -maxdepth 1 -mindepth 1); do \
-		go build -o $(basename $binary_folder) $binary_folder/*; \
+		CGO_ENABLED=0 go build -o $(basename $binary_folder) $binary_folder/*; \
 	done ; \
 	find . -type f -executable
 ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Copied from https://docs.docker.com/language/golang/build-images/ with minor modifications
+FROM golang:1.16-alpine  AS build
+
+WORKDIR /app
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download -x
+
+# copy the files necessary to building the binaries
+COPY pkg/ ./pkg
+COPY cmd/ ./cmd
+
+# build all of the binaries and show they were built
+RUN for binary_folder in $(find cmd -maxdepth 1 -mindepth 1); do \
+		go build -o $(basename $binary_folder) $binary_folder/*; \
+	done ; \
+	find . -type f -executable
+##
+## Deploy
+##
+
+FROM gcr.io/distroless/base-debian10
+
+COPY --from=build /app/controller-gen /
+COPY --from=build /app/helpgen /
+COPY --from=build /app/type-scaffold /
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/controller-gen"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,12 @@ RUN for binary_folder in $(find cmd -maxdepth 1 -mindepth 1); do \
 ## Deploy
 ##
 
-FROM gcr.io/distroless/base-debian10
+FROM golang:1.16-alpine
 
-COPY --from=build /app/controller-gen /
-COPY --from=build /app/helpgen /
-COPY --from=build /app/type-scaffold /
+COPY --from=build /app/controller-gen /usr/local/bin
+COPY --from=build /app/helpgen /usr/local/bin
+COPY --from=build /app/type-scaffold /usr/local/bin
 
-USER nonroot:nonroot
 
-ENTRYPOINT ["/controller-gen"]
+ENTRYPOINT ["controller-gen"]
 


### PR DESCRIPTION
# What
this PR adds dockerfile support to allow for execution of these tools in a container and not directly on the host

# Why
We have `controller-gen` installed on our CI server and migrating to the newer version there might break stuff for other repos running on that server

thus adding an image allows us to run it and not the binary on the host