### PR TITLE
🐛 Fix crd flattening for XMapType to not duplicate entries

### DIFF
--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -145,6 +145,8 @@ func flattenAllOfInto(dst *apiext.JSONSchemaProps, src apiext.JSONSchemaProps, e
 			flattenAllOfInto(dstProps.Schema, *srcProps.Schema, errRec)
 		case "XPreserveUnknownFields":
 			dstField.Set(srcField)
+		case "XMapType":
+			dstField.Set(srcField)
 		// NB(directxman12): no need to explicitly handle nullable -- false is considered to be the zero value
 		// TODO(directxman12): src isn't necessarily the field value -- it's just the most recent allOf entry
 		default:

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -7278,9 +7278,6 @@ spec:
                 description: Checks that multiply-nested maps work
                 type: object
               nestedStructWithSeveralFields:
-                allOf:
-                - x-kubernetes-map-type: atomic
-                - x-kubernetes-map-type: atomic
                 description: A struct that can only be entirely replaced via a nested
                   type.
                 properties:
@@ -7292,6 +7289,7 @@ spec:
                 - bar
                 - foo
                 type: object
+                x-kubernetes-map-type: atomic
               nestedassociativeList:
                 description: This tests that associative lists work via a nested type.
                 items:


### PR DESCRIPTION
Bug was introduced in #693.

As outlined in https://github.com/kubernetes-sigs/controller-tools/pull/693#issuecomment-1169433662 , #693 introduced the bug that `x-kubernetes-map-type` may now get set twice and thus result in two entries in `allOf`.

This is because before #693 the marker at the type definition was simply ignored but now they got combined.

This PR fixes the flattening to handle this case for the `structType` marker.

A similar fix for the markers `mapType`, `listType` and `listMapKey` is not necessary because setting them where the type is referenced would result in an error anyway. Before #693 this was also the case, but since #693 it is possible to set them at the type definition.