### PR TITLE
✨ Return an error for duplicate generators

### DIFF
--- a/pkg/genall/options.go
+++ b/pkg/genall/options.go
@@ -136,6 +136,9 @@ func protoFromOptions(optionsRegistry *markers.Registry, options []string) (prot
 		switch val := val.(type) {
 		case Generator:
 			gens = append(gens, &val)
+			if _, alreadyExists := gensByName[defn.Name]; alreadyExists {
+				return protoRuntime{}, fmt.Errorf("multiple instances of '%s' generator specified", defn.Name)
+			}
 			gensByName[defn.Name] = &val
 		case OutputRule:
 			_, genName := splitOutputRuleOption(defn.Name)


### PR DESCRIPTION
Return an error from controller-gen if the command includes multiple instances of the same generator. For example:

```
$ controller-gen "+crd:generateEmbeddedObjectMeta=true" rbac:roleName=manager-role crd webhook paths="~/src/operator/apis" +output:crd:artifacts:config=/tmp/wat

Error: multiple instances of 'crd' generator specified
```

I hit the issue described in https://github.com/kubernetes-sigs/controller-tools/issues/671 and was quite confused by it.

I'm not sure if you should ever be able to specify multiple of the same generator in a single run, as this causes apparently unintended effects. In my case, only honoring the `output` directive for one and dumping the other in the default location, with no obvious way to apply the `output` configuration to both.

I'm also unsure if there's actually a way to provide a warning versus returning an error, so this does the latter. I'm not that familiar with the codebase but didn't find anything that looked like warning-level logging. Prints to stderr only show up in the top-level command code, and it doesn't make sense to issue them directly from the generator library.