### PR TITLE
🐛 Updating WriteYAML to not add empty line to start files

### DIFF
--- a/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/pkg/crd/testdata/gen/bar.example.com_foos.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -135,7 +135,7 @@ func (g GenerationContext) WriteYAML(itemPath string, objs ...interface{}) error
 		if err != nil {
 			return err
 		}
-		n, err := out.Write(append([]byte("\n---\n"), yamlContent...))
+		n, err := out.Write(append([]byte("---\n"), yamlContent...))
 		if err != nil {
 			return err
 		}

--- a/pkg/webhook/parser_integration_test.go
+++ b/pkg/webhook/parser_integration_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Webhook Generation From Parsing to CustomResourceDefinition", 
 })
 
 func unmarshalBothV1(in []byte) (mutating admissionregv1.MutatingWebhookConfiguration, validating admissionregv1.ValidatingWebhookConfiguration) {
-	documents := bytes.Split(in, []byte("\n---\n"))[1:]
+	documents := bytes.Split(in, []byte("\n---\n"))
 	ExpectWithOffset(1, documents).To(HaveLen(2), "expected two documents in file, found %d", len(documents))
 
 	ExpectWithOffset(1, yaml.UnmarshalStrict(documents[0], &mutating)).To(Succeed(), "expected the first document in the file to be a mutating webhook configuration")

--- a/pkg/webhook/testdata/invalid-admissionReviewVersionsRequired/manifests.yaml
+++ b/pkg/webhook/testdata/invalid-admissionReviewVersionsRequired/manifests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -28,7 +27,6 @@ webhooks:
     resources:
     - cronjobs
   sideEffects: None
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/pkg/webhook/testdata/invalid-sideEffects/manifests.yaml
+++ b/pkg/webhook/testdata/invalid-sideEffects/manifests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -28,7 +27,6 @@ webhooks:
     resources:
     - cronjobs
   sideEffects: None
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/pkg/webhook/testdata/invalid-v1beta1NotSupported/manifests.yaml
+++ b/pkg/webhook/testdata/invalid-v1beta1NotSupported/manifests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -28,7 +27,6 @@ webhooks:
     resources:
     - cronjobs
   sideEffects: None
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/pkg/webhook/testdata/manifests.yaml
+++ b/pkg/webhook/testdata/manifests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -28,7 +27,6 @@ webhooks:
     resources:
     - cronjobs
   sideEffects: None
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/pkg/webhook/testdata/valid/manifests.yaml
+++ b/pkg/webhook/testdata/valid/manifests.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -28,7 +27,6 @@ webhooks:
     resources:
     - cronjobs
   sideEffects: None
-
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
Currently generated YAML files all have  `\n---\n` prepended to them. Although that's not an issue when using `kubectl apply` with those files, it requires extra work when trying to do something simple like parse CRD yaml from a controller. Although not a significant issue, it's caused us ([Gateway API](https://gateway-api.sigs.k8s.io/) + associated controller authors) to have to workaround it in several places. When parsing YAML files like this, the leading new line is parsed as an empty yaml struct, so we need to write code that can handle this empty/invalid object that starts all our generated YAML CRDs.

It looks like this code originated from https://github.com/kubernetes-sigs/controller-tools/pull/208, and this particular part of the change does not seem like it was intentional.

Initially I wrote this to simply not add the delimiter to the start of the file, but as @howardjohn pointed out, that would make the concatenated files invalid YAML. This change does mean that concatenating YAML files that don't have a trailing new line will not work. Of course all files generated by this tool do have a trailing new line, and that seems like a reasonable expectation of other YAML files.