### PR TITLE
:seedling: Update cronjob_types.go go:generate invocation and re-generate.

### DIFF
--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 // TODO(directxman12): test this across both versions (right now we're just
 // trusting k/k conversion, which is probably fine though)
 
-//go:generate ../../../.run-controller-gen.sh crd paths=./;./deprecated;./unserved output:dir=.
+//go:generate ../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true paths=./;./deprecated;./unserved output:dir=.
 
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -56,7 +56,8 @@ spec:
                 - secondary
                 x-kubernetes-list-type: map
               baz:
-                description: This tests that exported fields are not skipped in the schema generation
+                description: This tests that exported fields are not skipped in the
+                  schema generation
                 type: string
               binaryName:
                 description: This tests byte slice schema generation.
@@ -127,6 +128,10 @@ spec:
                   a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
+              foo:
+                description: This tests that exported fields are not skipped in the
+                  schema generation
+                type: string
               intOrStringWithAPattern:
                 anyOf:
                 - type: integer
@@ -137,9 +142,6 @@ spec:
                   for having a pattern on this type.
                 pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
                 x-kubernetes-int-or-string: true
-              foo:
-                description: This tests that exported fields are not skipped in the schema generation
-                type: string
               jobTemplate:
                 description: Specifies the job that will be created when executing
                   a CronJob.


### PR DESCRIPTION
This invocation now requires ignoreUnexportedFields=true. Regenerating
it produces a field-ordering- and whitespace-only manifest diff, but
the integration tests are only concerned with significant differences.
