### PR TITLE
:bug: Fix inconsistency the introduced in go 1.18

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,7 +23,7 @@ import (
 // Version returns the version of the main module
 func Version() string {
 	info, ok := debug.ReadBuildInfo()
-	if !ok {
+	if !ok || info.Main.Version == "" {
 		// binary has not been built with module support
 		return "(unknown)"
 	}


### PR DESCRIPTION
Go changed the results of the `ReadBuildInfo` in go 1.18. Now it always returns information also for modules

For more information on the use-case see
https://github.com/kubernetes-sigs/kubebuilder/pull/2561#discussion_r855087428
