### PR TITLE
🏃 Update to Flect v0.2.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/fatih/color v1.12.0
-	github.com/gobuffalo/flect v0.2.3
+	github.com/gobuffalo/flect v0.2.5
 	github.com/google/go-cmp v0.5.6
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/gobuffalo/flect v0.2.3 h1:f/ZukRnSNA/DUpSNDadko7Qc0PhGvsew35p/2tu+CRY=
-github.com/gobuffalo/flect v0.2.3/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
+github.com/gobuffalo/flect v0.2.5 h1:H6vvsv2an0lalEaCDRThvtBfmg44W/QHXBCYUXf/6S4=
+github.com/gobuffalo/flect v0.2.5/go.mod h1:1ZyCLIbg0YD7sDkzvFdPoOydPtD8y9JQnrOROolUcM8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=


### PR DESCRIPTION
### Overview
This PR bumps [flect](https://github.com/gobuffalo/flect) dependency -- used for [Pluralize](https://github.com/kubernetes-sigs/controller-tools/blob/ea8d4ead3e34dac7bb792cedc6d3cd7decf63137/pkg/typescaffold/resource.go#L45) logic -- to the latest version, [`v0.2.5`](https://github.com/gobuffalo/flect/releases/tag/v0.2.5). 

### Why is this needed
I am having issues generating a controller for a resource, `Fleet`, because Flect does not pluralize it correctly. The latest release includes a [fix to correctly pluralize `Fleet`](https://github.com/gobuffalo/flect/pull/54) (and similar words).