### PR TITLE
:bug: Fix the generation of listType=set

### DIFF
--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -114,6 +114,13 @@ func (l ListType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	if l != "map" && l != "atomic" && l != "set" {
 		return fmt.Errorf(`ListType must be either "map", "set" or "atomic"`)
 	}
+
+	if l == "set" {
+		if itemSchema := schema.Items.Schema; itemSchema != nil {
+			v := "atomic"
+			itemSchema.XMapType = &v
+		}
+	}
 	p := string(l)
 	schema.XListType = &p
 	return nil

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -233,6 +233,11 @@ type CronJobSpec struct {
 
 	// Checks that arrays work when the type contains a composite literal
 	ArrayUsingCompositeLiteral [len(struct{ X [3]int }{}.X)]string `json:"arrayUsingCompositeLiteral,omitempty"`
+
+	// Tests the generation of a set list type
+	// +listType=set
+	// +optional
+	Set []string `json:"set,omitempty"`
 }
 
 type ContainsNestedMap struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/controller-tools
     cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: cronjobs.testdata.kubebuilder.io
 spec:
@@ -7330,6 +7330,13 @@ spec:
                 type: string
               schemaless:
                 description: This tests that the schemaless marker works
+              set:
+                description: Tests the generation of a set list type
+                items:
+                  type: string
+                  x-kubernetes-map-type: atomic
+                type: array
+                x-kubernetes-list-type: set
               startingDeadlineSeconds:
                 description: Optional deadline in seconds for starting the job if
                   it misses scheduled time for any reason.  Missed jobs executions


### PR DESCRIPTION
It has to have x-kubernetes-map-type: atomic set.

Fixes https://github.com/kubernetes-sigs/controller-tools/issues/752

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
