### PR TITLE
:bug: ci: fix golangci-lint installation

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -100,7 +100,7 @@ function setup_envs {
 header_text "using tools"
 
 if ! which golangci-lint 2>&1 >/dev/null; then
-  curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
   export PATH=$PATH:$(go env GOPATH)/bin
 fi
 


### PR DESCRIPTION
`install.goreleaser.com` is now deprecated and stopped working so the tests
in new PRs are failing. Instructions are from https://golangci-lint.run/usage/install/#other-ci.