### PR TITLE
✨ New kubebuilder:skipDescriptions CRD marker

### DIFF
--- a/pkg/crd/markers/skip_descriptions.go
+++ b/pkg/crd/markers/skip_descriptions.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/crd/markers/skip_descriptions.go
+++ b/pkg/crd/markers/skip_descriptions.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package markers
+
+import (
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+func init() {
+	AllDefinitions = append(AllDefinitions,
+		must(markers.MakeDefinition("kubebuilder:skipDescriptions", markers.DescribesField, SkipDescriptionsOnField{})).
+			WithHelp(markers.SimpleHelp("CRD processing", "sets empty descriptions for nested properties of a field, recursively.")),
+
+		must(markers.MakeDefinition("kubebuilder:skipDescriptions", markers.DescribesPackage, SkipDescriptionsOnPackage{})).
+			WithHelp(markers.SimpleHelp("CRD processing", "sets empty descriptions for all types in a package, recursively.")),
+	)
+}
+
+type SkipDescriptionsOnField struct{}
+
+func (s SkipDescriptionsOnField) PostFlatten() {}
+
+func (s SkipDescriptionsOnField) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	applyToSchemaProperties(schema)
+	return nil
+}
+
+type SkipDescriptionsOnPackage struct{}
+
+func (s SkipDescriptionsOnPackage) PostFlatten() {}
+
+func (s SkipDescriptionsOnPackage) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	clearPropDescriptionRecurse(schema)
+	return nil
+}
+
+func applyToSchemaProperties(schema *apiext.JSONSchemaProps) {
+	for name := range schema.Properties {
+		value := schema.Properties[name]
+		clearPropDescriptionRecurse(&value)
+		schema.Properties[name] = value
+	}
+}
+
+func clearPropDescriptionRecurse(schema *apiext.JSONSchemaProps) {
+	schema.Description = ""
+	applyToSchemaProperties(schema)
+}

--- a/pkg/crd/markers_integration_test.go
+++ b/pkg/crd/markers_integration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/crd/markers_integration_test.go
+++ b/pkg/crd/markers_integration_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-tools/pkg/crd"
+	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
+	"sigs.k8s.io/controller-tools/pkg/genall"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var _ = DescribeTable("CRD Generation marker handling", testMarkers,
+	TableEntry{
+		Description: "skipDescriptions on field",
+		Parameters: []interface{}{
+			filepath.Join("skipdescriptions", "onfield"),
+			"example.com_testresources.yaml",
+		},
+	},
+	TableEntry{
+		Description: "skipDescriptions on package",
+		Parameters: []interface{}{
+			filepath.Join("skipdescriptions", "onpackage"),
+			"example.com_testresources.yaml",
+		},
+	},
+)
+
+// testMarkers is a Ginkgo It() body that runs the CRD generator in a directory and expects
+// the output to match the contents of a file.
+func testMarkers(testdataDirname, expectedFilename string) {
+	workDir := filepath.Join("testdata", "markers", testdataDirname)
+
+	By("switching into testdata to appease go modules")
+	cwd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(os.Chdir(workDir)).To(Succeed()) // go modules are directory-sensitive
+	defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+	By("loading the roots")
+	pkgs, err := loader.LoadRoots(".")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(pkgs).To(HaveLen(1))
+
+	By("setup up the context")
+	reg := &markers.Registry{}
+	Expect(crdmarkers.Register(reg)).To(Succeed())
+	out := &inMemoryOutput{}
+	ctx := &genall.GenerationContext{
+		Collector:  &markers.Collector{Registry: reg},
+		Roots:      pkgs,
+		Checker:    &loader.TypeChecker{},
+		OutputRule: out,
+	}
+
+	By("calling Generate")
+	gen := &crd.Generator{
+		CRDVersions: []string{"v1"},
+	}
+	Expect(gen.Generate(ctx)).To(Succeed())
+
+	By("loading the desired YAML")
+	expectedFile, err := ioutil.ReadFile(expectedFilename)
+	Expect(err).NotTo(HaveOccurred())
+	expectedFile = bytes.Replace(expectedFile, []byte("(devel)"), []byte("(unknown)"), 1)
+
+	By("comparing the output to the desired YAML")
+	Expect(out.body).To(Equal(string(expectedFile)), cmp.Diff(out.body, string(expectedFile)))
+}
+
+var _ genall.OutputRule = &inMemoryOutput{}
+
+type inMemoryOutput struct {
+	body string
+}
+
+func (o *inMemoryOutput) Open(*loader.Package, string) (io.WriteCloser, error) {
+	return &bufferedInMemoryWriter{inMemoryOutput: o}, nil
+}
+
+type bufferedInMemoryWriter struct {
+	bytes.Buffer
+	inMemoryOutput *inMemoryOutput
+}
+
+func (w *bufferedInMemoryWriter) Close() error {
+	w.inMemoryOutput.body = w.Buffer.String()
+	return nil
+}

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -126,6 +126,10 @@ func applyMarkers(ctx *schemaContext, markerSet markers.MarkerValues, props *api
 	// apply "apply first" markers first...
 	for _, markerValues := range markerSet {
 		for _, markerValue := range markerValues {
+			if _, isPostFlatten := markerValue.(PostFlattenMarker); isPostFlatten {
+				continue
+			}
+
 			if _, isApplyFirst := markerValue.(applyFirstMarker); !isApplyFirst {
 				continue
 			}
@@ -144,6 +148,10 @@ func applyMarkers(ctx *schemaContext, markerSet markers.MarkerValues, props *api
 	// ...then the rest of the markers
 	for _, markerValues := range markerSet {
 		for _, markerValue := range markerValues {
+			if _, isPostFlatten := markerValue.(PostFlattenMarker); isPostFlatten {
+				continue
+			}
+
 			if _, isApplyFirst := markerValue.(applyFirstMarker); isApplyFirst {
 				// skip apply-first markers, which were already applied
 				continue

--- a/pkg/crd/schema_post_flatten.go
+++ b/pkg/crd/schema_post_flatten.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/crd/schema_post_flatten.go
+++ b/pkg/crd/schema_post_flatten.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"fmt"
+	"strings"
+
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+// PostFlattenMarker is a marker that gets applied after the schema is flattened, where all nested
+// properties are available for the marker to use.
+type PostFlattenMarker interface {
+	PostFlatten()
+}
+
+// postFlattenSchema updates an existing schema that has already been flattened, where all nested
+// properties are available for markers to use.
+func postFlattenSchema(ctx *schemaContext, props *apiext.JSONSchemaProps) {
+	applySchemaMarkers(ctx, ctx.info.RawSpec, getPostFlattenSchemaMarkers(ctx.PackageMarkers), props)
+	applySchemaMarkers(ctx, ctx.info.RawSpec, getPostFlattenSchemaMarkers(ctx.info.Markers), props)
+
+	for _, field := range ctx.info.Fields {
+		fieldMarkers := getPostFlattenSchemaMarkers(field.Markers)
+		if len(fieldMarkers) == 0 {
+			continue
+		}
+
+		jsonTag, hasTag := field.Tag.Lookup("json")
+		if !hasTag {
+			// if the field doesn't have a JSON tag, it doesn't belong in output (and shouldn't exist in a serialized type)
+			ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("encountered struct field %q without JSON tag in type %q", field.Name, ctx.info.Name), field.RawField))
+			continue
+		}
+
+		fieldName := strings.SplitN(jsonTag, ",", 2)[0]
+
+		fieldProps, hasFieldProps := props.Properties[fieldName]
+		if !hasFieldProps {
+			var names []string
+			for name := range fieldMarkers {
+				names = append(names, name)
+			}
+
+			encountered := "a marker"
+			if len(names) > 1 {
+				encountered = "markers"
+			}
+
+			err := fmt.Errorf("encountered %s which may not be used on inline JSON struct fields, on field %q in type %q: %v", encountered, field.Name, ctx.info.Name, names)
+			ctx.pkg.AddError(loader.ErrFromNode(err, field.RawField))
+		}
+
+		applySchemaMarkers(ctx, field.RawField, fieldMarkers, &fieldProps)
+
+		props.Properties[fieldName] = fieldProps
+	}
+}
+
+// getPostFlattenSchemaMarkers returns a filtered slice of markers that are both PostFlattenMarker
+// and SchemaMarker types.
+func getPostFlattenSchemaMarkers(markerSet markers.MarkerValues) map[string][]SchemaMarker {
+	result := make(map[string][]SchemaMarker)
+
+	for name, markerValues := range markerSet {
+		for _, markerValue := range markerValues {
+			if _, isPostFlattenMarker := markerValue.(PostFlattenMarker); !isPostFlattenMarker {
+				continue
+			}
+
+			schemaMarker, isSchemaMarker := markerValue.(SchemaMarker)
+			if !isSchemaMarker {
+				continue
+			}
+
+			result[name] = append(result[name], schemaMarker)
+		}
+	}
+
+	return result
+}
+
+// applySchemaMarkers applies SchemaMarker schema markers to the given schema.
+func applySchemaMarkers(ctx *schemaContext, node loader.Node, markerSet map[string][]SchemaMarker, props *apiext.JSONSchemaProps) {
+	for _, markerValues := range markerSet {
+		for _, markerValue := range markerValues {
+			if err := markerValue.ApplyToSchema(props); err != nil {
+				ctx.pkg.AddError(loader.ErrFromNode(err, node))
+			}
+		}
+	}
+}

--- a/pkg/crd/testdata/markers/skipdescriptions/onfield/example.com_testresources.yaml
+++ b/pkg/crd/testdata/markers/skipdescriptions/onfield/example.com_testresources.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    listKind: TestResourceList
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TestResource type description.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          havingDescription:
+            description: HavingDescription field description.
+            properties:
+              foo:
+                description: Foo field description.
+                type: string
+            required:
+            - foo
+            type: object
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          notHavingDescription:
+            description: NotHavingDescription field description.
+            properties:
+              bar:
+                type: string
+              notHavingDescriptionEmbedded:
+                properties:
+                  baz:
+                    type: string
+                required:
+                - baz
+                type: object
+            required:
+            - bar
+            - notHavingDescriptionEmbedded
+            type: object
+        required:
+        - havingDescription
+        - notHavingDescription
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/crd/testdata/markers/skipdescriptions/onfield/types.go
+++ b/pkg/crd/testdata/markers/skipdescriptions/onfield/types.go
@@ -1,0 +1,58 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:generate ../../../../../../.run-controller-gen.sh crd:crdVersions=v1 paths=. output:dir=.
+
+// +groupName=example.com
+// +versionName=v1
+package onfield
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestResource type description.
+type TestResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// HavingDescription field description.
+	HavingDescription HavingDescription `json:"havingDescription"`
+
+	// NotHavingDescription field description.
+	// +kubebuilder:skipDescriptions
+	NotHavingDescription NotHavingDescription `json:"notHavingDescription"`
+}
+
+// HavingDescription type description.
+type HavingDescription struct {
+	// Foo field description.
+	Foo string `json:"foo"`
+}
+
+// NotHavingDescription type description.
+type NotHavingDescription struct {
+	// Bar field description.
+	Bar string `json:"bar"`
+
+	// NotHavingDescriptionEmbedded field description.
+	NotHavingDescriptionEmbedded NotHavingDescriptionEmbedded `json:"notHavingDescriptionEmbedded"`
+}
+
+// NotHavingDescriptionEmbedded type description.
+type NotHavingDescriptionEmbedded struct {
+	// Baz field description.
+	Baz string `json:"baz"`
+}

--- a/pkg/crd/testdata/markers/skipdescriptions/onpackage/example.com_testresources.yaml
+++ b/pkg/crd/testdata/markers/skipdescriptions/onpackage/example.com_testresources.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: testresources.example.com
+spec:
+  group: example.com
+  names:
+    kind: TestResource
+    listKind: TestResourceList
+    plural: testresources
+    singular: testresource
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          havingDescription:
+            properties:
+              foo:
+                type: string
+            required:
+            - foo
+            type: object
+          kind:
+            type: string
+          metadata:
+            type: object
+          notHavingDescription:
+            properties:
+              bar:
+                type: string
+              notHavingDescriptionEmbedded:
+                properties:
+                  baz:
+                    type: string
+                required:
+                - baz
+                type: object
+            required:
+            - bar
+            - notHavingDescriptionEmbedded
+            type: object
+        required:
+        - havingDescription
+        - notHavingDescription
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/crd/testdata/markers/skipdescriptions/onpackage/types.go
+++ b/pkg/crd/testdata/markers/skipdescriptions/onpackage/types.go
@@ -1,0 +1,58 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:generate ../../../../../../.run-controller-gen.sh crd:crdVersions=v1 paths=. output:dir=.
+
+// +groupName=example.com
+// +versionName=v1
+// +kubebuilder:skipDescriptions
+package onpackage
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestResource type description.
+type TestResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// HavingDescription field description.
+	HavingDescription HavingDescription `json:"havingDescription"`
+
+	// NotHavingDescription field description.
+	NotHavingDescription NotHavingDescription `json:"notHavingDescription"`
+}
+
+// HavingDescription type description.
+type HavingDescription struct {
+	// Foo field description.
+	Foo string `json:"foo"`
+}
+
+// NotHavingDescription type description.
+type NotHavingDescription struct {
+	// Bar field description.
+	Bar string `json:"bar"`
+
+	// NotHavingDescriptionEmbedded field description.
+	NotHavingDescriptionEmbedded NotHavingDescriptionEmbedded `json:"notHavingDescriptionEmbedded"`
+}
+
+// NotHavingDescriptionEmbedded type description.
+type NotHavingDescriptionEmbedded struct {
+	// Baz field description.
+	Baz string `json:"baz"`
+}


### PR DESCRIPTION
Signed-off-by: Adam Snyder <armsnyder@gmail.com>

### Overview

Closes #441 

I added a new marker `kubebuilder:skipDescriptions`. When added to a field it skips adding property descriptions for all nested properties under that field, recursively. When added to a package it skips adding property descriptions for all types in the package, recursively.

The benefit of this marker is it allows a user to embed types from external packages without causing the types to generate descriptions.

### Details

I had trouble implementing this because the marker system currently can only process one type at a time, meaning that markers do not have access to nested properties. This was a problem for removing descriptions in imported packages.

My solution was a new marker interface `PostFlattenMarker` that a marker can implement so that it gets invoked much later, after the JSON schema has been flattened.

### How this was tested

I added integration tests for both the package-type and field-type `kubebuilder:skipDescriptions` marker. The tests are modeled after the existing `gen_integration_test.go` test. They check the controller-gen output against go-generated CRD files.

(Half of this PR diff is testdata files.)