### PR TITLE
🐛 Fixed panic when parsing selector expressions containing composite literals

### DIFF
--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -193,6 +193,12 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self.size() % 2 == 0",message="must have even length"
 	// +kubebuilder:validation:XValidation:rule="true"
 	StringWithEvenLength string `json:"stringWithEvenLength,omitempty"`
+
+	// Checks that fixed-length arrays work
+	Array [3]int `json:"array,omitempty"`
+
+	// Checks that arrays work when the type contains a composite literal
+	ArrayUsingCompositeLiteral [len(struct{ X [3]int }{}.X)]string `json:"arrayUsingCompositeLiteral,omitempty"`
 }
 
 type ContainsNestedMap struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -35,6 +35,17 @@ spec:
           spec:
             description: CronJobSpec defines the desired state of CronJob
             properties:
+              array:
+                description: Checks that fixed-length arrays work
+                items:
+                  type: integer
+                type: array
+              arrayUsingCompositeLiteral:
+                description: Checks that arrays work when the type contains a composite
+                  literal
+                items:
+                  type: string
+                type: array
               associativeList:
                 description: This tests that associative lists work.
                 items:

--- a/pkg/loader/refs.go
+++ b/pkg/loader/refs.go
@@ -133,9 +133,14 @@ func (c *referenceCollector) Visit(node ast.Node) ast.Visitor {
 		// local reference or dot-import, ignore
 		return nil
 	case *ast.SelectorExpr:
-		pkgName := typedNode.X.(*ast.Ident).Name
-		c.refs.external(pkgName)
-		return nil
+		switch x := typedNode.X.(type) {
+		case *ast.Ident:
+			pkgName := x.Name
+			c.refs.external(pkgName)
+			return nil
+		default:
+			return c
+		}
 	default:
 		return c
 	}


### PR DESCRIPTION
This fixes #613 

Signed-off-by: Joe Kralicky <joe.kralicky@suse.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
