### PR TITLE
 🐛  Allow pattern usage for IntOrString fields

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -298,8 +298,11 @@ func (m MinLength) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	return nil
 }
 func (m Pattern) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "string" {
-		return fmt.Errorf("must apply pattern to a string")
+	// Allow string types or IntOrStrings. An IntOrString will still
+	// apply the pattern validation when a string is detected, the pattern
+	// will not apply to ints though.
+	if schema.Type != "string" || schema.XIntOrString {
+		return fmt.Errorf("must apply pattern to a `string` or `IntOrString`")
 	}
 	schema.Pattern = string(m)
 	return nil


### PR DESCRIPTION
As of today, if you want to add a pattern to a CRD field, the field has to be a string or you have to specify that it is of type string. Patterns are also compatible with `XIntOrString` but the CRD generator won't allow you to do this.

When patterns are used with the `IntOrString` type, the validation is run if a string is detected, but not run when an integer is detected. I have a use case where I want to ensure that the field is either an integer or percentage, and a pattern can be useful for validating the percentage.

There is also a workaround today where you can manually set a `IntOrString` field to a string type, but then validation blows up when you put an integer in.

This PR should allow patterns when an `IntOrString` field is used.