### PR TITLE
:bug: WIP: Fix order of ApplyFirst markers

### DIFF
--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -113,6 +113,15 @@ func (l ListType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 
 func (l ListType) ApplyFirst() {}
 
+func (l ListType) ApplyBefore(v interface{}) bool {
+	switch v.(type) {
+	case Type:
+		return false
+	default:
+		return true
+	}
+}
+
 func (l ListMapKey) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	if schema.Type != "array" {
 		return fmt.Errorf("must apply listMapKey to an array")

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -384,6 +384,10 @@ func (m Type) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 
 func (m Type) ApplyFirst() {}
 
+func (m Type) ApplyBefore(v interface{}) bool {
+	return true
+}
+
 func (m Nullable) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	schema.Nullable = true
 	return nil

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -48,7 +48,7 @@ func (DeprecatedVersion) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Warning": markers.DetailedHelp{
+			"Warning": {
 				Summary: "message to be shown on the deprecated version",
 				Details: "",
 			},

--- a/pkg/crd/schema_test.go
+++ b/pkg/crd/schema_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"reflect"
+	"testing"
+)
+
+type alwaysApplyBefore string
+
+func (a alwaysApplyBefore) ApplyFirst() {}
+
+func (a alwaysApplyBefore) ApplyBefore(v interface{}) bool {
+	return true
+}
+
+type applyBefore string
+
+func (a applyBefore) ApplyFirst() {}
+
+func (a applyBefore) ApplyBefore(v interface{}) bool {
+	switch v.(type) {
+	case alwaysApplyBefore:
+		return false
+	default:
+		return true
+	}
+}
+
+type neverApplyBefore string
+
+func (a neverApplyBefore) ApplyFirst() {}
+
+func (a neverApplyBefore) ApplyBefore(v interface{}) bool {
+	return false
+}
+
+type applyFirst string
+
+func (a applyFirst) ApplyFirst() {}
+
+func TestSortByApplyBefore(t *testing.T) {
+	values := []interface{}{
+		neverApplyBefore("baz"),
+		applyFirst("test"),
+		applyBefore("bar"),
+		alwaysApplyBefore("foo"),
+	}
+	expected := []interface{}{
+		alwaysApplyBefore("foo"),
+		applyBefore("bar"),
+		neverApplyBefore("baz"),
+		applyFirst("test"),
+	}
+	sorted := sortByApplyBefore(values)
+	if !reflect.DeepEqual(expected, sorted) {
+		t.Fatalf("expected values to equal %+v, got: %+v", expected, sorted)
+	}
+}

--- a/pkg/schemapatcher/zz_generated.markerhelp.go
+++ b/pkg/schemapatcher/zz_generated.markerhelp.go
@@ -40,6 +40,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},
+			"GenerateEmbeddedObjectMeta": {
+				Summary: "specifies if any embedded ObjectMeta in the CRD should be generated",
+				Details: "",
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This fixes one part of the mentioned problem in #435. The other case when the type marker is on a type and not a field still remains. I'm unsure how to fix this since the marker is applied before, but it seems the type isn't modified.

I'll try to figure out why it still fails for markers on types, but a preliminary review to see if my approach is acceptable would be much appreciated.