### PR TITLE
:sparkles:Upgrade to go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/fatih/color v1.15.0

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -131,7 +131,7 @@ type outputRule struct {
 	buf *bytes.Buffer
 }
 
-func (o *outputRule) Open(_ *loader.Package, itemPath string) (io.WriteCloser, error) {
+func (o *outputRule) Open(_ *loader.Package, _ string) (io.WriteCloser, error) {
 	return nopCloser{o.buf}, nil
 }
 

--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -283,7 +283,7 @@ type Resource struct {
 	Scope string `marker:",optional"`
 }
 
-func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, version string) error {
+func (s Resource) ApplyToCRD(crd *apiext.CustomResourceDefinitionSpec, _ string) error {
 	if s.Path != "" {
 		crd.Names.Plural = s.Path
 	}
@@ -362,7 +362,7 @@ type Metadata struct {
 	Labels []string `marker:",optional"`
 }
 
-func (s Metadata) ApplyToCRD(crd *apiext.CustomResourceDefinition, version string) error {
+func (s Metadata) ApplyToCRD(crd *apiext.CustomResourceDefinition, _ string) error {
 	if len(s.Annotations) > 0 {
 		if crd.Annotations == nil {
 			crd.Annotations = map[string]string{}

--- a/pkg/deepcopy/traverse.go
+++ b/pkg/deepcopy/traverse.go
@@ -735,11 +735,14 @@ func hasAnyDeepCopyMethod(pkg *loader.Package, typeInfo types.Type) bool {
 // eventualUnderlyingType gets the "final" type in a sequence of named aliases.
 // It's effectively a shortcut for calling Underlying in a loop.
 func eventualUnderlyingType(typeInfo types.Type) types.Type {
-	last := typeInfo
-	for underlying := typeInfo.Underlying(); underlying != last; last, underlying = underlying, underlying.Underlying() {
-		// get the actual underlying type
+	for {
+		underlying := typeInfo.Underlying()
+		if underlying == typeInfo {
+			break
+		}
+		typeInfo = underlying
 	}
-	return last
+	return typeInfo
 }
 
 // fineToShallowCopy checks if a shallow-copying a type is equivalent to deepcopy-ing it.

--- a/pkg/genall/output.go
+++ b/pkg/genall/output.go
@@ -122,7 +122,7 @@ var OutputToStdout = outputToStdout{}
 // Generally useful for single-artifact outputs.
 type outputToStdout struct{}
 
-func (o outputToStdout) Open(_ *loader.Package, itemPath string) (io.WriteCloser, error) {
+func (o outputToStdout) Open(_ *loader.Package, _ string) (io.WriteCloser, error) {
 	return nopCloser{os.Stdout}, nil
 }
 

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -268,7 +268,11 @@ func guessType(scanner *sc.Scanner, raw string, allowSlice bool) *Argument {
 		subScanner := parserScanner(subRaw, scanner.Error)
 
 		var tok rune
-		for tok = subScanner.Scan(); tok != ',' && tok != sc.EOF && tok != ';'; tok = subScanner.Scan() {
+		for {
+			tok = subScanner.Scan()
+			if tok == ',' || tok == sc.EOF || tok == ';' {
+				break
+			}
 			// wait till we get something interesting
 		}
 
@@ -495,7 +499,12 @@ func (a *Argument) parse(scanner *sc.Scanner, raw string, out reflect.Value, inS
 		// raw consumes everything else
 		castAndSet(out, reflect.ValueOf(raw[scanner.Pos().Offset:]))
 		// consume everything else
-		for tok := scanner.Scan(); tok != sc.EOF; tok = scanner.Scan() {
+		var tok rune
+		for {
+			tok = scanner.Scan()
+			if tok == sc.EOF {
+				break
+			}
 		}
 	case NumberType:
 		nextChar := scanner.Peek()

--- a/pkg/typescaffold/scaffold.go
+++ b/pkg/typescaffold/scaffold.go
@@ -92,11 +92,8 @@ type ScaffoldOptions struct {
 
 // Validate validates the options, returning an error if anything is invalid.
 func (o *ScaffoldOptions) Validate() error {
-	if err := o.Resource.Validate(); err != nil {
-		return err
-	}
-
-	return nil
+	err := o.Resource.Validate()
+	return err
 }
 
 // Scaffold prints the Kubernetes object scaffolding to the given output.

--- a/test.sh
+++ b/test.sh
@@ -100,7 +100,7 @@ function setup_envs {
 header_text "using tools"
 
 if ! which golangci-lint 2>&1 >/dev/null; then
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
   export PATH=$PATH:$(go env GOPATH)/bin
 fi
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
- Upgrade to `go` 1.20
- Upgrade `golangci-lint` to v1.52.2
- Fix lint findings