### PR TITLE
 🐛 Update CI golangci-lint checks to avoid deprecated linters

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -122,10 +122,9 @@ golangci-lint run --disable-all \
     --enable=misspell \
     --enable=revive \
     --enable=govet \
-    --enable=deadcode \
+    --enable=unused \
     --enable=goimports \
     --enable=errcheck \
-    --enable=varcheck \
     --enable=unparam \
     --enable=ineffassign \
     --enable=nakedret \


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->
```
running golangci-lint
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```

Fixes linter warnings. Replaced the deprecated linters with unused.

/assign @camilamacedo86 