### PR TITLE
:bug: output: ensure the directory exists

### DIFF
--- a/pkg/genall/output.go
+++ b/pkg/genall/output.go
@@ -103,7 +103,7 @@ type OutputToDirectory string
 
 func (o OutputToDirectory) Open(_ *loader.Package, itemPath string) (io.WriteCloser, error) {
 	// ensure the directory exists
-	if err := os.MkdirAll(string(o), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(string(o), itemPath)), os.ModePerm); err != nil {
 		return nil, err
 	}
 	path := filepath.Join(string(o), itemPath)


### PR DESCRIPTION
When using +output:dir=./something and attempting to write a nested path, the current implementation does not work.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
