### PR TITLE
✨Bumped go 1.18 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-tools
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fatih/color v1.12.0

--- a/pkg/loader/testmod/go.mod
+++ b/pkg/loader/testmod/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-tools/pkg/loader/testmod
 
-go 1.17
+go 1.18
 
 replace sigs.k8s.io/controller-tools/pkg/loader/testmod/submod1 => ./submod1
 

--- a/pkg/loader/testmod/subdir1/submod1/go.mod
+++ b/pkg/loader/testmod/subdir1/submod1/go.mod
@@ -1,3 +1,3 @@
 module sigs.k8s.io/controller-tools/pkg/loader/testmod/subdir1/submod1
 
-go 1.17
+go 1.18

--- a/pkg/loader/testmod/submod1/go.mod
+++ b/pkg/loader/testmod/submod1/go.mod
@@ -1,3 +1,3 @@
 module sigs.k8s.io/controller-tools/pkg/loader/testmod/submod1
 
-go 1.17
+go 1.18


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
### Description
Bumped go 1.18 to get a new release and for adding it to https://github.com/kubernetes-sigs/kubebuilder.