### PR TITLE
:bug: Change the type of `markers.Collector.byPackage`'s key from `string` to `*loader.Package`

### DIFF
--- a/pkg/crd/testdata/multiple_versions/common.go
+++ b/pkg/crd/testdata/multiple_versions/common.go
@@ -1,0 +1,10 @@
+package multiple_versions
+
+type InnerStruct struct {
+	Foo string `json:"foo,omitempty"`
+}
+
+type OuterStruct struct {
+	// +structType=atomic
+	Struct InnerStruct `json:"struct,omitempty"`
+}

--- a/pkg/crd/testdata/multiple_versions/testdata.kubebuilder.io_versionedresources.yaml
+++ b/pkg/crd/testdata/multiple_versions/testdata.kubebuilder.io_versionedresources.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  creationTimestamp: null
+  name: versionedresources.testdata.kubebuilder.io
+spec:
+  group: testdata.kubebuilder.io
+  names:
+    kind: VersionedResource
+    listKind: VersionedResourceList
+    plural: versionedresources
+    singular: versionedresource
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              struct:
+                properties:
+                  struct:
+                    properties:
+                      foo:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              struct:
+                properties:
+                  struct:
+                    properties:
+                      foo:
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/crd/testdata/multiple_versions/v1beta1/types.go
+++ b/pkg/crd/testdata/multiple_versions/v1beta1/types.go
@@ -1,0 +1,45 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+package v1beta1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	multiver "testdata.kubebuilder.io/cronjob/multiple_versions"
+)
+
+type VersionedResourceSpec struct {
+	Struct multiver.OuterStruct `json:"struct,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=versionedresource
+
+type VersionedResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec VersionedResourceSpec `json:"spec"`
+}
+
+// +kubebuilder:object:root=true
+
+type VersionedResourceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []VersionedResource `json:"items"`
+}

--- a/pkg/crd/testdata/multiple_versions/v1beta2/types.go
+++ b/pkg/crd/testdata/multiple_versions/v1beta2/types.go
@@ -1,0 +1,46 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+package v1beta2
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	multiver "testdata.kubebuilder.io/cronjob/multiple_versions"
+)
+
+type VersionedResourceSpec struct {
+	Struct multiver.OuterStruct `json:"struct,omitempty"`
+}
+
+// +kubebuilder:storageversion
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=versionedresource
+
+type VersionedResource struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec VersionedResourceSpec `json:"spec"`
+}
+
+// +kubebuilder:object:root=true
+
+type VersionedResourceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []VersionedResource `json:"items"`
+}

--- a/pkg/markers/collect.go
+++ b/pkg/markers/collect.go
@@ -31,7 +31,7 @@ import (
 type Collector struct {
 	*Registry
 
-	byPackage map[string]map[ast.Node]MarkerValues
+	byPackage map[*loader.Package]map[ast.Node]MarkerValues
 	mu        sync.Mutex
 }
 
@@ -53,7 +53,7 @@ func (c *Collector) init() {
 		c.Registry = &Registry{}
 	}
 	if c.byPackage == nil {
-		c.byPackage = make(map[string]map[ast.Node]MarkerValues)
+		c.byPackage = make(map[*loader.Package]map[ast.Node]MarkerValues)
 	}
 }
 
@@ -75,7 +75,7 @@ func (c *Collector) init() {
 func (c *Collector) MarkersInPackage(pkg *loader.Package) (map[ast.Node]MarkerValues, error) {
 	c.mu.Lock()
 	c.init()
-	if markers, exist := c.byPackage[pkg.ID]; exist {
+	if markers, exist := c.byPackage[pkg]; exist {
 		c.mu.Unlock()
 		return markers, nil
 	}
@@ -91,8 +91,7 @@ func (c *Collector) MarkersInPackage(pkg *loader.Package) (map[ast.Node]MarkerVa
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.byPackage[pkg.ID] = markers
-
+	c.byPackage[pkg] = markers
 	return markers, nil
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Fix #783.

As I described in https://github.com/kubernetes-sigs/controller-tools/issues/783#issuecomment-1487356924 , this issue is caused by using `Package.ID` as a key for cache of markers. This PR adds a testcase to reproduce the issue and fixes it by using `Package` itself instead.