### PR TITLE
🐛 Fix marker parsing

### DIFF
--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -369,6 +369,14 @@ func guessType(scanner *sc.Scanner, raw string, allowSlice bool) *Argument {
 
 // parseString parses either of the two accepted string forms (quoted, or bare tokens).
 func (a *Argument) parseString(scanner *sc.Scanner, raw string, out reflect.Value) {
+	// we need to temporarily disable the scanner's int/float parsing, since we want to
+	// prevent number parsing errors.
+	oldMode := scanner.Mode
+	scanner.Mode = oldMode &^ sc.ScanInts &^ sc.ScanFloats
+	defer func() {
+		scanner.Mode = oldMode
+	}()
+
 	// strings are a bit weird -- the "easy" case is quoted strings (tokenized as strings),
 	// the "hard" case (present for backwards compat) is a bare sequence of tokens that aren't
 	// a comma.

--- a/pkg/markers/parse_test.go
+++ b/pkg/markers/parse_test.go
@@ -171,6 +171,9 @@ var _ = Describe("Parsing", func() {
 
 	Context("of individual arguments", func() {
 		It("should support bare strings", argParseTestCase{arg: Argument{Type: StringType}, raw: `some string here!`, output: "some string here!"}.Run)
+		It("should support bare strings containing number-ish values 1", argParseTestCase{arg: Argument{Type: StringType}, raw: `aa 0Baaa aaa`, output: "aa 0Baaa aaa"}.Run)
+		It("should support bare strings containing number-ish values 2", argParseTestCase{arg: Argument{Type: StringType}, raw: `/tmp/tmp-CHECKCRD-0B7LDeoZta`, output: "/tmp/tmp-CHECKCRD-0B7LDeoZta"}.Run)
+		It("should support bare strings containing number-ish values 3", argParseTestCase{arg: Argument{Type: StringType}, raw: `.0B7LDeoZt`, output: ".0B7LDeoZt"}.Run)
 		It("should support double-quoted strings", argParseTestCase{arg: Argument{Type: StringType}, raw: `"some; string, \nhere"`, output: "some; string, \nhere"}.Run)
 		It("should support raw strings", argParseTestCase{arg: Argument{Type: StringType}, raw: "`some; string, \\nhere`", output: `some; string, \nhere`}.Run)
 		It("should support integers", argParseTestCase{arg: Argument{Type: IntType}, raw: "42", output: 42}.Run)


### PR DESCRIPTION
Markers that have number-like parts (like `0B7LDeoZta`) trigger parsing errors.
This causes `controller-gen` to fail (see https://github.com/cert-manager/cert-manager/issues/5955).
This PR updates the scanner, so it does not try to parse a string as numbers when we know it is a string instead of a number.