### PR TITLE
🐛 Ensure schemapatcher does not error when non CRD yaml files are present

### DIFF
--- a/pkg/schemapatcher/gen.go
+++ b/pkg/schemapatcher/gen.go
@@ -358,11 +358,15 @@ func crdsFromDirectory(ctx *genall.GenerationContext, dir string) (map[schema.Gr
 		if err := kyaml.Unmarshal(rawContent, &typeMeta); err != nil {
 			continue
 		}
+
+		if typeMeta.APIVersion == "" || typeMeta.Kind != "CustomResourceDefinition" {
+			// If there's no API version this file probably isn't a CRD.
+			// Likewise we don't need to care if the Kind isn't CustomResourceDefinition.
+			continue
+		}
+
 		if !isSupportedAPIExtGroupVer(typeMeta.APIVersion) {
 			return nil, fmt.Errorf("load %q: apiVersion %q not supported", filepath.Join(dir, fileInfo.Name()), typeMeta.APIVersion)
-		}
-		if typeMeta.Kind != "CustomResourceDefinition" {
-			continue
 		}
 
 		// collect the group-kind and versions from the actual structured form

--- a/pkg/schemapatcher/testdata/valid/example.cr.yaml
+++ b/pkg/schemapatcher/testdata/valid/example.cr.yaml
@@ -1,0 +1,3 @@
+# This is an example of the resource defined in this package.
+apiVersion: kubebuilder.schemapatcher.controller-tools.sigs.k8s.io/v1
+kind: Example

--- a/pkg/schemapatcher/testdata/valid/random.yaml
+++ b/pkg/schemapatcher/testdata/valid/random.yaml
@@ -1,0 +1,1 @@
+name: This is a random YAML file to ensure the generator doesn't error with non-kube YAML files.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
While trying to add some example and additional YAML files to my API directory, eg schemas for other tools unrelated to controller-gen, I noticed that the generator would error out because there were files it didn't think were CRDs
```
load "example/v1/stable.testsuite.yaml": apiVersion "" not supported
Error: not all generators ran successfully
```

This patch moves the check for the Kind ahead of the check for the supported group version, this means that even if we find a type meta whose Kind is empty or not a CustomResourceDefintion, that we just ignore the file. Likewise if the API version is empty, we can ignore it, it's probably not a valid kube like file.
