### PR TITLE
:bug: Allow setting the type for structs that implement json.Marshaler

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -110,10 +110,14 @@ func (c *schemaContext) requestSchema(pkgPath, typeName string) {
 
 // infoToSchema creates a schema for the type in the given set of type information.
 func infoToSchema(ctx *schemaContext) *apiext.JSONSchemaProps {
+	// If the obj implements a JSON marshaler and has a marker, use the markers value and do not traverse as
+	// the marshaler could be doing anything. If there is no marker, fall back to traversing.
 	if obj := ctx.pkg.Types.Scope().Lookup(ctx.info.Name); obj != nil && implementsJSONMarshaler(obj.Type()) {
-		schema := &apiext.JSONSchemaProps{Type: "Any"}
+		schema := &apiext.JSONSchemaProps{}
 		applyMarkers(ctx, ctx.info.Markers, schema, ctx.info.RawSpec.Type)
-		return schema
+		if schema.Type != "" {
+			return schema
+		}
 	}
 	return typeToSchema(ctx, ctx.info.RawSpec.Type)
 }

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -326,6 +327,20 @@ func (u *URL2) String() string {
 	return (*url.URL)(u).String()
 }
 
+// Duration has a custom Marshaler but no markers.
+// We want the CRD generation to infer type information
+// from the go types and ignore the presense of the Marshaler.
+type Duration struct {
+	Value time.Duration `json:"value"`
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	type durationWithoutUnmarshaler Duration
+	return json.Marshal(durationWithoutUnmarshaler(d))
+}
+
+var _ json.Marshaler = Duration{}
+
 // ConcurrencyPolicy describes how the job will be handled.
 // Only one of the following concurrent policies may be specified.
 // If none of the following policies is specified, the default one
@@ -370,6 +385,8 @@ type CronJobStatus struct {
 	// LastActiveLogURL2 specifies the logging url for the last started job
 	// +optional
 	LastActiveLogURL2 *URL2 `json:"lastActiveLogURL2,omitempty"`
+
+	Runtime *Duration `json:"duration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -7353,6 +7353,20 @@ spec:
                       type: string
                   type: object
                 type: array
+              duration:
+                description: Duration has a custom Marshaler but no markers. We want
+                  the CRD generation to infer type information from the go types and
+                  ignore the presense of the Marshaler.
+                properties:
+                  value:
+                    description: A Duration represents the elapsed time between two
+                      instants as an int64 nanosecond count. The representation limits
+                      the largest representable duration to approximately 290 years.
+                    format: int64
+                    type: integer
+                required:
+                - value
+                type: object
               lastActiveLogURL:
                 description: LastActiveLogURL specifies the logging url for the last
                   started job


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This change re-introduces https://github.com/kubernetes-sigs/controller-tools/pull/427 which was reverted in https://github.com/kubernetes-sigs/controller-tools/pull/505 because it generates a schema with `Any` in it which the kube api server won't allow. The change compared to the original work is in the last commit: We will fallback to the standard generation when there is no marker, rather than inserting the invalid `Any`.

Fixes https://github.com/kubernetes-sigs/controller-tools/issues/552
Fixes https://github.com/kubernetes-sigs/controller-tools/issues/560
Original issue: https://github.com/kubernetes-sigs/controller-tools/issues/391

/assign @vincepri 
/cc @markusthoemmes 
