### PR TITLE
:sparkles: testdata/cronjob_types.go: add NestedStructWithSeveralFieldsDoubleMarked

### DIFF
--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -162,7 +162,6 @@ type CronJobSpec struct {
 	StructWithSeveralFields NestedObject `json:"structWithSeveralFields"`
 
 	// A struct that can only be entirely replaced via a nested type.
-	// +structType=atomic
 	NestedStructWithSeveralFields NestedStructWithSeveralFields `json:"nestedStructWithSeveralFields"`
 
 	// This tests that type references are properly flattened

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -164,6 +164,11 @@ type CronJobSpec struct {
 	// A struct that can only be entirely replaced via a nested type.
 	NestedStructWithSeveralFields NestedStructWithSeveralFields `json:"nestedStructWithSeveralFields"`
 
+	// A struct that can only be entirely replaced via a nested type and
+	// field markers.
+	// +structType=atomic
+	NestedStructWithSeveralFieldsDoubleMarked NestedStructWithSeveralFields `json:"nestedStructWithSeveralFieldsDoubleMarked"`
+
 	// This tests that type references are properly flattened
 	// +kubebuilder:validation:optional
 	JustNestedObject *JustNestedObject `json:"justNestedObject,omitempty"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -7290,6 +7290,19 @@ spec:
                 - foo
                 type: object
                 x-kubernetes-map-type: atomic
+              nestedStructWithSeveralFieldsDoubleMarked:
+                description: A struct that can only be entirely replaced via a nested
+                  type and field markers.
+                properties:
+                  bar:
+                    type: boolean
+                  foo:
+                    type: string
+                required:
+                - bar
+                - foo
+                type: object
+                x-kubernetes-map-type: atomic
               nestedassociativeList:
                 description: This tests that associative lists work via a nested type.
                 items:
@@ -7423,6 +7436,7 @@ spec:
             - mapOfInfo
             - nestedMapOfInfo
             - nestedStructWithSeveralFields
+            - nestedStructWithSeveralFieldsDoubleMarked
             - nestedassociativeList
             - patternObject
             - schedule


### PR DESCRIPTION
This adds a field to the cronjob test data, that ensures that fields
which are marked twice (once through a type marker, one through a field
marker) still generate the correct yaml structure.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
