### PR TITLE
🐛 Fix crd flattening for structType marker to not create duplicate entries for XMapType

### DIFF
--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -143,6 +143,8 @@ func flattenAllOfInto(dst *apiext.JSONSchemaProps, src apiext.JSONSchemaProps, e
 				dstProps.Schema = &apiext.JSONSchemaProps{}
 			}
 			flattenAllOfInto(dstProps.Schema, *srcProps.Schema, errRec)
+		case "XMapType":
+			dstField.Set(srcField)
 		// NB(directxman12): no need to explicitly handle nullable -- false is considered to be the zero value
 		// TODO(directxman12): src isn't necessarily the field value -- it's just the most recent allOf entry
 		default:

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -7277,9 +7277,6 @@ spec:
                 description: Checks that multiply-nested maps work
                 type: object
               nestedStructWithSeveralFields:
-                allOf:
-                - x-kubernetes-map-type: atomic
-                - x-kubernetes-map-type: atomic
                 description: A struct that can only be entirely replaced via a nested
                   type.
                 properties:
@@ -7291,6 +7288,7 @@ spec:
                 - bar
                 - foo
                 type: object
+                x-kubernetes-map-type: atomic
               nestedassociativeList:
                 description: This tests that associative lists work via a nested type.
                 items:


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/kubernetes-sigs/controller-tools/pull/697

<!-- What does this do, and why do we need it? -->
