### PR TITLE
🐛 Fix int or string pattern application

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -66,6 +66,7 @@ var ValidationMarkers = mustMakeAllWithPrefix("kubebuilder:validation", markers.
 	Type(""),
 	XPreserveUnknownFields{},
 	XEmbeddedResource{},
+	XIntOrString{},
 )
 
 // FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make
@@ -231,6 +232,14 @@ type XPreserveUnknownFields struct{}
 // running apiserver. It is not necessary to add any additional schema for these
 // field, yet it is possible. This can be combined with PreserveUnknownFields.
 type XEmbeddedResource struct{}
+
+// +controllertools:marker:generateHelp:category="CRD validation"
+// IntOrString marks a fields as an IntOrString.
+//
+// This is required when applying patterns or other validations to an IntOrString
+// field. Knwon information about the type is applied during the collapse phase
+// and as such is not normally available during marker application.
+type XIntOrString struct{}
 
 // +controllertools:marker:generateHelp:category="CRD validation"
 // Schemaless marks a field as being a schemaless object.
@@ -409,3 +418,13 @@ func (m XEmbeddedResource) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	schema.XEmbeddedResource = true
 	return nil
 }
+
+// NB(JoelSpeed): we use this property in other markers here,
+// which means the "XIntOrString" marker *must* be applied first.
+
+func (m XIntOrString) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	schema.XIntOrString = true
+	return nil
+}
+
+func (m XIntOrString) ApplyFirst() {}

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -301,7 +301,7 @@ func (m Pattern) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	// Allow string types or IntOrStrings. An IntOrString will still
 	// apply the pattern validation when a string is detected, the pattern
 	// will not apply to ints though.
-	if schema.Type != "string" || schema.XIntOrString {
+	if schema.Type != "string" && !schema.XIntOrString {
 		return fmt.Errorf("must apply pattern to a `string` or `IntOrString`")
 	}
 	schema.Pattern = string(m)

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -48,7 +48,7 @@ func (DeprecatedVersion) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Warning": markers.DetailedHelp{
+			"Warning": {
 				Summary: "message to be shown on the deprecated version",
 				Details: "",
 			},
@@ -440,6 +440,17 @@ func (XEmbeddedResource) Help() *markers.DefinitionHelp {
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "EmbeddedResource marks a fields as an embedded resource with apiVersion, kind and metadata fields. ",
 			Details: "An embedded resource is a value that has apiVersion, kind and metadata fields. They are validated implicitly according to the semantics of the currently running apiserver. It is not necessary to add any additional schema for these field, yet it is possible. This can be combined with PreserveUnknownFields.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
+func (XIntOrString) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "IntOrString marks a fields as an IntOrString. ",
+			Details: "This is required when applying patterns or other validations to an IntOrString field. Knwon information about the type is applied during the collapse phase and as such is not normally available during marker application.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -160,6 +161,14 @@ type CronJobSpec struct {
 	// This tests that the schemaless marker works
 	// +kubebuilder:validation:Schemaless
 	Schemaless []byte `json:"schemaless,omitempty"`
+
+	// This tests that an IntOrString can also have a pattern attached
+	// to it.
+	// This can be useful if you want to limit the string to a perecentage or integer.
+	// The XIntOrString marker is a requirement for having a pattern on this type.
+	// +kubebuilder:validation:XIntOrString
+	// +kubebuilder:validation:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"
+	IntOrStringWithAPattern *intstr.IntOrString `json:"intOrStringWithAPattern,omitempty"`
 }
 
 // +kubebuilder:validation:Type=object

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -125,6 +125,16 @@ spec:
                   a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
+              intOrStringWithAPattern:
+                anyOf:
+                - type: integer
+                - type: string
+                description: This tests that an IntOrString can also have a pattern
+                  attached to it. This can be useful if you want to limit the string
+                  to a perecentage or integer. The XIntOrString marker is a requirement
+                  for having a pattern on this type.
+                pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                x-kubernetes-int-or-string: true
               jobTemplate:
                 description: Specifies the job that will be created when executing
                   a CronJob.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
This is a follow up to fix #608 which I hadn't appropriately tested before proposing it 😞 

I tried this out this morning and worked out that it wasn't working, there are two reasons for this.

The condition check was wrong, we meant to check for the schema *not* being an IntOrString.

The second issue is that the additional information for the type that the generator applies (eg setting XIntOrString=true) is not done until way later in the generation than the markers being applied. Looking at the existing code, the "fix" for this seems to be that you have to apply an additional marker, eg the Type marker, that sets the required fields early.

So this introduces a new marker `// +kubebuilder:validation:XIntOrString` which marks the type as an IntOrString early to allow the pattern marker to pick this up. Not sure if this is the best approach given Solly's old notes, but it seems to be in-keeping with the rest of the markers

/CC @alvaroaleman @vincepri 
