### PR TITLE
🐛 Fix controller-gen/schemapatch with marker allowDangerousTypes

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -434,7 +434,7 @@ func builtinToType(basic *types.Basic, allowDangerousTypes bool) (typ string, fo
 		if allowDangerousTypes {
 			typ = "number"
 		} else {
-			return "", "", errors.New("found float, the usage of which is highly discouraged, as support for them varies across languages. Please consider serializing your float as string instead. If you are really sure you want to use them, re-run with crd:allowDangerousTypes=true")
+			return "", "", errors.New("found float, the usage of which is highly discouraged, as support for them varies across languages. Please consider serializing your float as string instead. If you are really sure you want to use them, re-run with crd:allowDangerousTypes=true or schemapatch:allowDangerousTypes=true")
 		}
 	default:
 		return "", "", fmt.Errorf("unsupported type %q", basic.String())

--- a/pkg/schemapatcher/gen.go
+++ b/pkg/schemapatcher/gen.go
@@ -73,6 +73,16 @@ type Generator struct {
 	// closest sentence boundary if it exceeds n characters.
 	MaxDescLen *int `marker:",optional"`
 
+	// AllowDangerousTypes allows types which are usually omitted from CRD generation
+	// because they are not recommended.
+	//
+	// Currently the following additional types are allowed when this is true:
+	// float32
+	// float64
+	//
+	// Left unspecified, the default is false
+	AllowDangerousTypes *bool `marker:",optional"`
+
 	// GenerateEmbeddedObjectMeta specifies if any embedded ObjectMeta in the CRD should be generated
 	GenerateEmbeddedObjectMeta *bool `marker:",optional"`
 }
@@ -89,10 +99,11 @@ func (Generator) RegisterMarkers(into *markers.Registry) error {
 
 func (g Generator) Generate(ctx *genall.GenerationContext) (result error) {
 	parser := &crdgen.Parser{
-		Collector: ctx.Collector,
-		Checker:   ctx.Checker,
+		Collector:           ctx.Collector,
+		Checker:             ctx.Checker,
+		AllowDangerousTypes: g.AllowDangerousTypes != nil && *g.AllowDangerousTypes,
 		// Indicates the parser on whether to register the ObjectMeta type or not
-		GenerateEmbeddedObjectMeta: g.GenerateEmbeddedObjectMeta != nil && *g.GenerateEmbeddedObjectMeta == true,
+		GenerateEmbeddedObjectMeta: g.GenerateEmbeddedObjectMeta != nil && *g.GenerateEmbeddedObjectMeta,
 	}
 
 	crdgen.AddKnownTypes(parser)

--- a/pkg/schemapatcher/zz_generated.markerhelp.go
+++ b/pkg/schemapatcher/zz_generated.markerhelp.go
@@ -41,6 +41,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},
+			"AllowDangerousTypes": {
+				Summary: "allows types which are usually omitted from CRD generation because they are not recommended. ",
+				Details: "Currently the following additional types are allowed when this is true: float32 float64 \n Left unspecified, the default is false",
+			},
 			"GenerateEmbeddedObjectMeta": {
 				Summary: "specifies if any embedded ObjectMeta in the CRD should be generated",
 				Details: "",


### PR DESCRIPTION
when schemapatch with types contain float32/float64, it output these attenions

```
.../types.go:207:23: found float, the usage of which is highly discouraged, as support for them varies across languages.
Please consider serializing your float as string instead. If you are really sure you want to use them, re-run with
crd:allowDangerousTypes=true
```
i think it's ok to add allowDangerousTypes marker to schemapatch

after this PR, user can rerun command like

```
controller-gen schemapatch:manifests=./crd,allowDangerousTypes=true paths=./pkg/apis/... output:dir=./crd
```