### PR TITLE
:running: golangci-lint: use revive instead of golint linter

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -120,7 +120,7 @@ header_text "running golangci-lint"
 
 golangci-lint run --disable-all \
     --enable=misspell \
-    --enable=golint \
+    --enable=revive \
     --enable=govet \
     --enable=deadcode \
     --enable=goimports \


### PR DESCRIPTION
test.sh triggers a warning:
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The
repository of the linter has been archived by the owner.  Replaced by revive.

Change the script accordingly.