### PR TITLE
:bug: Be more helpful with floats when allowDangerousTypes=false

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -17,6 +17,7 @@ limitations under the License.
 package crd
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/token"
@@ -427,10 +428,13 @@ func builtinToType(basic *types.Basic, allowDangerousTypes bool) (typ string, fo
 		typ = "string"
 	case basicInfo&types.IsInteger != 0:
 		typ = "integer"
-	case basicInfo&types.IsFloat != 0 && allowDangerousTypes:
-		typ = "number"
+	case basicInfo&types.IsFloat != 0:
+		if allowDangerousTypes {
+			typ = "number"
+		} else {
+			return "", "", errors.New("found float, the usage of which is highly discouraged, as support for them varies across languages. Please consider serializing your float as string instead. If you are really sure you want to use them, re-run with crd:allowDangerousTypes=true")
+		}
 	default:
-		// NB(directxman12): floats are *NOT* allowed in kubernetes APIs
 		return "", "", fmt.Errorf("unsupported type %q", basic.String())
 	}
 


### PR DESCRIPTION
Currently, we fall through and just emit an error telling that floats
are not supported which lead to ppl creating prs to add support. We
actually do support them although that is discouraged. This change makes
us emit a more helpful error.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Closes https://github.com/kubernetes-sigs/controller-tools/pull/566
Closes https://github.com/kubernetes-sigs/controller-tools/issues/245
