### PR TITLE
🐛 add generateName in ObjectMeta

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -153,6 +153,9 @@ var ObjectMetaPackages = map[string]PackageOverride{
 						},
 					},
 				},
+				"generateName": {
+					Type: "string",
+				},
 			},
 		}
 	},


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
Sometimes `GenerateName` will be set to generate a unique name ONLY IF the `Name` field has not been provided.
