### PR TITLE
:bug: return a bit more verbosy error messages for go-package errors

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -404,7 +404,11 @@ func LoadRootsWithConfig(cfg *packages.Config, roots ...string) ([]*Package, err
 	loadPackages := func(roots ...string) ([]*Package, error) {
 		rawPkgs, err := packages.Load(l.cfg, roots...)
 		if err != nil {
-			return nil, fmt.Errorf("error in %s: %w", l.cfg.Dir, err)
+			loadRoot := l.cfg.Dir
+			if l.cfg.Dir == "" {
+				loadRoot, _ = os.Getwd()
+			}
+			return nil, fmt.Errorf("load packages in root %q: %w", loadRoot, err)
 		}
 		var pkgs []*Package
 		for _, rp := range rawPkgs {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -404,7 +404,7 @@ func LoadRootsWithConfig(cfg *packages.Config, roots ...string) ([]*Package, err
 	loadPackages := func(roots ...string) ([]*Package, error) {
 		rawPkgs, err := packages.Load(l.cfg, roots...)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error in %s: %w", l.cfg.Dir, err)
 		}
 		var pkgs []*Package
 		for _, rp := range rawPkgs {


### PR DESCRIPTION
When having sub-packages, and one of them is out of sync, we might get an error such as:
```
err: exit status 1: stderr: go: updates to go.mod needed; to update it:
        go mod tidy
```

Although this error is true, it was a nightmare to debug it and figure out that it was related to a sub-package.


This PR introduces a bit more verbosy error message that can help you to debug the issue:
```
Error: error in /Users/AlmogBaku/projects/myproject/subpackage: err: exit status 1: stderr: go: updates to go.mod needed; to update it:
        go mod tidy
```
