### PR TITLE
:bug: Allow setting PreserveUnknownFields at both type and field level

### DIFF
--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -143,6 +143,8 @@ func flattenAllOfInto(dst *apiext.JSONSchemaProps, src apiext.JSONSchemaProps, e
 				dstProps.Schema = &apiext.JSONSchemaProps{}
 			}
 			flattenAllOfInto(dstProps.Schema, *srcProps.Schema, errRec)
+		case "XPreserveUnknownFields":
+			dstField.Set(srcField)
 		// NB(directxman12): no need to explicitly handle nullable -- false is considered to be the zero value
 		// TODO(directxman12): src isn't necessarily the field value -- it's just the most recent allOf entry
 		default:

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -134,8 +134,12 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:nullable
 	UnprunedEmbeddedResource runtime.RawExtension `json:"unprunedEmbeddedResource"`
 
-	// This tests that a type-level pruning maker works.
+	// This tests that a type-level pruning marker works.
 	UnprunedFromType Preserved `json:"unprunedFomType"`
+
+	// This tests that a type-level pruning marker combined with a field-level pruning marker works.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	UnprunedFromTypeAndField Preserved `json:"unprunedFomTypeAndField"`
 
 	// This tests that associative lists work.
 	// +listType=map

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -7344,7 +7344,12 @@ spec:
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
               unprunedFomType:
-                description: This tests that a type-level pruning maker works.
+                description: This tests that a type-level pruning marker works.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              unprunedFomTypeAndField:
+                description: This tests that a type-level pruning marker combined
+                  with a field-level pruning marker works.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               unprunedJSON:
@@ -7381,6 +7386,7 @@ spec:
             - twoOfAKindPart1
             - unprunedEmbeddedResource
             - unprunedFomType
+            - unprunedFomTypeAndField
             - unprunedJSON
             type: object
           status:


### PR DESCRIPTION
This PR allows setting `PreserveUnknownFields` at both type and field level.

Fixes #688 