### PR TITLE
add support for oneOf

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -80,6 +80,9 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 	must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional, if fields are required by default.")),
 
+	must(markers.MakeDefinition("kubebuilder:validation:OneOf", markers.DescribesField, struct{}{})).
+		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is part of a oneOf group")),
+
 	must(markers.MakeDefinition("nullable", markers.DescribesField, Nullable{})).
 		WithHelp(Nullable{}.Help()),
 


### PR DESCRIPTION
Cargo culted from github.com/kubernetes-sigs/controller-tools/pull/298 (with some vetting), it looks correct.

The only concern is described in point C of [this comment](https://github.com/kubernetes-sigs/controller-tools/pull/298#issuecomment-518826515), but I don't know if a non-structural schema can actually be generated with this logic.