### PR TITLE
:book: fix typo: minimun -> minimum

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -173,7 +173,7 @@ type Pattern string
 type MaxItems int
 
 // +controllertools:marker:generateHelp:category="CRD validation"
-// MinItems specifies the minimun length for this list.
+// MinItems specifies the minimum length for this list.
 type MinItems int
 
 // +controllertools:marker:generateHelp:category="CRD validation"

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -218,7 +218,7 @@ func (MinItems) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
-			Summary: "specifies the minimun length for this list.",
+			Summary: "specifies the minimum length for this list.",
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},


### PR DESCRIPTION
fix typo `minimun` -> `minimum` that appears in the kubebuilder book marker validation page