### PR TITLE
🐛 release-0.11: remove metadata.creationTimestamp when generating CRDs, RBAC, and webhooks

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -153,7 +153,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			} else {
 				fileName = fmt.Sprintf("%s_%s.%s.yaml", crdRaw.Spec.Group, crdRaw.Spec.Names.Plural, crdVersions[i])
 			}
-			if err := ctx.WriteYAML(fileName, []interface{}{crd}, genall.WithTransform(transformRemoveCRDStatus)); err != nil {
+			if err := ctx.WriteYAML(fileName, []interface{}{crd}, genall.WithTransform(transformRemoveCRDStatus), genall.WithTransform(genall.TransformRemoveCreationTimestamp)); err != nil {
 				return err
 			}
 		}

--- a/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.v1beta1.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: foos.bar.example.com
 spec:
   group: bar.example.com

--- a/pkg/crd/testdata/gen/bar.example.com_foos.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: foos.bar.example.com
 spec:
   group: bar.example.com

--- a/pkg/crd/testdata/gen/zoo/bar.example.com_zooes.v1beta1.yaml
+++ b/pkg/crd/testdata/gen/zoo/bar.example.com_zooes.v1beta1.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: zoos.bar.example.com
 spec:
   group: bar.example.com

--- a/pkg/crd/testdata/gen/zoo/bar.example.com_zooes.yaml
+++ b/pkg/crd/testdata/gen/zoo/bar.example.com_zooes.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: zooes.bar.example.com
 spec:
   group: bar.example.com

--- a/pkg/crd/testdata/plural/plural.example.com_testquotas.yaml
+++ b/pkg/crd/testdata/plural/plural.example.com_testquotas.yaml
@@ -5,7 +5,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: testquotas.plural.example.com
 spec:
   group: plural.example.com

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -6,7 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: (devel)
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/controller-tools
     cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
-  creationTimestamp: null
   name: cronjobs.testdata.kubebuilder.io
 spec:
   group: testdata.kubebuilder.io

--- a/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: jobs.testdata.kubebuilder.io
 spec:
   group: testdata.kubebuilder.io

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -133,6 +133,13 @@ func WithTransform(transform func(obj map[string]interface{}) error) *WriteYAMLO
 	}
 }
 
+// TransformRemoveCreationTimestamp ensures we do not write the metadata.creationTimestamp field.
+func TransformRemoveCreationTimestamp(obj map[string]interface{}) error {
+	metadata := obj["metadata"].(map[interface{}]interface{})
+	delete(metadata, "creationTimestamp")
+	return nil
+}
+
 // WriteYAML writes the given objects out, serialized as YAML, using the
 // context's OutputRule.  Objects are written as separate documents, separated
 // from each other by `---` (as per the YAML spec).

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -263,5 +263,5 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		return nil
 	}
 
-	return ctx.WriteYAML("role.yaml", objs)
+	return ctx.WriteYAML("role.yaml", objs, genall.WithTransform(genall.TransformRemoveCreationTimestamp))
 }

--- a/pkg/rbac/testdata/role.yaml
+++ b/pkg/rbac/testdata/role.yaml
@@ -3,7 +3,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: manager-role
 rules:
 - apiGroups:
@@ -58,7 +57,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: manager-role
   namespace: park
 rules:
@@ -73,7 +71,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: manager-role
   namespace: zoo
 rules:

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -412,7 +412,7 @@ func (Generator) Generate(ctx *genall.GenerationContext) error {
 		} else {
 			fileName = fmt.Sprintf("manifests.%s.yaml", k)
 		}
-		if err := ctx.WriteYAML(fileName, v); err != nil {
+		if err := ctx.WriteYAML(fileName, v, genall.WithTransform(genall.TransformRemoveCreationTimestamp)); err != nil {
 			return err
 		}
 	}

--- a/pkg/webhook/testdata/invalid-admissionReviewVersionsRequired/manifests.yaml
+++ b/pkg/webhook/testdata/invalid-admissionReviewVersionsRequired/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -31,7 +30,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/pkg/webhook/testdata/invalid-sideEffects/manifests.yaml
+++ b/pkg/webhook/testdata/invalid-sideEffects/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -31,7 +30,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/pkg/webhook/testdata/invalid-v1beta1NotSupported/manifests.yaml
+++ b/pkg/webhook/testdata/invalid-v1beta1NotSupported/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -31,7 +30,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/pkg/webhook/testdata/manifests.yaml
+++ b/pkg/webhook/testdata/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -32,7 +31,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/pkg/webhook/testdata/valid/manifests.yaml
+++ b/pkg/webhook/testdata/valid/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -32,7 +31,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
Manual cherry-pick of #800 to backport to `release-0.11`

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
