### PR TITLE
🐛 crd: Respect multiline comments at godocs 

### DIFF
--- a/pkg/crd/testdata/gen/bar.example.com_foos.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos.yaml
@@ -19,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,7 +40,8 @@ spec:
             properties:
               defaultedString:
                 default: fooDefaultString
-                description: This tests that defaulted fields are stripped for v1beta1,
+                description: |-
+                  This tests that defaulted fields are stripped for v1beta1,
                   but not for v1
                 example: fooExampleString
                 type: string

--- a/pkg/crd/testdata/gen/zoo/bar.example.com_zoos.yaml
+++ b/pkg/crd/testdata/gen/zoo/bar.example.com_zoos.yaml
@@ -19,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -35,7 +40,8 @@ spec:
             properties:
               defaultedString:
                 default: zooDefaultString
-                description: This tests that defaulted fields are stripped for v1beta1,
+                description: |-
+                  This tests that defaulted fields are stripped for v1beta1,
                   but not for v1
                 example: zooExampleString
                 type: string

--- a/pkg/crd/testdata/gen/zoo/zoo_types.go
+++ b/pkg/crd/testdata/gen/zoo/zoo_types.go
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//go:generate ../../../../.run-controller-gen.sh crd:crdVersions=v1beta1 paths=. output:dir=.
+//go:generate ../../../../../.run-controller-gen.sh crd:crdVersions=v1beta1 paths=. output:dir=.
 //go:generate mv bar.example.com_zoos.yaml bar.example.com_zoos.v1beta1.yaml
-//go:generate ../../../../.run-controller-gen.sh crd:crdVersions=v1 paths=. output:dir=.
+//go:generate ../../../../../.run-controller-gen.sh crd:crdVersions=v1 paths=. output:dir=.
 
 // +groupName=bar.example.com
 package zoo

--- a/pkg/crd/testdata/multiple_versions/common.go
+++ b/pkg/crd/testdata/multiple_versions/common.go
@@ -1,3 +1,5 @@
+//go:generate ../../../../.run-controller-gen.sh crd paths=./v1beta1;./v1beta2 output:dir=.
+
 package multiple_versions
 
 type InnerStruct struct {

--- a/pkg/crd/testdata/multiple_versions/testdata.kubebuilder.io_versionedresources.yaml
+++ b/pkg/crd/testdata/multiple_versions/testdata.kubebuilder.io_versionedresources.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: versionedresources.testdata.kubebuilder.io
 spec:
   group: testdata.kubebuilder.io
@@ -20,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -55,14 +59,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/pkg/crd/testdata/plural/plural.example.com_testquotas.yaml
+++ b/pkg/crd/testdata/plural/plural.example.com_testquotas.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -20,14 +19,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -3,9 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/controller-tools
     cert-manager.io/inject-ca-from-secret: cert-manager/cert-manager-webhook-ca
+    controller-gen.kubebuilder.io/version: (devel)
   name: cronjobs.testdata.kubebuilder.io
 spec:
   group: testdata.kubebuilder.io
@@ -22,14 +22,19 @@ spec:
         description: CronJob is the Schema for the cronjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -86,31 +91,34 @@ spec:
                 nullable: true
                 type: string
               concurrencyPolicy:
-                description: 'Specifies how to treat concurrent executions of a Job.
-                  Valid values are: - "Allow" (default): allows CronJobs to run concurrently;
-                  - "Forbid": forbids concurrent runs, skipping next run if previous
-                  run hasn''t finished yet; - "Replace": cancels currently running
-                  job and replaces it with a new one'
+                description: |-
+                  Specifies how to treat concurrent executions of a Job.
+                  Valid values are:
+                  - "Allow" (default): allows CronJobs to run concurrently;
+                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+                  - "Replace": cancels currently running job and replaces it with a new one
                 enum:
                 - Allow
                 - Forbid
                 - Replace
                 type: string
               defaultedEmptyMap:
-                default: {}
-                description: This tests that an empty object defaulting can be performed on a map.
-                type: object
                 additionalProperties:
                   type: string
+                default: {}
+                description: This tests that an empty object defaulting can be performed
+                  on a map.
+                type: object
               defaultedEmptyObject:
                 default: {}
-                description: This tests that an empty object defaulting can be performed on an object.
+                description: This tests that an empty object defaulting can be performed
+                  on an object.
                 properties:
                   bar:
                     type: string
                   foo:
-                    type: string
                     default: forty-two
+                    type: string
                 type: object
               defaultedEmptySlice:
                 default: []
@@ -169,8 +177,9 @@ spec:
                 x-kubernetes-embedded-resource: true
                 x-kubernetes-preserve-unknown-fields: true
               failedJobsHistoryLimit:
-                description: The number of failed finished jobs to retain. This is
-                  a pointer to distinguish between explicit zero and not specified.
+                description: |-
+                  The number of failed finished jobs to retain.
+                  This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
               float64WithValidations:
@@ -197,10 +206,11 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: This tests that an IntOrString can also have a pattern
-                  attached to it. This can be useful if you want to limit the string
-                  to a perecentage or integer. The XIntOrString marker is a requirement
-                  for having a pattern on this type.
+                description: |-
+                  This tests that an IntOrString can also have a pattern attached
+                  to it.
+                  This can be useful if you want to limit the string to a perecentage or integer.
+                  The XIntOrString marker is a requirement for having a pattern on this type.
                 pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
                 x-kubernetes-int-or-string: true
               intWithValidations:
@@ -213,65 +223,71 @@ spec:
                   a CronJob.
                 properties:
                   metadata:
-                    description: 'Standard object''s metadata of the jobs created
-                      from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    description: |-
+                      Standard object's metadata of the jobs created from this template.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     type: object
                   spec:
-                    description: 'Specification of the desired behavior of the job.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    description: |-
+                      Specification of the desired behavior of the job.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       activeDeadlineSeconds:
-                        description: Specifies the duration in seconds relative to
-                          the startTime that the job may be active before the system
-                          tries to terminate it; value must be positive integer
+                        description: |-
+                          Specifies the duration in seconds relative to the startTime that the job may be active
+                          before the system tries to terminate it; value must be positive integer
                         format: int64
                         type: integer
                       backoffLimit:
-                        description: Specifies the number of retries before marking
-                          this job failed. Defaults to 6
+                        description: |-
+                          Specifies the number of retries before marking this job failed.
+                          Defaults to 6
                         format: int32
                         type: integer
                       completions:
-                        description: 'Specifies the desired number of successfully
-                          finished pods the job should be run with.  Setting to nil
-                          means that the success of any pod signals the success of
-                          all pods, and allows parallelism to have any positive value.  Setting
-                          to 1 means that parallelism is limited to 1 and the success
-                          of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                        description: |-
+                          Specifies the desired number of successfully finished pods the
+                          job should be run with.  Setting to nil means that the success of any
+                          pod signals the success of all pods, and allows parallelism to have any positive
+                          value.  Setting to 1 means that parallelism is limited to 1 and the success of that
+                          pod signals the success of the job.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
                         format: int32
                         type: integer
                       manualSelector:
-                        description: 'manualSelector controls generation of pod labels
-                          and pod selectors. Leave `manualSelector` unset unless you
-                          are certain what you are doing. When false or unset, the
-                          system pick labels unique to this job and appends those
-                          labels to the pod template.  When true, the user is responsible
-                          for picking unique labels and specifying the selector.  Failure
-                          to pick a unique label may cause this and other jobs to
-                          not function correctly.  However, You may see `manualSelector=true`
-                          in jobs that were created with the old `extensions/v1beta1`
-                          API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector'
+                        description: |-
+                          manualSelector controls generation of pod labels and pod selectors.
+                          Leave `manualSelector` unset unless you are certain what you are doing.
+                          When false or unset, the system pick labels unique to this job
+                          and appends those labels to the pod template.  When true,
+                          the user is responsible for picking unique labels and specifying
+                          the selector.  Failure to pick a unique label may cause this
+                          and other jobs to not function correctly.  However, You may see
+                          `manualSelector=true` in jobs that were created with the old `extensions/v1beta1`
+                          API.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
                         type: boolean
                       parallelism:
-                        description: 'Specifies the maximum desired number of pods
-                          the job should run at any given time. The actual number
-                          of pods running in steady state will be less than this number
-                          when ((.spec.completions - .status.successful) < .spec.parallelism),
+                        description: |-
+                          Specifies the maximum desired number of pods the job should
+                          run at any given time. The actual number of pods running in steady state will
+                          be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
                           i.e. when the work left to do is less than max parallelism.
-                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
                         format: int32
                         type: integer
                       selector:
-                        description: 'A label query over pods that should match the
-                          pod count. Normally, the system sets this field for you.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                        description: |-
+                          A label query over pods that should match the pod count.
+                          Normally, the system sets this field for you.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
                                 relates the key and values.
                               properties:
                                 key:
@@ -279,17 +295,16 @@ spec:
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -301,31 +316,32 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                       template:
-                        description: 'Describes the pod that will be created when
-                          executing a job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/'
+                        description: |-
+                          Describes the pod that will be created when executing a job.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
                         properties:
                           metadata:
-                            description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            description: |-
+                              Standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                             type: object
                           spec:
-                            description: 'Specification of the desired behavior of
-                              the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                            description: |-
+                              Specification of the desired behavior of the pod.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                             properties:
                               activeDeadlineSeconds:
-                                description: Optional duration in seconds the pod
-                                  may be active on the node relative to StartTime
-                                  before the system will actively try to mark it failed
-                                  and kill associated containers. Value must be a
-                                  positive integer.
+                                description: |-
+                                  Optional duration in seconds the pod may be active on the node relative to
+                                  StartTime before the system will actively try to mark it failed and kill associated containers.
+                                  Value must be a positive integer.
                                 format: int64
                                 type: integer
                               affinity:
@@ -336,27 +352,20 @@ spec:
                                       rules for the pod.
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          affinity expressions specified by this field,
-                                          but it may choose a node that violates one
-                                          or more of the expressions. The node that
-                                          is most preferred is the one with the greatest
-                                          sum of weights, i.e. for each node that
-                                          meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          affinity expressions, etc.), compute a sum
-                                          by iterating through the elements of this
-                                          field and adding "weight" to the sum if
-                                          the node matches the corresponding matchExpressions;
-                                          the node(s) with the highest sum are the
-                                          most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
-                                          description: An empty preferred scheduling
-                                            term matches all objects with implicit
-                                            weight 0 (i.e. it's a no-op). A null preferred
-                                            scheduling term matches no objects (i.e.
-                                            is also a no-op).
+                                          description: |-
+                                            An empty preferred scheduling term matches all objects with implicit weight 0
+                                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                           properties:
                                             preference:
                                               description: A node selector term, associated
@@ -366,9 +375,8 @@ spec:
                                                   description: A list of node selector
                                                     requirements by node's labels.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -377,27 +385,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -410,9 +408,8 @@ spec:
                                                   description: A list of node selector
                                                     requirements by node's fields.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -421,27 +418,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -463,31 +450,28 @@ spec:
                                           type: object
                                         type: array
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the affinity requirements specified
-                                          by this field cease to be met at some point
-                                          during pod execution (e.g. due to an update),
-                                          the system may or may not try to eventually
-                                          evict the pod from its node.
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to an update), the system
+                                          may or may not try to eventually evict the pod from its node.
                                         properties:
                                           nodeSelectorTerms:
                                             description: Required. A list of node
                                               selector terms. The terms are ORed.
                                             items:
-                                              description: A null or empty node selector
-                                                term matches no objects. The requirements
-                                                of them are ANDed. The TopologySelectorTerm
-                                                type implements a subset of the NodeSelectorTerm.
+                                              description: |-
+                                                A null or empty node selector term matches no objects. The requirements of
+                                                them are ANDed.
+                                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                               properties:
                                                 matchExpressions:
                                                   description: A list of node selector
                                                     requirements by node's labels.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -496,27 +480,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -529,9 +503,8 @@ spec:
                                                   description: A list of node selector
                                                     requirements by node's fields.
                                                   items:
-                                                    description: A node selector requirement
-                                                      is a selector that contains
-                                                      values, a key, and an operator
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
                                                       that relates the key and values.
                                                     properties:
                                                       key:
@@ -540,27 +513,17 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: Represents a
-                                                          key's relationship to a
-                                                          set of values. Valid operators
-                                                          are In, NotIn, Exists, DoesNotExist.
-                                                          Gt, and Lt.
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                         type: string
                                                       values:
-                                                        description: An array of string
-                                                          values. If the operator
-                                                          is In or NotIn, the values
-                                                          array must be non-empty.
-                                                          If the operator is Exists
-                                                          or DoesNotExist, the values
-                                                          array must be empty. If
-                                                          the operator is Gt or Lt,
-                                                          the values array must have
-                                                          a single element, which
-                                                          will be interpreted as an
-                                                          integer. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -581,21 +544,16 @@ spec:
                                       zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          affinity expressions specified by this field,
-                                          but it may choose a node that violates one
-                                          or more of the expressions. The node that
-                                          is most preferred is the one with the greatest
-                                          sum of weights, i.e. for each node that
-                                          meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          affinity expressions, etc.), compute a sum
-                                          by iterating through the elements of this
-                                          field and adding "weight" to the sum if
-                                          the node has pods which matches the corresponding
-                                          podAffinityTerm; the node(s) with the highest
-                                          sum are the most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -617,10 +575,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -629,24 +585,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -659,46 +606,33 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaces:
-                                                  description: namespaces specifies
-                                                    which namespaces the labelSelector
-                                                    applies to (matches against);
-                                                    null or empty list means "this
-                                                    pod's namespace"
+                                                  description: |-
+                                                    namespaces specifies which namespaces the labelSelector applies to (matches against);
+                                                    null or empty list means "this pod's namespace"
                                                   items:
                                                     type: string
                                                   type: array
                                                 topologyKey:
-                                                  description: This pod should be
-                                                    co-located (affinity) or not co-located
-                                                    (anti-affinity) with the pods
-                                                    matching the labelSelector in
-                                                    the specified namespaces, where
-                                                    co-located is defined as running
-                                                    on a node whose value of the label
-                                                    with key topologyKey matches that
-                                                    of any node on which any of the
-                                                    selected pods is running. Empty
-                                                    topologyKey is not allowed.
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
                                                   type: string
                                               required:
                                               - topologyKey
                                               type: object
                                             weight:
-                                              description: weight associated with
-                                                matching the corresponding podAffinityTerm,
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
                                               format: int32
                                               type: integer
@@ -708,28 +642,22 @@ spec:
                                           type: object
                                         type: array
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the affinity requirements specified
-                                          by this field cease to be met at some point
-                                          during pod execution (e.g. due to a pod
-                                          label update), the system may or may not
-                                          try to eventually evict the pod from its
-                                          node. When there are multiple elements,
-                                          the lists of nodes corresponding to each
-                                          podAffinityTerm are intersected, i.e. all
-                                          terms must be satisfied.
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                         items:
-                                          description: Defines a set of pods (namely
-                                            those matching the labelSelector relative
-                                            to the given namespace(s)) that this pod
-                                            should be co-located (affinity) or not
-                                            co-located (anti-affinity) with, where
-                                            co-located is defined as running on a
-                                            node whose value of the label with key
-                                            <topologyKey> matches that of any node
-                                            on which a pod of the set of pods is running
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
                                           properties:
                                             labelSelector:
                                               description: A label query over a set
@@ -740,11 +668,9 @@ spec:
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -752,23 +678,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -780,36 +699,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                             namespaces:
-                                              description: namespaces specifies which
-                                                namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
+                                              description: |-
+                                                namespaces specifies which namespaces the labelSelector applies to (matches against);
+                                                null or empty list means "this pod's namespace"
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
@@ -822,21 +731,16 @@ spec:
                                       node, zone, etc. as some other pod(s)).
                                     properties:
                                       preferredDuringSchedulingIgnoredDuringExecution:
-                                        description: The scheduler will prefer to
-                                          schedule pods to nodes that satisfy the
-                                          anti-affinity expressions specified by this
-                                          field, but it may choose a node that violates
-                                          one or more of the expressions. The node
-                                          that is most preferred is the one with the
-                                          greatest sum of weights, i.e. for each node
-                                          that meets all of the scheduling requirements
-                                          (resource request, requiredDuringScheduling
-                                          anti-affinity expressions, etc.), compute
-                                          a sum by iterating through the elements
-                                          of this field and adding "weight" to the
-                                          sum if the node has pods which matches the
-                                          corresponding podAffinityTerm; the node(s)
-                                          with the highest sum are the most preferred.
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the anti-affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
                                         items:
                                           description: The weights of all of the matched
                                             WeightedPodAffinityTerm fields are added
@@ -858,10 +762,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -870,24 +772,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -900,46 +793,33 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                 namespaces:
-                                                  description: namespaces specifies
-                                                    which namespaces the labelSelector
-                                                    applies to (matches against);
-                                                    null or empty list means "this
-                                                    pod's namespace"
+                                                  description: |-
+                                                    namespaces specifies which namespaces the labelSelector applies to (matches against);
+                                                    null or empty list means "this pod's namespace"
                                                   items:
                                                     type: string
                                                   type: array
                                                 topologyKey:
-                                                  description: This pod should be
-                                                    co-located (affinity) or not co-located
-                                                    (anti-affinity) with the pods
-                                                    matching the labelSelector in
-                                                    the specified namespaces, where
-                                                    co-located is defined as running
-                                                    on a node whose value of the label
-                                                    with key topologyKey matches that
-                                                    of any node on which any of the
-                                                    selected pods is running. Empty
-                                                    topologyKey is not allowed.
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
                                                   type: string
                                               required:
                                               - topologyKey
                                               type: object
                                             weight:
-                                              description: weight associated with
-                                                matching the corresponding podAffinityTerm,
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
                                               format: int32
                                               type: integer
@@ -949,28 +829,22 @@ spec:
                                           type: object
                                         type: array
                                       requiredDuringSchedulingIgnoredDuringExecution:
-                                        description: If the anti-affinity requirements
-                                          specified by this field are not met at scheduling
-                                          time, the pod will not be scheduled onto
-                                          the node. If the anti-affinity requirements
-                                          specified by this field cease to be met
-                                          at some point during pod execution (e.g.
-                                          due to a pod label update), the system may
-                                          or may not try to eventually evict the pod
-                                          from its node. When there are multiple elements,
-                                          the lists of nodes corresponding to each
-                                          podAffinityTerm are intersected, i.e. all
-                                          terms must be satisfied.
+                                        description: |-
+                                          If the anti-affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the anti-affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                         items:
-                                          description: Defines a set of pods (namely
-                                            those matching the labelSelector relative
-                                            to the given namespace(s)) that this pod
-                                            should be co-located (affinity) or not
-                                            co-located (anti-affinity) with, where
-                                            co-located is defined as running on a
-                                            node whose value of the label with key
-                                            <topologyKey> matches that of any node
-                                            on which a pod of the set of pods is running
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
                                           properties:
                                             labelSelector:
                                               description: A label query over a set
@@ -981,11 +855,9 @@ spec:
                                                     a list of label selector requirements.
                                                     The requirements are ANDed.
                                                   items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
                                                     properties:
                                                       key:
                                                         description: key is the label
@@ -993,23 +865,16 @@ spec:
                                                           to.
                                                         type: string
                                                       operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                                         type: string
                                                       values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
                                                         items:
                                                           type: string
                                                         type: array
@@ -1021,36 +886,26 @@ spec:
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                   type: object
                                               type: object
                                             namespaces:
-                                              description: namespaces specifies which
-                                                namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
+                                              description: |-
+                                                namespaces specifies which namespaces the labelSelector applies to (matches against);
+                                                null or empty list means "this pod's namespace"
                                               items:
                                                 type: string
                                               type: array
                                             topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
                                               type: string
                                           required:
                                           - topologyKey
@@ -1064,48 +919,45 @@ spec:
                                   mounted.
                                 type: boolean
                               containers:
-                                description: List of containers belonging to the pod.
+                                description: |-
+                                  List of containers belonging to the pod.
                                   Containers cannot currently be added or removed.
-                                  There must be at least one container in a Pod. Cannot
-                                  be updated.
+                                  There must be at least one container in a Pod.
+                                  Cannot be updated.
                                 items:
                                   description: A single application container that
                                     you want to run within a pod.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        docker image''s CMD is used if this is not
-                                        provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. The
-                                        $(VAR_NAME) syntax can be escaped with a double
-                                        $$, ie: $$(VAR_NAME). Escaped references will
-                                        never be expanded, regardless of whether the
-                                        variable exists or not. Cannot be updated.
-                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The docker image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax
+                                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                                        regardless of whether the variable exists or not.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The docker image''s ENTRYPOINT
-                                        is used if this is not provided. Variable
-                                        references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. The $(VAR_NAME)
-                                        syntax can be escaped with a double $$, ie:
-                                        $$(VAR_NAME). Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The docker image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax
+                                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                                        regardless of whether the variable exists or not.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -1115,17 +967,15 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previous defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. The $(VAR_NAME) syntax can
-                                              be escaped with a double $$, ie: $$(VAR_NAME).
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previous defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. The $(VAR_NAME)
+                                              syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                                              references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -1139,10 +989,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1153,11 +1003,9 @@ spec:
                                                 - key
                                                 type: object
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                                 properties:
                                                   apiVersion:
                                                     description: Version of the schema
@@ -1173,12 +1021,9 @@ spec:
                                                 - fieldPath
                                                 type: object
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -1211,10 +1056,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -1229,15 +1074,13 @@ spec:
                                         type: object
                                       type: array
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -1246,10 +1089,10 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -1265,10 +1108,10 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -1278,51 +1121,44 @@ spec:
                                         type: object
                                       type: array
                                     image:
-                                      description: 'Docker image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images
-                                        This field is optional to allow higher level
-                                        config management to default or override container
-                                        images in workload controllers like Deployments
-                                        and StatefulSets.'
+                                      description: |-
+                                        Docker image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
-                                      description: Actions that the management system
-                                        should take in response to container lifecycle
-                                        events. Cannot be updated.
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: |-
+                                                One and only one of the following should be specified.
+                                                Exec specifies the action to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1332,10 +1168,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -1367,23 +1202,24 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: |-
+                                                TCPSocket specifies an action involving a TCP port.
+                                                TCP hooks not yet supported
+                                                TODO: implement a realistic TCP lifecycle hook
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1394,52 +1230,40 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The reason for termination is
-                                            passed to the handler. The Pod''s termination
-                                            grace period countdown begins before the
-                                            PreStop hooked is executed. Regardless
-                                            of the outcome of the handler, the container
-                                            will eventually terminate within the Pod''s
-                                            termination grace period. Other management
-                                            of the container blocks until the hook
-                                            completes or until the termination grace
-                                            period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The reason for termination is passed to the
+                                            handler. The Pod's termination grace period countdown begins before the
+                                            PreStop hooked is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period. Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: |-
+                                                One and only one of the following should be specified.
+                                                Exec specifies the action to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1449,10 +1273,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -1484,23 +1307,24 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: |-
+                                                TCPSocket specifies an action involving a TCP port.
+                                                TCP hooks not yet supported
+                                                TODO: implement a realistic TCP lifecycle hook
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1511,10 +1335,10 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -1522,36 +1346,32 @@ spec:
                                           type: object
                                       type: object
                                     livenessProbe:
-                                      description: 'Periodic probe of container liveness.
+                                      description: |-
+                                        Periodic probe of container liveness.
                                         Container will be restarted if the probe fails.
-                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -1559,10 +1379,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -1594,43 +1413,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1640,46 +1458,45 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the container specified
-                                        as a DNS_LABEL. Each container in a pod must
-                                        have a unique name (DNS_LABEL). Cannot be
-                                        updated.
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
                                       type: string
                                     ports:
-                                      description: List of ports to expose from the
-                                        container. Exposing a port here gives the
-                                        system additional information about the network
-                                        connections a container uses, but is primarily
-                                        informational. Not specifying a port here
-                                        DOES NOT prevent that port from being exposed.
-                                        Any port which is listening on the default
-                                        "0.0.0.0" address inside a container will
-                                        be accessible from the network. Cannot be
-                                        updated.
+                                      description: |-
+                                        List of ports to expose from the container. Exposing a port here gives
+                                        the system additional information about the network connections a
+                                        container uses, but is primarily informational. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Cannot be updated.
                                       items:
                                         description: ContainerPort represents a network
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -1687,25 +1504,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -1716,37 +1532,32 @@ spec:
                                       - protocol
                                       x-kubernetes-list-type: map
                                     readinessProbe:
-                                      description: 'Periodic probe of container service
-                                        readiness. Container will be removed from
-                                        service endpoints if the probe fails. Cannot
-                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -1754,10 +1565,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -1789,43 +1599,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -1835,25 +1644,27 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     resources:
-                                      description: 'Compute Resources required by
-                                        this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -1862,9 +1673,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -1873,33 +1684,32 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                           type: object
                                       type: object
                                     securityContext:
-                                      description: 'Security options the pod should
-                                        run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      description: |-
+                                        Security options the pod should run with.
+                                        More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
                                           type: boolean
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -1917,66 +1727,54 @@ spec:
                                               type: array
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -1996,49 +1794,42 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must only be set
-                                                if type is "Localhost".
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must only be set if type is "Localhost".
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -2046,57 +1837,45 @@ spec:
                                                 spec to use.
                                               type: string
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
                                     startupProbe:
-                                      description: 'StartupProbe indicates that the
-                                        Pod has successfully initialized. If specified,
-                                        no other probes are executed until this completes
-                                        successfully. If this probe fails, the Pod
-                                        will be restarted, just as if the livenessProbe
-                                        failed. This can be used to provide different
-                                        probe parameters at the beginning of a Pod''s
-                                        lifecycle, when it might take a long time
-                                        to load data or warm a cache, than during
-                                        steady-state operation. This cannot be updated.
-                                        This is a beta feature enabled by the StartupProbe
-                                        feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        This is a beta feature enabled by the StartupProbe feature flag.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -2104,10 +1883,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2139,43 +1917,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2185,71 +1962,62 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -2273,48 +2041,45 @@ spec:
                                         type: object
                                       type: array
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
@@ -2322,34 +2087,36 @@ spec:
                                         type: object
                                       type: array
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
                               dnsConfig:
-                                description: Specifies the DNS parameters of a pod.
-                                  Parameters specified here will be merged to the
-                                  generated DNS configuration based on DNSPolicy.
+                                description: |-
+                                  Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the generated DNS
+                                  configuration based on DNSPolicy.
                                 properties:
                                   nameservers:
-                                    description: A list of DNS name server IP addresses.
-                                      This will be appended to the base nameservers
-                                      generated from DNSPolicy. Duplicated nameservers
-                                      will be removed.
+                                    description: |-
+                                      A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers generated from DNSPolicy.
+                                      Duplicated nameservers will be removed.
                                     items:
                                       type: string
                                     type: array
                                   options:
-                                    description: A list of DNS resolver options. This
-                                      will be merged with the base options generated
-                                      from DNSPolicy. Duplicated entries will be removed.
-                                      Resolution options given in Options will override
-                                      those that appear in the base DNSPolicy.
+                                    description: |-
+                                      A list of DNS resolver options.
+                                      This will be merged with the base options generated from DNSPolicy.
+                                      Duplicated entries will be removed. Resolution options given in Options
+                                      will override those that appear in the base DNSPolicy.
                                     items:
                                       description: PodDNSConfigOption defines DNS
                                         resolver options of a pod.
@@ -2362,89 +2129,78 @@ spec:
                                       type: object
                                     type: array
                                   searches:
-                                    description: A list of DNS search domains for
-                                      host-name lookup. This will be appended to the
-                                      base search paths generated from DNSPolicy.
+                                    description: |-
+                                      A list of DNS search domains for host-name lookup.
+                                      This will be appended to the base search paths generated from DNSPolicy.
                                       Duplicated search paths will be removed.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               dnsPolicy:
-                                description: Set DNS policy for the pod. Defaults
-                                  to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
-                                  'ClusterFirst', 'Default' or 'None'. DNS parameters
-                                  given in DNSConfig will be merged with the policy
-                                  selected with DNSPolicy. To have DNS options set
-                                  along with hostNetwork, you have to specify DNS
-                                  policy explicitly to 'ClusterFirstWithHostNet'.
+                                description: |-
+                                  Set DNS policy for the pod.
+                                  Defaults to "ClusterFirst".
+                                  Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                  DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                  To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                  explicitly to 'ClusterFirstWithHostNet'.
                                 type: string
                               enableServiceLinks:
-                                description: 'EnableServiceLinks indicates whether
-                                  information about services should be injected into
-                                  pod''s environment variables, matching the syntax
-                                  of Docker links. Optional: Defaults to true.'
+                                description: |-
+                                  EnableServiceLinks indicates whether information about services should be injected into pod's
+                                  environment variables, matching the syntax of Docker links.
+                                  Optional: Defaults to true.
                                 type: boolean
                               ephemeralContainers:
-                                description: List of ephemeral containers run in this
-                                  pod. Ephemeral containers may be run in an existing
-                                  pod to perform user-initiated actions such as debugging.
-                                  This list cannot be specified when creating a pod,
-                                  and it cannot be modified by updating the pod spec.
-                                  In order to add an ephemeral container to an existing
-                                  pod, use the pod's ephemeralcontainers subresource.
-                                  This field is alpha-level and is only honored by
-                                  servers that enable the EphemeralContainers feature.
+                                description: |-
+                                  List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                  pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                  creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                  ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                                  This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                                 items:
-                                  description: An EphemeralContainer is a container
-                                    that may be added temporarily to an existing pod
-                                    for user-initiated activities such as debugging.
-                                    Ephemeral containers have no resource or scheduling
-                                    guarantees, and they will not be restarted when
-                                    they exit or when a pod is removed or restarted.
-                                    If an ephemeral container causes a pod to exceed
-                                    its resource allocation, the pod may be evicted.
-                                    Ephemeral containers may not be added by directly
-                                    updating the pod spec. They must be added via
-                                    the pod's ephemeralcontainers subresource, and
-                                    they will appear in the pod spec once added. This
-                                    is an alpha feature enabled by the EphemeralContainers
-                                    feature flag.
+                                  description: |-
+                                    An EphemeralContainer is a container that may be added temporarily to an existing pod for
+                                    user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                    scheduling guarantees, and they will not be restarted when they exit or when a pod is
+                                    removed or restarted. If an ephemeral container causes a pod to exceed its resource
+                                    allocation, the pod may be evicted.
+                                    Ephemeral containers may not be added by directly updating the pod spec. They must be added
+                                    via the pod's ephemeralcontainers subresource, and they will appear in the pod spec
+                                    once added.
+                                    This is an alpha feature enabled by the EphemeralContainers feature flag.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        docker image''s CMD is used if this is not
-                                        provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. The
-                                        $(VAR_NAME) syntax can be escaped with a double
-                                        $$, ie: $$(VAR_NAME). Escaped references will
-                                        never be expanded, regardless of whether the
-                                        variable exists or not. Cannot be updated.
-                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The docker image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax
+                                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                                        regardless of whether the variable exists or not.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The docker image''s ENTRYPOINT
-                                        is used if this is not provided. Variable
-                                        references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. The $(VAR_NAME)
-                                        syntax can be escaped with a double $$, ie:
-                                        $$(VAR_NAME). Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The docker image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax
+                                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                                        regardless of whether the variable exists or not.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -2454,17 +2210,15 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previous defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. The $(VAR_NAME) syntax can
-                                              be escaped with a double $$, ie: $$(VAR_NAME).
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previous defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. The $(VAR_NAME)
+                                              syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                                              references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -2478,10 +2232,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2492,11 +2246,9 @@ spec:
                                                 - key
                                                 type: object
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                                 properties:
                                                   apiVersion:
                                                     description: Version of the schema
@@ -2512,12 +2264,9 @@ spec:
                                                 - fieldPath
                                                 type: object
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -2550,10 +2299,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -2568,15 +2317,13 @@ spec:
                                         type: object
                                       type: array
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -2585,10 +2332,10 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -2604,10 +2351,10 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -2617,46 +2364,41 @@ spec:
                                         type: object
                                       type: array
                                     image:
-                                      description: 'Docker image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images'
+                                      description: |-
+                                        Docker image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
                                       description: Lifecycle is not allowed for ephemeral
                                         containers.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: |-
+                                                One and only one of the following should be specified.
+                                                Exec specifies the action to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -2666,10 +2408,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -2701,23 +2442,24 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: |-
+                                                TCPSocket specifies an action involving a TCP port.
+                                                TCP hooks not yet supported
+                                                TODO: implement a realistic TCP lifecycle hook
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -2728,52 +2470,40 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The reason for termination is
-                                            passed to the handler. The Pod''s termination
-                                            grace period countdown begins before the
-                                            PreStop hooked is executed. Regardless
-                                            of the outcome of the handler, the container
-                                            will eventually terminate within the Pod''s
-                                            termination grace period. Other management
-                                            of the container blocks until the hook
-                                            completes or until the termination grace
-                                            period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The reason for termination is passed to the
+                                            handler. The Pod's termination grace period countdown begins before the
+                                            PreStop hooked is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period. Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: |-
+                                                One and only one of the following should be specified.
+                                                Exec specifies the action to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -2783,10 +2513,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -2818,23 +2547,24 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: |-
+                                                TCPSocket specifies an action involving a TCP port.
+                                                TCP hooks not yet supported
+                                                TODO: implement a realistic TCP lifecycle hook
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -2845,10 +2575,10 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -2860,31 +2590,25 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -2892,10 +2616,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -2927,43 +2650,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -2973,26 +2695,26 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the ephemeral container
-                                        specified as a DNS_LABEL. This name must be
-                                        unique among all containers, init containers
-                                        and ephemeral containers.
+                                      description: |-
+                                        Name of the ephemeral container specified as a DNS_LABEL.
+                                        This name must be unique among all containers, init containers and ephemeral containers.
                                       type: string
                                     ports:
                                       description: Ports are not allowed for ephemeral
@@ -3002,9 +2724,9 @@ spec:
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -3012,25 +2734,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -3041,31 +2762,25 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -3073,10 +2788,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3108,43 +2822,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3154,25 +2867,26 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     resources:
-                                      description: Resources are not allowed for ephemeral
-                                        containers. Ephemeral containers use spare
-                                        resources already allocated to the pod.
+                                      description: |-
+                                        Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                        already allocated to the pod.
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -3181,9 +2895,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -3192,12 +2906,11 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                           type: object
                                       type: object
                                     securityContext:
@@ -3205,19 +2918,18 @@ spec:
                                         for ephemeral containers.
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
                                           type: boolean
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -3235,66 +2947,54 @@ spec:
                                               type: array
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -3314,49 +3014,42 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must only be set
-                                                if type is "Localhost".
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must only be set if type is "Localhost".
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -3364,14 +3057,11 @@ spec:
                                                 spec to use.
                                               type: string
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
@@ -3380,31 +3070,25 @@ spec:
                                         containers.
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -3412,10 +3096,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -3447,43 +3130,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3493,81 +3175,69 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     targetContainerName:
-                                      description: If set, the name of the container
-                                        from PodSpec that this ephemeral container
-                                        targets. The ephemeral container will be run
-                                        in the namespaces (IPC, PID, etc) of this
-                                        container. If not set then the ephemeral container
-                                        is run in whatever namespaces are shared for
-                                        the pod. Note that the container runtime must
-                                        support this feature.
+                                      description: |-
+                                        If set, the name of the container from PodSpec that this ephemeral container targets.
+                                        The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                        If not set then the ephemeral container is run in whatever namespaces are shared
+                                        for the pod. Note that the container runtime must support this feature.
                                       type: string
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -3591,48 +3261,45 @@ spec:
                                         type: object
                                       type: array
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
@@ -3640,24 +3307,24 @@ spec:
                                         type: object
                                       type: array
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
                               hostAliases:
-                                description: HostAliases is an optional list of hosts
-                                  and IPs that will be injected into the pod's hosts
-                                  file if specified. This is only valid for non-hostNetwork
-                                  pods.
+                                description: |-
+                                  HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                  file if specified. This is only valid for non-hostNetwork pods.
                                 items:
-                                  description: HostAlias holds the mapping between
-                                    IP and hostnames that will be injected as an entry
-                                    in the pod's hosts file.
+                                  description: |-
+                                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                    pod's hosts file.
                                   properties:
                                     hostnames:
                                       description: Hostnames for the above IP address.
@@ -3670,100 +3337,94 @@ spec:
                                   type: object
                                 type: array
                               hostIPC:
-                                description: 'Use the host''s ipc namespace. Optional:
-                                  Default to false.'
+                                description: |-
+                                  Use the host's ipc namespace.
+                                  Optional: Default to false.
                                 type: boolean
                               hostNetwork:
-                                description: Host networking requested for this pod.
-                                  Use the host's network namespace. If this option
-                                  is set, the ports that will be used must be specified.
+                                description: |-
+                                  Host networking requested for this pod. Use the host's network namespace.
+                                  If this option is set, the ports that will be used must be specified.
                                   Default to false.
                                 type: boolean
                               hostPID:
-                                description: 'Use the host''s pid namespace. Optional:
-                                  Default to false.'
+                                description: |-
+                                  Use the host's pid namespace.
+                                  Optional: Default to false.
                                 type: boolean
                               hostname:
-                                description: Specifies the hostname of the Pod If
-                                  not specified, the pod's hostname will be set to
-                                  a system-defined value.
+                                description: |-
+                                  Specifies the hostname of the Pod
+                                  If not specified, the pod's hostname will be set to a system-defined value.
                                 type: string
                               imagePullSecrets:
-                                description: 'ImagePullSecrets is an optional list
-                                  of references to secrets in the same namespace to
-                                  use for pulling any of the images used by this PodSpec.
-                                  If specified, these secrets will be passed to individual
-                                  puller implementations for them to use. For example,
-                                  in the case of docker, only DockerConfig type secrets
-                                  are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                description: |-
+                                  ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual puller implementations for them to use. For example,
+                                  in the case of docker, only DockerConfig type secrets are honored.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                                 items:
-                                  description: LocalObjectReference contains enough
-                                    information to let you locate the referenced object
-                                    inside the same namespace.
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                   type: object
                                 type: array
                               initContainers:
-                                description: 'List of initialization containers belonging
-                                  to the pod. Init containers are executed in order
-                                  prior to containers being started. If any init container
-                                  fails, the pod is considered to have failed and
-                                  is handled according to its restartPolicy. The name
-                                  for an init container or normal container must be
-                                  unique among all containers. Init containers may
-                                  not have Lifecycle actions, Readiness probes, Liveness
-                                  probes, or Startup probes. The resourceRequirements
-                                  of an init container are taken into account during
-                                  scheduling by finding the highest request/limit
-                                  for each resource type, and then using the max of
-                                  of that value or the sum of the normal containers.
-                                  Limits are applied to init containers in a similar
-                                  fashion. Init containers cannot currently be added
-                                  or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                                description: |-
+                                  List of initialization containers belonging to the pod.
+                                  Init containers are executed in order prior to containers being started. If any
+                                  init container fails, the pod is considered to have failed and is handled according
+                                  to its restartPolicy. The name for an init container or normal container must be
+                                  unique among all containers.
+                                  Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                                  The resourceRequirements of an init container are taken into account during scheduling
+                                  by finding the highest request/limit for each resource type, and then using the max of
+                                  of that value or the sum of the normal containers. Limits are applied to init containers
+                                  in a similar fashion.
+                                  Init containers cannot currently be added or removed.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                                 items:
                                   description: A single application container that
                                     you want to run within a pod.
                                   properties:
                                     args:
-                                      description: 'Arguments to the entrypoint. The
-                                        docker image''s CMD is used if this is not
-                                        provided. Variable references $(VAR_NAME)
-                                        are expanded using the container''s environment.
-                                        If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. The
-                                        $(VAR_NAME) syntax can be escaped with a double
-                                        $$, ie: $$(VAR_NAME). Escaped references will
-                                        never be expanded, regardless of whether the
-                                        variable exists or not. Cannot be updated.
-                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The docker image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax
+                                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                                        regardless of whether the variable exists or not.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     command:
-                                      description: 'Entrypoint array. Not executed
-                                        within a shell. The docker image''s ENTRYPOINT
-                                        is used if this is not provided. Variable
-                                        references $(VAR_NAME) are expanded using
-                                        the container''s environment. If a variable
-                                        cannot be resolved, the reference in the input
-                                        string will be unchanged. The $(VAR_NAME)
-                                        syntax can be escaped with a double $$, ie:
-                                        $$(VAR_NAME). Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The docker image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax
+                                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                                        regardless of whether the variable exists or not.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                       items:
                                         type: string
                                       type: array
                                     env:
-                                      description: List of environment variables to
-                                        set in the container. Cannot be updated.
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
                                       items:
                                         description: EnvVar represents an environment
                                           variable present in a Container.
@@ -3773,17 +3434,15 @@ spec:
                                               Must be a C_IDENTIFIER.
                                             type: string
                                           value:
-                                            description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previous defined
-                                              environment variables in the container
-                                              and any service environment variables.
-                                              If a variable cannot be resolved, the
-                                              reference in the input string will be
-                                              unchanged. The $(VAR_NAME) syntax can
-                                              be escaped with a double $$, ie: $$(VAR_NAME).
-                                              Escaped references will never be expanded,
-                                              regardless of whether the variable exists
-                                              or not. Defaults to "".'
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previous defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. The $(VAR_NAME)
+                                              syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                                              references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
                                             type: string
                                           valueFrom:
                                             description: Source for the environment
@@ -3797,10 +3456,10 @@ spec:
                                                     description: The key to select.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3811,11 +3470,9 @@ spec:
                                                 - key
                                                 type: object
                                               fieldRef:
-                                                description: 'Selects a field of the
-                                                  pod: supports metadata.name, metadata.namespace,
-                                                  `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                                  spec.nodeName, spec.serviceAccountName,
-                                                  status.hostIP, status.podIP, status.podIPs.'
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                                 properties:
                                                   apiVersion:
                                                     description: Version of the schema
@@ -3831,12 +3488,9 @@ spec:
                                                 - fieldPath
                                                 type: object
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  limits.ephemeral-storage, requests.cpu,
-                                                  requests.memory and requests.ephemeral-storage)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -3869,10 +3523,10 @@ spec:
                                                       secret key.
                                                     type: string
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -3887,15 +3541,13 @@ spec:
                                         type: object
                                       type: array
                                     envFrom:
-                                      description: List of sources to populate environment
-                                        variables in the container. The keys defined
-                                        within a source must be a C_IDENTIFIER. All
-                                        invalid keys will be reported as an event
-                                        when the container is starting. When a key
-                                        exists in multiple sources, the value associated
-                                        with the last source will take precedence.
-                                        Values defined by an Env with a duplicate
-                                        key will take precedence. Cannot be updated.
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                        will be reported as an event when the container is starting. When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
                                       items:
                                         description: EnvFromSource represents the
                                           source of a set of ConfigMaps
@@ -3904,10 +3556,10 @@ spec:
                                             description: The ConfigMap to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the ConfigMap
@@ -3923,10 +3575,10 @@ spec:
                                             description: The Secret to select from
                                             properties:
                                               name:
-                                                description: 'Name of the referent.
+                                                description: |-
+                                                  Name of the referent.
                                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                                 type: string
                                               optional:
                                                 description: Specify whether the Secret
@@ -3936,51 +3588,44 @@ spec:
                                         type: object
                                       type: array
                                     image:
-                                      description: 'Docker image name. More info:
-                                        https://kubernetes.io/docs/concepts/containers/images
-                                        This field is optional to allow higher level
-                                        config management to default or override container
-                                        images in workload controllers like Deployments
-                                        and StatefulSets.'
+                                      description: |-
+                                        Docker image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
                                       type: string
                                     imagePullPolicy:
-                                      description: 'Image pull policy. One of Always,
-                                        Never, IfNotPresent. Defaults to Always if
-                                        :latest tag is specified, or IfNotPresent
-                                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                       type: string
                                     lifecycle:
-                                      description: Actions that the management system
-                                        should take in response to container lifecycle
-                                        events. Cannot be updated.
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
                                       properties:
                                         postStart:
-                                          description: 'PostStart is called immediately
-                                            after a container is created. If the handler
-                                            fails, the container is terminated and
-                                            restarted according to its restart policy.
-                                            Other management of the container blocks
-                                            until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: |-
+                                                One and only one of the following should be specified.
+                                                Exec specifies the action to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -3990,10 +3635,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -4025,23 +3669,24 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: |-
+                                                TCPSocket specifies an action involving a TCP port.
+                                                TCP hooks not yet supported
+                                                TODO: implement a realistic TCP lifecycle hook
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -4052,52 +3697,40 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
                                               type: object
                                           type: object
                                         preStop:
-                                          description: 'PreStop is called immediately
-                                            before a container is terminated due to
-                                            an API request or management event such
-                                            as liveness/startup probe failure, preemption,
-                                            resource contention, etc. The handler
-                                            is not called if the container crashes
-                                            or exits. The reason for termination is
-                                            passed to the handler. The Pod''s termination
-                                            grace period countdown begins before the
-                                            PreStop hooked is executed. Regardless
-                                            of the outcome of the handler, the container
-                                            will eventually terminate within the Pod''s
-                                            termination grace period. Other management
-                                            of the container blocks until the hook
-                                            completes or until the termination grace
-                                            period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The reason for termination is passed to the
+                                            handler. The Pod's termination grace period countdown begins before the
+                                            PreStop hooked is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period. Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: |-
+                                                One and only one of the following should be specified.
+                                                Exec specifies the action to take.
                                               properties:
                                                 command:
-                                                  description: Command is the command
-                                                    line to execute inside the container,
-                                                    the working directory for the
-                                                    command  is root ('/') in the
-                                                    container's filesystem. The command
-                                                    is simply exec'd, it is not run
-                                                    inside a shell, so traditional
-                                                    shell instructions ('|', etc)
-                                                    won't work. To use a shell, you
-                                                    need to explicitly call out to
-                                                    that shell. Exit status of 0 is
-                                                    treated as live/healthy and non-zero
-                                                    is unhealthy.
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                   items:
                                                     type: string
                                                   type: array
@@ -4107,10 +3740,9 @@ spec:
                                                 request to perform.
                                               properties:
                                                 host:
-                                                  description: Host name to connect
-                                                    to, defaults to the pod IP. You
-                                                    probably want to set "Host" in
-                                                    httpHeaders instead.
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
                                                   type: string
                                                 httpHeaders:
                                                   description: Custom headers to set
@@ -4142,23 +3774,24 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Name or number of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                                 scheme:
-                                                  description: Scheme to use for connecting
-                                                    to the host. Defaults to HTTP.
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
                                                   type: string
                                               required:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: |-
+                                                TCPSocket specifies an action involving a TCP port.
+                                                TCP hooks not yet supported
+                                                TODO: implement a realistic TCP lifecycle hook
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -4169,10 +3802,10 @@ spec:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Number or name of the
-                                                    port to access on the container.
-                                                    Number must be in the range 1
-                                                    to 65535. Name must be an IANA_SVC_NAME.
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
                                                   x-kubernetes-int-or-string: true
                                               required:
                                               - port
@@ -4180,36 +3813,32 @@ spec:
                                           type: object
                                       type: object
                                     livenessProbe:
-                                      description: 'Periodic probe of container liveness.
+                                      description: |-
+                                        Periodic probe of container liveness.
                                         Container will be restarted if the probe fails.
-                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -4217,10 +3846,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -4252,43 +3880,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4298,46 +3925,45 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the container specified
-                                        as a DNS_LABEL. Each container in a pod must
-                                        have a unique name (DNS_LABEL). Cannot be
-                                        updated.
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
                                       type: string
                                     ports:
-                                      description: List of ports to expose from the
-                                        container. Exposing a port here gives the
-                                        system additional information about the network
-                                        connections a container uses, but is primarily
-                                        informational. Not specifying a port here
-                                        DOES NOT prevent that port from being exposed.
-                                        Any port which is listening on the default
-                                        "0.0.0.0" address inside a container will
-                                        be accessible from the network. Cannot be
-                                        updated.
+                                      description: |-
+                                        List of ports to expose from the container. Exposing a port here gives
+                                        the system additional information about the network connections a
+                                        container uses, but is primarily informational. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Cannot be updated.
                                       items:
                                         description: ContainerPort represents a network
                                           port in a single container.
                                         properties:
                                           containerPort:
-                                            description: Number of port to expose
-                                              on the pod's IP address. This must be
-                                              a valid port number, 0 < x < 65536.
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
                                             format: int32
                                             type: integer
                                           hostIP:
@@ -4345,25 +3971,24 @@ spec:
                                               external port to.
                                             type: string
                                           hostPort:
-                                            description: Number of port to expose
-                                              on the host. If specified, this must
-                                              be a valid port number, 0 < x < 65536.
-                                              If HostNetwork is specified, this must
-                                              match ContainerPort. Most containers
-                                              do not need this.
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
                                             format: int32
                                             type: integer
                                           name:
-                                            description: If specified, this must be
-                                              an IANA_SVC_NAME and unique within the
-                                              pod. Each named port in a pod must have
-                                              a unique name. Name for the port that
-                                              can be referred to by services.
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
                                             type: string
                                           protocol:
                                             default: TCP
-                                            description: Protocol for port. Must be
-                                              UDP, TCP, or SCTP. Defaults to "TCP".
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
                                             type: string
                                         required:
                                         - containerPort
@@ -4374,37 +3999,32 @@ spec:
                                       - protocol
                                       x-kubernetes-list-type: map
                                     readinessProbe:
-                                      description: 'Periodic probe of container service
-                                        readiness. Container will be removed from
-                                        service endpoints if the probe fails. Cannot
-                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -4412,10 +4032,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -4447,43 +4066,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4493,25 +4111,27 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     resources:
-                                      description: 'Compute Resources required by
-                                        this container. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -4520,9 +4140,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Limits describes the maximum
-                                            amount of compute resources allowed. More
-                                            info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -4531,33 +4151,32 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
-                                          description: 'Requests describes the minimum
-                                            amount of compute resources required.
-                                            If Requests is omitted for a container,
-                                            it defaults to Limits if that is explicitly
-                                            specified, otherwise to an implementation-defined
-                                            value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                           type: object
                                       type: object
                                     securityContext:
-                                      description: 'Security options the pod should
-                                        run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                      description: |-
+                                        Security options the pod should run with.
+                                        More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                       properties:
                                         allowPrivilegeEscalation:
-                                          description: 'AllowPrivilegeEscalation controls
-                                            whether a process can gain more privileges
-                                            than its parent process. This bool directly
-                                            controls if the no_new_privs flag will
-                                            be set on the container process. AllowPrivilegeEscalation
-                                            is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
                                           type: boolean
                                         capabilities:
-                                          description: The capabilities to add/drop
-                                            when running containers. Defaults to the
-                                            default set of capabilities granted by
-                                            the container runtime.
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -4575,66 +4194,54 @@ spec:
                                               type: array
                                           type: object
                                         privileged:
-                                          description: Run container in privileged
-                                            mode. Processes in privileged containers
-                                            are essentially equivalent to root on
-                                            the host. Defaults to false.
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
                                           type: boolean
                                         procMount:
-                                          description: procMount denotes the type
-                                            of proc mount to use for the containers.
-                                            The default is DefaultProcMount which
-                                            uses the container runtime defaults for
-                                            readonly paths and masked paths. This
-                                            requires the ProcMountType feature flag
-                                            to be enabled.
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default is DefaultProcMount which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
                                           type: string
                                         readOnlyRootFilesystem:
-                                          description: Whether this container has
-                                            a read-only root filesystem. Default is
-                                            false.
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
                                           type: boolean
                                         runAsGroup:
-                                          description: The GID to run the entrypoint
-                                            of the container process. Uses runtime
-                                            default if unset. May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
-                                          description: Indicates that the container
-                                            must run as a non-root user. If true,
-                                            the Kubelet will validate the image at
-                                            runtime to ensure that it does not run
-                                            as UID 0 (root) and fail to start the
-                                            container if it does. If unset or false,
-                                            no such validation will be performed.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           type: boolean
                                         runAsUser:
-                                          description: The UID to run the entrypoint
-                                            of the container process. Defaults to
-                                            user specified in image metadata if unspecified.
-                                            May also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
-                                          description: The SELinux context to be applied
-                                            to the container. If unspecified, the
-                                            container runtime will allocate a random
-                                            SELinux context for each container.  May
-                                            also be set in PodSecurityContext.  If
-                                            set in both SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence.
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -4654,49 +4261,42 @@ spec:
                                               type: string
                                           type: object
                                         seccompProfile:
-                                          description: The seccomp options to use
-                                            by this container. If seccomp options
-                                            are provided at both the pod & container
-                                            level, the container options override
-                                            the pod options.
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
                                           properties:
                                             localhostProfile:
-                                              description: localhostProfile indicates
-                                                a profile defined in a file on the
-                                                node should be used. The profile must
-                                                be preconfigured on the node to work.
-                                                Must be a descending path, relative
-                                                to the kubelet's configured seccomp
-                                                profile location. Must only be set
-                                                if type is "Localhost".
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must only be set if type is "Localhost".
                                               type: string
                                             type:
-                                              description: "type indicates which kind
-                                                of seccomp profile will be applied.
-                                                Valid options are: \n Localhost -
-                                                a profile defined in a file on the
-                                                node should be used. RuntimeDefault
-                                                - the container runtime default profile
-                                                should be used. Unconfined - no profile
-                                                should be applied."
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
                                               type: string
                                           required:
                                           - type
                                           type: object
                                         windowsOptions:
-                                          description: The Windows specific settings
-                                            applied to all containers. If unspecified,
-                                            the options from the PodSecurityContext
-                                            will be used. If set in both SecurityContext
-                                            and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence.
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                           properties:
                                             gmsaCredentialSpec:
-                                              description: GMSACredentialSpec is where
-                                                the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                                inlines the contents of the GMSA credential
-                                                spec named by the GMSACredentialSpecName
-                                                field.
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
                                               type: string
                                             gmsaCredentialSpecName:
                                               description: GMSACredentialSpecName
@@ -4704,57 +4304,45 @@ spec:
                                                 spec to use.
                                               type: string
                                             runAsUserName:
-                                              description: The UserName in Windows
-                                                to run the entrypoint of the container
-                                                process. Defaults to the user specified
-                                                in image metadata if unspecified.
-                                                May also be set in PodSecurityContext.
-                                                If set in both SecurityContext and
-                                                PodSecurityContext, the value specified
-                                                in SecurityContext takes precedence.
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
                                               type: string
                                           type: object
                                       type: object
                                     startupProbe:
-                                      description: 'StartupProbe indicates that the
-                                        Pod has successfully initialized. If specified,
-                                        no other probes are executed until this completes
-                                        successfully. If this probe fails, the Pod
-                                        will be restarted, just as if the livenessProbe
-                                        failed. This can be used to provide different
-                                        probe parameters at the beginning of a Pod''s
-                                        lifecycle, when it might take a long time
-                                        to load data or warm a cache, than during
-                                        steady-state operation. This cannot be updated.
-                                        This is a beta feature enabled by the StartupProbe
-                                        feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        This is a beta feature enabled by the StartupProbe feature flag.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: |-
+                                            One and only one of the following should be specified.
+                                            Exec specifies the action to take.
                                           properties:
                                             command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                               items:
                                                 type: string
                                               type: array
                                           type: object
                                         failureThreshold:
-                                          description: Minimum consecutive failures
-                                            for the probe to be considered failed
-                                            after having succeeded. Defaults to 3.
-                                            Minimum value is 1.
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         httpGet:
@@ -4762,10 +4350,9 @@ spec:
                                             request to perform.
                                           properties:
                                             host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
                                               type: string
                                             httpHeaders:
                                               description: Custom headers to set in
@@ -4797,43 +4384,42 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                             scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
                                               type: string
                                           required:
                                           - port
                                           type: object
                                         initialDelaySeconds:
-                                          description: 'Number of seconds after the
-                                            container has started before liveness
-                                            probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                         periodSeconds:
-                                          description: How often (in seconds) to perform
-                                            the probe. Default to 10 seconds. Minimum
-                                            value is 1.
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         successThreshold:
-                                          description: Minimum consecutive successes
-                                            for the probe to be considered successful
-                                            after having failed. Defaults to 1. Must
-                                            be 1 for liveness and startup. Minimum
-                                            value is 1.
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: |-
+                                            TCPSocket specifies an action involving a TCP port.
+                                            TCP hooks not yet supported
+                                            TODO: implement a realistic TCP lifecycle hook
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -4843,71 +4429,62 @@ spec:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
                                               x-kubernetes-int-or-string: true
                                           required:
                                           - port
                                           type: object
                                         timeoutSeconds:
-                                          description: 'Number of seconds after which
-                                            the probe times out. Defaults to 1 second.
-                                            Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                           format: int32
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -4931,48 +4508,45 @@ spec:
                                         type: object
                                       type: array
                                     volumeMounts:
-                                      description: Pod volumes to mount into the container's
-                                        filesystem. Cannot be updated.
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
                                       items:
                                         description: VolumeMount describes a mounting
                                           of a Volume within a container.
                                         properties:
                                           mountPath:
-                                            description: Path within the container
-                                              at which the volume should be mounted.  Must
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
                                               not contain ':'.
                                             type: string
                                           mountPropagation:
-                                            description: mountPropagation determines
-                                              how mounts are propagated from the host
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
                                               to container and the other way around.
-                                              When not set, MountPropagationNone is
-                                              used. This field is beta in 1.10.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
                                             type: string
                                           name:
                                             description: This must match the Name
                                               of a Volume.
                                             type: string
                                           readOnly:
-                                            description: Mounted read-only if true,
-                                              read-write otherwise (false or unspecified).
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
                                               Defaults to false.
                                             type: boolean
                                           subPath:
-                                            description: Path within the volume from
-                                              which the container's volume should
-                                              be mounted. Defaults to "" (volume's
-                                              root).
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
                                             type: string
                                           subPathExpr:
-                                            description: Expanded path within the
-                                              volume from which the container's volume
-                                              should be mounted. Behaves similarly
-                                              to SubPath but environment variable
-                                              references $(VAR_NAME) are expanded
-                                              using the container's environment. Defaults
-                                              to "" (volume's root). SubPathExpr and
-                                              SubPath are mutually exclusive.
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
                                             type: string
                                         required:
                                         - mountPath
@@ -4980,28 +4554,29 @@ spec:
                                         type: object
                                       type: array
                                     workingDir:
-                                      description: Container's working directory.
-                                        If not specified, the container runtime's
-                                        default will be used, which might be configured
-                                        in the container image. Cannot be updated.
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
                                       type: string
                                   required:
                                   - name
                                   type: object
                                 type: array
                               nodeName:
-                                description: NodeName is a request to schedule this
-                                  pod onto a specific node. If it is non-empty, the
-                                  scheduler simply schedules this pod onto that node,
-                                  assuming that it fits resource requirements.
+                                description: |-
+                                  NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                  the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                  requirements.
                                 type: string
                               nodeSelector:
                                 additionalProperties:
                                   type: string
-                                description: 'NodeSelector is a selector which must
-                                  be true for the pod to fit on a node. Selector which
-                                  must match a node''s labels for the pod to be scheduled
-                                  on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                description: |-
+                                  NodeSelector is a selector which must be true for the pod to fit on a node.
+                                  Selector which must match a node's labels for the pod to be scheduled on that node.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                                 type: object
                               overhead:
                                 additionalProperties:
@@ -5010,54 +4585,47 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Overhead represents the resource overhead
-                                  associated with running a pod for a given RuntimeClass.
-                                  This field will be autopopulated at admission time
-                                  by the RuntimeClass admission controller. If the
-                                  RuntimeClass admission controller is enabled, overhead
-                                  must not be set in Pod create requests. The RuntimeClass
-                                  admission controller will reject Pod create requests
-                                  which have the overhead already set. If RuntimeClass
-                                  is configured and selected in the PodSpec, Overhead
-                                  will be set to the value defined in the corresponding
-                                  RuntimeClass, otherwise it will remain unset and
-                                  treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                  This field is alpha-level as of Kubernetes v1.16,
-                                  and is only honored by servers that enable the PodOverhead
-                                  feature.'
+                                description: |-
+                                  Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                  the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                  The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                  set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                                  defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                                  This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.
                                 type: object
                               preemptionPolicy:
-                                description: PreemptionPolicy is the Policy for preempting
-                                  pods with lower priority. One of Never, PreemptLowerPriority.
-                                  Defaults to PreemptLowerPriority if unset. This
-                                  field is beta-level, gated by the NonPreemptingPriority
-                                  feature-gate.
+                                description: |-
+                                  PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                  One of Never, PreemptLowerPriority.
+                                  Defaults to PreemptLowerPriority if unset.
+                                  This field is beta-level, gated by the NonPreemptingPriority feature-gate.
                                 type: string
                               priority:
-                                description: The priority value. Various system components
-                                  use this field to find the priority of the pod.
-                                  When Priority Admission Controller is enabled, it
-                                  prevents users from setting this field. The admission
-                                  controller populates this field from PriorityClassName.
+                                description: |-
+                                  The priority value. Various system components use this field to find the
+                                  priority of the pod. When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission controller populates
+                                  this field from PriorityClassName.
                                   The higher the value, the higher the priority.
                                 format: int32
                                 type: integer
                               priorityClassName:
-                                description: If specified, indicates the pod's priority.
-                                  "system-node-critical" and "system-cluster-critical"
-                                  are two special keywords which indicate the highest
-                                  priorities with the former being the highest priority.
-                                  Any other name must be defined by creating a PriorityClass
-                                  object with that name. If not specified, the pod
-                                  priority will be default or zero if there is no
+                                description: |-
+                                  If specified, indicates the pod's priority. "system-node-critical" and
+                                  "system-cluster-critical" are two special keywords which indicate the
+                                  highest priorities with the former being the highest priority. Any other
+                                  name must be defined by creating a PriorityClass object with that name.
+                                  If not specified, the pod priority will be default or zero if there is no
                                   default.
                                 type: string
                               readinessGates:
-                                description: 'If specified, all readiness gates will
-                                  be evaluated for pod readiness. A pod is ready when
-                                  all its containers are ready AND all conditions
-                                  specified in the readiness gates have status equal
-                                  to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                                description: |-
+                                  If specified, all readiness gates will be evaluated for pod readiness.
+                                  A pod is ready when all its containers are ready AND
+                                  all conditions specified in the readiness gates have status equal to "True"
+                                  More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md
                                 items:
                                   description: PodReadinessGate contains the reference
                                     to a pod condition
@@ -5072,95 +4640,89 @@ spec:
                                   type: object
                                 type: array
                               restartPolicy:
-                                description: 'Restart policy for all containers within
-                                  the pod. One of Always, OnFailure, Never. Default
-                                  to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                                description: |-
+                                  Restart policy for all containers within the pod.
+                                  One of Always, OnFailure, Never.
+                                  Default to Always.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                                 type: string
                               runtimeClassName:
-                                description: 'RuntimeClassName refers to a RuntimeClass
-                                  object in the node.k8s.io group, which should be
-                                  used to run this pod.  If no RuntimeClass resource
-                                  matches the named class, the pod will not be run.
-                                  If unset or empty, the "legacy" RuntimeClass will
-                                  be used, which is an implicit class with an empty
-                                  definition that uses the default runtime handler.
+                                description: |-
+                                  RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                  to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                  empty definition that uses the default runtime handler.
                                   More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                  This is a beta feature as of Kubernetes v1.14.'
+                                  This is a beta feature as of Kubernetes v1.14.
                                 type: string
                               schedulerName:
-                                description: If specified, the pod will be dispatched
-                                  by specified scheduler. If not specified, the pod
-                                  will be dispatched by default scheduler.
+                                description: |-
+                                  If specified, the pod will be dispatched by specified scheduler.
+                                  If not specified, the pod will be dispatched by default scheduler.
                                 type: string
                               securityContext:
-                                description: 'SecurityContext holds pod-level security
-                                  attributes and common container settings. Optional:
-                                  Defaults to empty.  See type description for default
-                                  values of each field.'
+                                description: |-
+                                  SecurityContext holds pod-level security attributes and common container settings.
+                                  Optional: Defaults to empty.  See type description for default values of each field.
                                 properties:
                                   fsGroup:
-                                    description: "A special supplemental group that
-                                      applies to all containers in a pod. Some volume
-                                      types allow the Kubelet to change the ownership
-                                      of that volume to be owned by the pod: \n 1.
-                                      The owning GID will be the FSGroup 2. The setgid
-                                      bit is set (new files created in the volume
-                                      will be owned by FSGroup) 3. The permission
-                                      bits are OR'd with rw-rw---- \n If unset, the
-                                      Kubelet will not modify the ownership and permissions
-                                      of any volume."
+                                    description: |-
+                                      A special supplemental group that applies to all containers in a pod.
+                                      Some volume types allow the Kubelet to change the ownership of that volume
+                                      to be owned by the pod:
+
+
+                                      1. The owning GID will be the FSGroup
+                                      2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                      3. The permission bits are OR'd with rw-rw----
+
+
+                                      If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                     format: int64
                                     type: integer
                                   fsGroupChangePolicy:
-                                    description: 'fsGroupChangePolicy defines behavior
-                                      of changing ownership and permission of the
-                                      volume before being exposed inside Pod. This
-                                      field will only apply to volume types which
-                                      support fsGroup based ownership(and permissions).
-                                      It will have no effect on ephemeral volume types
-                                      such as: secret, configmaps and emptydir. Valid
-                                      values are "OnRootMismatch" and "Always". If
-                                      not specified defaults to "Always".'
+                                    description: |-
+                                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                      before being exposed inside Pod. This field will only apply to
+                                      volume types which support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types such as: secret, configmaps
+                                      and emptydir.
+                                      Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".
                                     type: string
                                   runAsGroup:
-                                    description: The GID to run the entrypoint of
-                                      the container process. Uses runtime default
-                                      if unset. May also be set in SecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence for that container.
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
                                     format: int64
                                     type: integer
                                   runAsNonRoot:
-                                    description: Indicates that the container must
-                                      run as a non-root user. If true, the Kubelet
-                                      will validate the image at runtime to ensure
-                                      that it does not run as UID 0 (root) and fail
-                                      to start the container if it does. If unset
-                                      or false, no such validation will be performed.
-                                      May also be set in SecurityContext.  If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence.
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
-                                    description: The UID to run the entrypoint of
-                                      the container process. Defaults to user specified
-                                      in image metadata if unspecified. May also be
-                                      set in SecurityContext.  If set in both SecurityContext
-                                      and PodSecurityContext, the value specified
-                                      in SecurityContext takes precedence for that
-                                      container.
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
                                     format: int64
                                     type: integer
                                   seLinuxOptions:
-                                    description: The SELinux context to be applied
-                                      to all containers. If unspecified, the container
-                                      runtime will allocate a random SELinux context
-                                      for each container.  May also be set in SecurityContext.  If
-                                      set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence for that container.
+                                    description: |-
+                                      The SELinux context to be applied to all containers.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in SecurityContext.  If set in
+                                      both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                      takes precedence for that container.
                                     properties:
                                       level:
                                         description: Level is SELinux level label
@@ -5184,40 +4746,38 @@ spec:
                                       containers in this pod.
                                     properties:
                                       localhostProfile:
-                                        description: localhostProfile indicates a
-                                          profile defined in a file on the node should
-                                          be used. The profile must be preconfigured
-                                          on the node to work. Must be a descending
-                                          path, relative to the kubelet's configured
-                                          seccomp profile location. Must only be set
-                                          if type is "Localhost".
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must only be set if type is "Localhost".
                                         type: string
                                       type:
-                                        description: "type indicates which kind of
-                                          seccomp profile will be applied. Valid options
-                                          are: \n Localhost - a profile defined in
-                                          a file on the node should be used. RuntimeDefault
-                                          - the container runtime default profile
-                                          should be used. Unconfined - no profile
-                                          should be applied."
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
                                         type: string
                                     required:
                                     - type
                                     type: object
                                   supplementalGroups:
-                                    description: A list of groups applied to the first
-                                      process run in each container, in addition to
-                                      the container's primary GID.  If unspecified,
-                                      no groups will be added to any container.
+                                    description: |-
+                                      A list of groups applied to the first process run in each container, in addition
+                                      to the container's primary GID.  If unspecified, no groups will be added to
+                                      any container.
                                     items:
                                       format: int64
                                       type: integer
                                     type: array
                                   sysctls:
-                                    description: Sysctls hold a list of namespaced
-                                      sysctls used for the pod. Pods with unsupported
-                                      sysctls (by the container runtime) might fail
-                                      to launch.
+                                    description: |-
+                                      Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail to launch.
                                     items:
                                       description: Sysctl defines a kernel parameter
                                         to be set
@@ -5234,146 +4794,124 @@ spec:
                                       type: object
                                     type: array
                                   windowsOptions:
-                                    description: The Windows specific settings applied
-                                      to all containers. If unspecified, the options
-                                      within a container's SecurityContext will be
-                                      used. If set in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence.
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options within a container's SecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     properties:
                                       gmsaCredentialSpec:
-                                        description: GMSACredentialSpec is where the
-                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                          inlines the contents of the GMSA credential
-                                          spec named by the GMSACredentialSpecName
-                                          field.
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
                                         type: string
                                       gmsaCredentialSpecName:
                                         description: GMSACredentialSpecName is the
                                           name of the GMSA credential spec to use.
                                         type: string
                                       runAsUserName:
-                                        description: The UserName in Windows to run
-                                          the entrypoint of the container process.
-                                          Defaults to the user specified in image
-                                          metadata if unspecified. May also be set
-                                          in PodSecurityContext. If set in both SecurityContext
-                                          and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: string
                                     type: object
                                 type: object
                               serviceAccount:
-                                description: 'DeprecatedServiceAccount is a depreciated
-                                  alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                                  instead.'
+                                description: |-
+                                  DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                  Deprecated: Use serviceAccountName instead.
                                 type: string
                               serviceAccountName:
-                                description: 'ServiceAccountName is the name of the
-                                  ServiceAccount to use to run this pod. More info:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                                description: |-
+                                  ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                                 type: string
                               setHostnameAsFQDN:
-                                description: If true the pod's hostname will be configured
-                                  as the pod's FQDN, rather than the leaf name (the
-                                  default). In Linux containers, this means setting
-                                  the FQDN in the hostname field of the kernel (the
-                                  nodename field of struct utsname). In Windows containers,
-                                  this means setting the registry value of hostname
-                                  for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters
-                                  to FQDN. If a pod does not have FQDN, this has no
-                                  effect. Default to false.
+                                description: |-
+                                  If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                  In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                                  In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                                  If a pod does not have FQDN, this has no effect.
+                                  Default to false.
                                 type: boolean
                               shareProcessNamespace:
-                                description: 'Share a single process namespace between
-                                  all of the containers in a pod. When this is set
-                                  containers will be able to view and signal processes
-                                  from other containers in the same pod, and the first
-                                  process in each container will not be assigned PID
-                                  1. HostPID and ShareProcessNamespace cannot both
-                                  be set. Optional: Default to false.'
+                                description: |-
+                                  Share a single process namespace between all of the containers in a pod.
+                                  When this is set containers will be able to view and signal processes from other containers
+                                  in the same pod, and the first process in each container will not be assigned PID 1.
+                                  HostPID and ShareProcessNamespace cannot both be set.
+                                  Optional: Default to false.
                                 type: boolean
                               subdomain:
-                                description: If specified, the fully qualified Pod
-                                  hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                                  domain>". If not specified, the pod will not have
-                                  a domainname at all.
+                                description: |-
+                                  If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                  If not specified, the pod will not have a domainname at all.
                                 type: string
                               terminationGracePeriodSeconds:
-                                description: Optional duration in seconds the pod
-                                  needs to terminate gracefully. May be decreased
-                                  in delete request. Value must be non-negative integer.
-                                  The value zero indicates delete immediately. If
-                                  this value is nil, the default grace period will
-                                  be used instead. The grace period is the duration
-                                  in seconds after the processes running in the pod
-                                  are sent a termination signal and the time when
-                                  the processes are forcibly halted with a kill signal.
-                                  Set this value longer than the expected cleanup
-                                  time for your process. Defaults to 30 seconds.
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                  Value must be non-negative integer. The value zero indicates delete immediately.
+                                  If this value is nil, the default grace period will be used instead.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  Defaults to 30 seconds.
                                 format: int64
                                 type: integer
                               tolerations:
                                 description: If specified, the pod's tolerations.
                                 items:
-                                  description: The pod this Toleration is attached
-                                    to tolerates any taint that matches the triple
-                                    <key,value,effect> using the matching operator
-                                    <operator>.
+                                  description: |-
+                                    The pod this Toleration is attached to tolerates any taint that matches
+                                    the triple <key,value,effect> using the matching operator <operator>.
                                   properties:
                                     effect:
-                                      description: Effect indicates the taint effect
-                                        to match. Empty means match all taint effects.
-                                        When specified, allowed values are NoSchedule,
-                                        PreferNoSchedule and NoExecute.
+                                      description: |-
+                                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                       type: string
                                     key:
-                                      description: Key is the taint key that the toleration
-                                        applies to. Empty means match all taint keys.
-                                        If the key is empty, operator must be Exists;
-                                        this combination means to match all values
-                                        and all keys.
+                                      description: |-
+                                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                       type: string
                                     operator:
-                                      description: Operator represents a key's relationship
-                                        to the value. Valid operators are Exists and
-                                        Equal. Defaults to Equal. Exists is equivalent
-                                        to wildcard for value, so that a pod can tolerate
-                                        all taints of a particular category.
+                                      description: |-
+                                        Operator represents a key's relationship to the value.
+                                        Valid operators are Exists and Equal. Defaults to Equal.
+                                        Exists is equivalent to wildcard for value, so that a pod can
+                                        tolerate all taints of a particular category.
                                       type: string
                                     tolerationSeconds:
-                                      description: TolerationSeconds represents the
-                                        period of time the toleration (which must
-                                        be of effect NoExecute, otherwise this field
-                                        is ignored) tolerates the taint. By default,
-                                        it is not set, which means tolerate the taint
-                                        forever (do not evict). Zero and negative
-                                        values will be treated as 0 (evict immediately)
-                                        by the system.
+                                      description: |-
+                                        TolerationSeconds represents the period of time the toleration (which must be
+                                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                        negative values will be treated as 0 (evict immediately) by the system.
                                       format: int64
                                       type: integer
                                     value:
-                                      description: Value is the taint value the toleration
-                                        matches to. If the operator is Exists, the
-                                        value should be empty, otherwise just a regular
-                                        string.
+                                      description: |-
+                                        Value is the taint value the toleration matches to.
+                                        If the operator is Exists, the value should be empty, otherwise just a regular string.
                                       type: string
                                   type: object
                                 type: array
                               topologySpreadConstraints:
-                                description: TopologySpreadConstraints describes how
-                                  a group of pods ought to spread across topology
-                                  domains. Scheduler will schedule pods in a way which
-                                  abides by the constraints. All topologySpreadConstraints
-                                  are ANDed.
+                                description: |-
+                                  TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                  All topologySpreadConstraints are ANDed.
                                 items:
                                   description: TopologySpreadConstraint specifies
                                     how to spread matching pods among the given topology.
                                   properties:
                                     labelSelector:
-                                      description: LabelSelector is used to find matching
-                                        pods. Pods that match this label selector
-                                        are counted to determine the number of pods
+                                      description: |-
+                                        LabelSelector is used to find matching pods.
+                                        Pods that match this label selector are counted to determine the number of pods
                                         in their corresponding topology domain.
                                       properties:
                                         matchExpressions:
@@ -5381,30 +4919,25 @@ spec:
                                             of label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key
                                                   that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -5416,66 +4949,58 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     maxSkew:
-                                      description: 'MaxSkew describes the degree to
-                                        which pods may be unevenly distributed. When
-                                        `whenUnsatisfiable=DoNotSchedule`, it is the
-                                        maximum permitted difference between the number
-                                        of matching pods in the target topology and
-                                        the global minimum. For example, in a 3-zone
-                                        cluster, MaxSkew is set to 1, and pods with
-                                        the same labelSelector spread as 1/1/0: |
-                                        zone1 | zone2 | zone3 | |   P   |   P   |       |
-                                        - if MaxSkew is 1, incoming pod can only be
-                                        scheduled to zone3 to become 1/1/1; scheduling
-                                        it onto zone1(zone2) would make the ActualSkew(2-0)
-                                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                        is 2, incoming pod can be scheduled onto any
-                                        zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                                        it is used to give higher precedence to topologies
-                                        that satisfy it. It''s a required field. Default
-                                        value is 1 and 0 is not allowed.'
+                                      description: |-
+                                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                        between the number of matching pods in the target topology and the global minimum.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 1/1/0:
+                                        | zone1 | zone2 | zone3 |
+                                        |   P   |   P   |       |
+                                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1;
+                                        scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2)
+                                        violate MaxSkew(1).
+                                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                        to topologies that satisfy it.
+                                        It's a required field. Default value is 1 and 0 is not allowed.
                                       format: int32
                                       type: integer
                                     topologyKey:
-                                      description: TopologyKey is the key of node
-                                        labels. Nodes that have a label with this
-                                        key and identical values are considered to
-                                        be in the same topology. We consider each
-                                        <key, value> as a "bucket", and try to put
-                                        balanced number of pods into each bucket.
+                                      description: |-
+                                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                                        and identical values are considered to be in the same topology.
+                                        We consider each <key, value> as a "bucket", and try to put balanced number
+                                        of pods into each bucket.
                                         It's a required field.
                                       type: string
                                     whenUnsatisfiable:
-                                      description: 'WhenUnsatisfiable indicates how
-                                        to deal with a pod if it doesn''t satisfy
-                                        the spread constraint. - DoNotSchedule (default)
-                                        tells the scheduler not to schedule it. -
-                                        ScheduleAnyway tells the scheduler to schedule
-                                        the pod in any location, but giving higher
-                                        precedence to topologies that would help reduce
-                                        the skew. A constraint is considered "Unsatisfiable"
-                                        for an incoming pod if and only if every possible
-                                        node assigment for that pod would violate
-                                        "MaxSkew" on some topology. For example, in
-                                        a 3-zone cluster, MaxSkew is set to 1, and
-                                        pods with the same labelSelector spread as
-                                        3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                                        If WhenUnsatisfiable is set to DoNotSchedule,
-                                        incoming pod can only be scheduled to zone2(zone3)
-                                        to become 3/2/1(3/1/2) as ActualSkew(2-1)
-                                        on zone2(zone3) satisfies MaxSkew(1). In other
-                                        words, the cluster can still be imbalanced,
-                                        but scheduler won''t make it *more* imbalanced.
-                                        It''s a required field.'
+                                      description: |-
+                                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                        the spread constraint.
+                                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                          but giving higher precedence to topologies that would help reduce the
+                                          skew.
+                                        A constraint is considered "Unsatisfiable" for an incoming pod
+                                        if and only if every possible node assigment for that pod would violate
+                                        "MaxSkew" on some topology.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 3/1/1:
+                                        | zone1 | zone2 | zone3 |
+                                        | P P P |   P   |   P   |
+                                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                        won't make it *more* imbalanced.
+                                        It's a required field.
                                       type: string
                                   required:
                                   - maxSkew
@@ -5488,49 +5013,46 @@ spec:
                                 - whenUnsatisfiable
                                 x-kubernetes-list-type: map
                               volumes:
-                                description: 'List of volumes that can be mounted
-                                  by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                                description: |-
+                                  List of volumes that can be mounted by containers belonging to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes
                                 items:
                                   description: Volume represents a named volume in
                                     a pod that may be accessed by any container in
                                     the pod.
                                   properties:
                                     awsElasticBlockStore:
-                                      description: 'AWSElasticBlockStore represents
-                                        an AWS Disk resource that is attached to a
-                                        kubelet''s host machine and then exposed to
-                                        the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                      description: |-
+                                        AWSElasticBlockStore represents an AWS Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                       properties:
                                         fsType:
-                                          description: 'Filesystem type of the volume
-                                            that you want to mount. Tip: Ensure that
-                                            the filesystem type is supported by the
-                                            host operating system. Examples: "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                          description: |-
+                                            Filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
-                                          description: 'The partition in the volume
-                                            that you want to mount. If omitted, the
-                                            default is to mount by volume name. Examples:
-                                            For volume /dev/sda1, you specify the
-                                            partition as "1". Similarly, the volume
-                                            partition for /dev/sda is "0" (or you
-                                            can leave the property empty).'
+                                          description: |-
+                                            The partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'Specify "true" to force and
-                                            set the ReadOnly property in VolumeMounts
-                                            to "true". If omitted, the default is
-                                            "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          description: |-
+                                            Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
+                                            If omitted, the default is "false".
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           type: boolean
                                         volumeID:
-                                          description: 'Unique ID of the persistent
-                                            disk resource in AWS (Amazon EBS volume).
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                          description: |-
+                                            Unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           type: string
                                       required:
                                       - volumeID
@@ -5553,11 +5075,10 @@ spec:
                                             blob storage
                                           type: string
                                         fsType:
-                                          description: Filesystem type to mount. Must
-                                            be a filesystem type supported by the
-                                            host operating system. Ex. "ext4", "xfs",
-                                            "ntfs". Implicitly inferred to be "ext4"
-                                            if unspecified.
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         kind:
                                           description: 'Expected values Shared: multiple
@@ -5567,9 +5088,9 @@ spec:
                                             availability set). defaults to shared'
                                           type: string
                                         readOnly:
-                                          description: Defaults to false (read/write).
-                                            ReadOnly here will force the ReadOnly
-                                            setting in VolumeMounts.
+                                          description: |-
+                                            Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                       required:
                                       - diskName
@@ -5581,9 +5102,9 @@ spec:
                                         the pod.
                                       properties:
                                         readOnly:
-                                          description: Defaults to false (read/write).
-                                            ReadOnly here will force the ReadOnly
-                                            setting in VolumeMounts.
+                                          description: |-
+                                            Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretName:
                                           description: the name of secret that contains
@@ -5601,8 +5122,9 @@ spec:
                                         on the host that shares a pod's lifetime
                                       properties:
                                         monitors:
-                                          description: 'Required: Monitors is a collection
-                                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            Required: Monitors is a collection of Ceph monitors
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           items:
                                             type: string
                                           type: array
@@ -5612,69 +5134,70 @@ spec:
                                             default is /'
                                           type: string
                                         readOnly:
-                                          description: 'Optional: Defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            Optional: Defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: boolean
                                         secretFile:
-                                          description: 'Optional: SecretFile is the
-                                            path to key ring for User, default is
-                                            /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: string
                                         secretRef:
-                                          description: 'Optional: SecretRef is reference
-                                            to the authentication secret for User,
-                                            default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                         user:
-                                          description: 'Optional: User is the rados
-                                            user name, default is admin More info:
-                                            https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                          description: |-
+                                            Optional: User is the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                           type: string
                                       required:
                                       - monitors
                                       type: object
                                     cinder:
-                                      description: 'Cinder represents a cinder volume
-                                        attached and mounted on kubelets host machine.
-                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                      description: |-
+                                        Cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                       properties:
                                         fsType:
-                                          description: 'Filesystem type to mount.
-                                            Must be a filesystem type supported by
-                                            the host operating system. Examples: "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: string
                                         readOnly:
-                                          description: 'Optional: Defaults to false
-                                            (read/write). ReadOnly here will force
+                                          description: |-
+                                            Optional: Defaults to false (read/write). ReadOnly here will force
                                             the ReadOnly setting in VolumeMounts.
-                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: boolean
                                         secretRef:
-                                          description: 'Optional: points to a secret
-                                            object containing parameters used to connect
-                                            to OpenStack.'
+                                          description: |-
+                                            Optional: points to a secret object containing parameters used to connect
+                                            to OpenStack.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                         volumeID:
-                                          description: 'volume id used to identify
-                                            the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                          description: |-
+                                            volume id used to identify the volume in cinder.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                           type: string
                                       required:
                                       - volumeID
@@ -5684,33 +5207,25 @@ spec:
                                         that should populate this volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on created files by default.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. Defaults to 0644. Directories
-                                            within the path are not affected by this
-                                            setting. This might be in conflict with
-                                            other options that affect the file mode,
-                                            like fsGroup, and the result can be other
-                                            mode bits set.'
+                                          description: |-
+                                            Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
-                                          description: If unspecified, each key-value
-                                            pair in the Data field of the referenced
-                                            ConfigMap will be projected into the volume
-                                            as a file whose name is the key and content
-                                            is the value. If specified, the listed
-                                            keys will be projected into the specified
-                                            paths, and unlisted keys will not be present.
-                                            If a key is specified which is not present
-                                            in the ConfigMap, the volume setup will
-                                            error unless it is marked optional. Paths
-                                            must be relative and may not contain the
-                                            '..' path or start with '..'.
+                                          description: |-
+                                            If unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
                                           items:
                                             description: Maps a string key to a path
                                               within a volume.
@@ -5719,27 +5234,21 @@ spec:
                                                 description: The key to project.
                                                 type: string
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file. Must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: The relative path of
-                                                  the file to map the key to. May
-                                                  not be an absolute path. May not
-                                                  contain the path element '..'. May
-                                                  not start with the string '..'.
+                                                description: |-
+                                                  The relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                             - key
@@ -5747,10 +5256,10 @@ spec:
                                             type: object
                                           type: array
                                         name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description: Specify whether the ConfigMap
@@ -5763,47 +5272,42 @@ spec:
                                         by certain external CSI drivers (Beta feature).
                                       properties:
                                         driver:
-                                          description: Driver is the name of the CSI
-                                            driver that handles this volume. Consult
-                                            with your admin for the correct name as
-                                            registered in the cluster.
+                                          description: |-
+                                            Driver is the name of the CSI driver that handles this volume.
+                                            Consult with your admin for the correct name as registered in the cluster.
                                           type: string
                                         fsType:
-                                          description: Filesystem type to mount. Ex.
-                                            "ext4", "xfs", "ntfs". If not provided,
-                                            the empty value is passed to the associated
-                                            CSI driver which will determine the default
-                                            filesystem to apply.
+                                          description: |-
+                                            Filesystem type to mount. Ex. "ext4", "xfs", "ntfs".
+                                            If not provided, the empty value is passed to the associated CSI driver
+                                            which will determine the default filesystem to apply.
                                           type: string
                                         nodePublishSecretRef:
-                                          description: NodePublishSecretRef is a reference
-                                            to the secret object containing sensitive
-                                            information to pass to the CSI driver
-                                            to complete the CSI NodePublishVolume
-                                            and NodeUnpublishVolume calls. This field
-                                            is optional, and  may be empty if no secret
-                                            is required. If the secret object contains
-                                            more than one secret, all secret references
-                                            are passed.
+                                          description: |-
+                                            NodePublishSecretRef is a reference to the secret object containing
+                                            sensitive information to pass to the CSI driver to complete the CSI
+                                            NodePublishVolume and NodeUnpublishVolume calls.
+                                            This field is optional, and  may be empty if no secret is required. If the
+                                            secret object contains more than one secret, all secret references are passed.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                         readOnly:
-                                          description: Specifies a read-only configuration
-                                            for the volume. Defaults to false (read/write).
+                                          description: |-
+                                            Specifies a read-only configuration for the volume.
+                                            Defaults to false (read/write).
                                           type: boolean
                                         volumeAttributes:
                                           additionalProperties:
                                             type: string
-                                          description: VolumeAttributes stores driver-specific
-                                            properties that are passed to the CSI
-                                            driver. Consult your driver's documentation
-                                            for supported values.
+                                          description: |-
+                                            VolumeAttributes stores driver-specific properties that are passed to the CSI
+                                            driver. Consult your driver's documentation for supported values.
                                           type: object
                                       required:
                                       - driver
@@ -5814,20 +5318,15 @@ spec:
                                         volume
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits to use
-                                            on created files by default. Must be a
-                                            Optional: mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Defaults to 0644. Directories within
-                                            the path are not affected by this setting.
-                                            This might be in conflict with other options
-                                            that affect the file mode, like fsGroup,
-                                            and the result can be other mode bits
-                                            set.'
+                                          description: |-
+                                            Optional: mode bits to use on created files by default. Must be a
+                                            Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
@@ -5857,19 +5356,13 @@ spec:
                                                 - fieldPath
                                                 type: object
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file, must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
@@ -5882,11 +5375,9 @@ spec:
                                                   with ''..'''
                                                 type: string
                                               resourceFieldRef:
-                                                description: 'Selects a resource of
-                                                  the container: only resources limits
-                                                  and requests (limits.cpu, limits.memory,
-                                                  requests.cpu and requests.memory)
-                                                  are currently supported.'
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                 properties:
                                                   containerName:
                                                     description: 'Container name:
@@ -5915,146 +5406,134 @@ spec:
                                           type: array
                                       type: object
                                     emptyDir:
-                                      description: 'EmptyDir represents a temporary
-                                        directory that shares a pod''s lifetime. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                      description: |-
+                                        EmptyDir represents a temporary directory that shares a pod's lifetime.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                       properties:
                                         medium:
-                                          description: 'What type of storage medium
-                                            should back this directory. The default
-                                            is "" which means to use the node''s default
-                                            medium. Must be an empty string (default)
-                                            or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                          description: |-
+                                            What type of storage medium should back this directory.
+                                            The default is "" which means to use the node's default medium.
+                                            Must be an empty string (default) or Memory.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                           type: string
                                         sizeLimit:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: 'Total amount of local storage
-                                            required for this EmptyDir volume. The
-                                            size limit is also applicable for memory
-                                            medium. The maximum usage on memory medium
-                                            EmptyDir would be the minimum value between
-                                            the SizeLimit specified here and the sum
-                                            of memory limits of all containers in
-                                            a pod. The default is nil which means
-                                            that the limit is undefined. More info:
-                                            http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                          description: |-
+                                            Total amount of local storage required for this EmptyDir volume.
+                                            The size limit is also applicable for memory medium.
+                                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                            The default is nil which means that the limit is undefined.
+                                            More info: http://kubernetes.io/docs/user-guide/volumes#emptydir
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                       type: object
                                     ephemeral:
-                                      description: "Ephemeral represents a volume
-                                        that is handled by a cluster storage driver
-                                        (Alpha feature). The volume's lifecycle is
-                                        tied to the pod that defines it - it will
-                                        be created before the pod starts, and deleted
-                                        when the pod is removed. \n Use this if: a)
-                                        the volume is only needed while the pod runs,
-                                        b) features of normal volumes like restoring
-                                        from snapshot or capacity tracking are needed,
-                                        c) the storage driver is specified through
-                                        a storage class, and d) the storage driver
-                                        supports dynamic volume provisioning through
-                                        a PersistentVolumeClaim (see EphemeralVolumeSource
-                                        for more information on the connection between
-                                        this volume type and PersistentVolumeClaim).
-                                        \n Use PersistentVolumeClaim or one of the
-                                        vendor-specific APIs for volumes that persist
-                                        for longer than the lifecycle of an individual
-                                        pod. \n Use CSI for light-weight local ephemeral
-                                        volumes if the CSI driver is meant to be used
-                                        that way - see the documentation of the driver
-                                        for more information. \n A pod can use both
-                                        types of ephemeral volumes and persistent
-                                        volumes at the same time."
+                                      description: |-
+                                        Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature).
+                                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                        and deleted when the pod is removed.
+
+
+                                        Use this if:
+                                        a) the volume is only needed while the pod runs,
+                                        b) features of normal volumes like restoring from snapshot or capacity
+                                           tracking are needed,
+                                        c) the storage driver is specified through a storage class, and
+                                        d) the storage driver supports dynamic volume provisioning through
+                                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                           information on the connection between this volume type
+                                           and PersistentVolumeClaim).
+
+
+                                        Use PersistentVolumeClaim or one of the vendor-specific
+                                        APIs for volumes that persist for longer than the lifecycle
+                                        of an individual pod.
+
+
+                                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                        be used that way - see the documentation of the driver for
+                                        more information.
+
+
+                                        A pod can use both types of ephemeral volumes and
+                                        persistent volumes at the same time.
                                       properties:
                                         readOnly:
-                                          description: Specifies a read-only configuration
-                                            for the volume. Defaults to false (read/write).
+                                          description: |-
+                                            Specifies a read-only configuration for the volume.
+                                            Defaults to false (read/write).
                                           type: boolean
                                         volumeClaimTemplate:
-                                          description: "Will be used to create a stand-alone
-                                            PVC to provision the volume. The pod in
-                                            which this EphemeralVolumeSource is embedded
-                                            will be the owner of the PVC, i.e. the
-                                            PVC will be deleted together with the
-                                            pod.  The name of the PVC will be `<pod
-                                            name>-<volume name>` where `<volume name>`
-                                            is the name from the `PodSpec.Volumes`
-                                            array entry. Pod validation will reject
-                                            the pod if the concatenated name is not
-                                            valid for a PVC (for example, too long).
-                                            \n An existing PVC with that name that
-                                            is not owned by the pod will *not* be
-                                            used for the pod to avoid using an unrelated
-                                            volume by mistake. Starting the pod is
-                                            then blocked until the unrelated PVC is
-                                            removed. If such a pre-created PVC is
-                                            meant to be used by the pod, the PVC has
-                                            to updated with an owner reference to
-                                            the pod once the pod exists. Normally
-                                            this should not be necessary, but it may
-                                            be useful when manually reconstructing
-                                            a broken cluster. \n This field is read-only
-                                            and no changes will be made by Kubernetes
+                                          description: |-
+                                            Will be used to create a stand-alone PVC to provision the volume.
+                                            The pod in which this EphemeralVolumeSource is embedded will be the
+                                            owner of the PVC, i.e. the PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                                            entry. Pod validation will reject the pod if the concatenated name
+                                            is not valid for a PVC (for example, too long).
+
+
+                                            An existing PVC with that name that is not owned by the pod
+                                            will *not* be used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is then blocked until
+                                            the unrelated PVC is removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has to updated with an
+                                            owner reference to the pod once the pod exists. Normally
+                                            this should not be necessary, but it may be useful when
+                                            manually reconstructing a broken cluster.
+
+
+                                            This field is read-only and no changes will be made by Kubernetes
                                             to the PVC after it has been created.
-                                            \n Required, must not be nil."
+
+
+                                            Required, must not be nil.
                                           properties:
                                             metadata:
-                                              description: May contain labels and
-                                                annotations that will be copied into
-                                                the PVC when creating it. No other
-                                                fields are allowed and will be rejected
-                                                during validation.
+                                              description: |-
+                                                May contain labels and annotations that will be copied into the PVC
+                                                when creating it. No other fields are allowed and will be rejected during
+                                                validation.
                                               type: object
                                             spec:
-                                              description: The specification for the
-                                                PersistentVolumeClaim. The entire
-                                                content is copied unchanged into the
-                                                PVC that gets created from this template.
-                                                The same fields as in a PersistentVolumeClaim
+                                              description: |-
+                                                The specification for the PersistentVolumeClaim. The entire content is
+                                                copied unchanged into the PVC that gets created from this
+                                                template. The same fields as in a PersistentVolumeClaim
                                                 are also valid here.
                                               properties:
                                                 accessModes:
-                                                  description: 'AccessModes contains
-                                                    the desired access modes the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                  description: |-
+                                                    AccessModes contains the desired access modes the volume should have.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                                   items:
                                                     type: string
                                                   type: array
                                                 dataSource:
-                                                  description: 'This field can be
-                                                    used to specify either: * An existing
-                                                    VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                    - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                    * An existing custom resource/object
-                                                    that implements data population
-                                                    (Alpha) In order to use VolumeSnapshot
-                                                    object types, the appropriate
-                                                    feature gate must be enabled (VolumeSnapshotDataSource
-                                                    or AnyVolumeDataSource) If the
-                                                    provisioner or an external controller
-                                                    can support the specified data
-                                                    source, it will create a new volume
-                                                    based on the contents of the specified
-                                                    data source. If the specified
-                                                    data source is not supported,
-                                                    the volume will not be created
-                                                    and the failure will be reported
-                                                    as an event. In the future, we
-                                                    plan to support more data source
-                                                    types and the behavior of the
-                                                    provisioner may change.'
+                                                  description: |-
+                                                    This field can be used to specify either:
+                                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta)
+                                                    * An existing PVC (PersistentVolumeClaim)
+                                                    * An existing custom resource/object that implements data population (Alpha)
+                                                    In order to use VolumeSnapshot object types, the appropriate feature gate
+                                                    must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                                    If the provisioner or an external controller can support the specified data source,
+                                                    it will create a new volume based on the contents of the specified data source.
+                                                    If the specified data source is not supported, the volume will
+                                                    not be created and the failure will be reported as an event.
+                                                    In the future, we plan to support more data source types and the behavior
+                                                    of the provisioner may change.
                                                   properties:
                                                     apiGroup:
-                                                      description: APIGroup is the
-                                                        group for the resource being
-                                                        referenced. If APIGroup is
-                                                        not specified, the specified
-                                                        Kind must be in the core API
-                                                        group. For any other third-party
-                                                        types, APIGroup is required.
+                                                      description: |-
+                                                        APIGroup is the group for the resource being referenced.
+                                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                        For any other third-party types, APIGroup is required.
                                                       type: string
                                                     kind:
                                                       description: Kind is the type
@@ -6069,9 +5548,9 @@ spec:
                                                   - name
                                                   type: object
                                                 resources:
-                                                  description: 'Resources represents
-                                                    the minimum resources the volume
-                                                    should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  description: |-
+                                                    Resources represents the minimum resources the volume should have.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                                   properties:
                                                     limits:
                                                       additionalProperties:
@@ -6080,10 +5559,9 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Limits describes
-                                                        the maximum amount of compute
-                                                        resources allowed. More info:
-                                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      description: |-
+                                                        Limits describes the maximum amount of compute resources allowed.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                                       type: object
                                                     requests:
                                                       additionalProperties:
@@ -6092,14 +5570,11 @@ spec:
                                                         - type: string
                                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                         x-kubernetes-int-or-string: true
-                                                      description: 'Requests describes
-                                                        the minimum amount of compute
-                                                        resources required. If Requests
-                                                        is omitted for a container,
-                                                        it defaults to Limits if that
-                                                        is explicitly specified, otherwise
-                                                        to an implementation-defined
-                                                        value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      description: |-
+                                                        Requests describes the minimum amount of compute resources required.
+                                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                        otherwise to an implementation-defined value.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                                                       type: object
                                                   type: object
                                                 selector:
@@ -6112,10 +5587,8 @@ spec:
                                                         requirements. The requirements
                                                         are ANDed.
                                                       items:
-                                                        description: A label selector
-                                                          requirement is a selector
-                                                          that contains values, a
-                                                          key, and an operator that
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
                                                           relates the key and values.
                                                         properties:
                                                           key:
@@ -6124,24 +5597,15 @@ spec:
                                                               applies to.
                                                             type: string
                                                           operator:
-                                                            description: operator
-                                                              represents a key's relationship
-                                                              to a set of values.
-                                                              Valid operators are
-                                                              In, NotIn, Exists and
-                                                              DoesNotExist.
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                                             type: string
                                                           values:
-                                                            description: values is
-                                                              an array of string values.
-                                                              If the operator is In
-                                                              or NotIn, the values
-                                                              array must be non-empty.
-                                                              If the operator is Exists
-                                                              or DoesNotExist, the
-                                                              values array must be
-                                                              empty. This array is
-                                                              replaced during a strategic
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
                                                               merge patch.
                                                             items:
                                                               type: string
@@ -6154,29 +5618,21 @@ spec:
                                                     matchLabels:
                                                       additionalProperties:
                                                         type: string
-                                                      description: matchLabels is
-                                                        a map of {key,value} pairs.
-                                                        A single {key,value} in the
-                                                        matchLabels map is equivalent
-                                                        to an element of matchExpressions,
-                                                        whose key field is "key",
-                                                        the operator is "In", and
-                                                        the values array contains
-                                                        only "value". The requirements
-                                                        are ANDed.
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                       type: object
                                                   type: object
                                                 storageClassName:
-                                                  description: 'Name of the StorageClass
-                                                    required by the claim. More info:
-                                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                  description: |-
+                                                    Name of the StorageClass required by the claim.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                                   type: string
                                                 volumeMode:
-                                                  description: volumeMode defines
-                                                    what type of volume is required
-                                                    by the claim. Value of Filesystem
-                                                    is implied when not included in
-                                                    claim spec.
+                                                  description: |-
+                                                    volumeMode defines what type of volume is required by the claim.
+                                                    Value of Filesystem is implied when not included in claim spec.
                                                   type: string
                                                 volumeName:
                                                   description: VolumeName is the binding
@@ -6194,22 +5650,20 @@ spec:
                                         and then exposed to the pod.
                                       properties:
                                         fsType:
-                                          description: 'Filesystem type to mount.
-                                            Must be a filesystem type supported by
-                                            the host operating system. Ex. "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. TODO: how do
-                                            we prevent errors in the filesystem from
-                                            compromising the machine'
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         lun:
                                           description: 'Optional: FC target lun number'
                                           format: int32
                                           type: integer
                                         readOnly:
-                                          description: 'Optional: Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.'
+                                          description: |-
+                                            Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         targetWWNs:
                                           description: 'Optional: FC target worldwide
@@ -6218,29 +5672,27 @@ spec:
                                             type: string
                                           type: array
                                         wwids:
-                                          description: 'Optional: FC volume world
-                                            wide identifiers (wwids) Either wwids
-                                            or combination of targetWWNs and lun must
-                                            be set, but not both simultaneously.'
+                                          description: |-
+                                            Optional: FC volume world wide identifiers (wwids)
+                                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     flexVolume:
-                                      description: FlexVolume represents a generic
-                                        volume resource that is provisioned/attached
-                                        using an exec based plugin.
+                                      description: |-
+                                        FlexVolume represents a generic volume resource that is
+                                        provisioned/attached using an exec based plugin.
                                       properties:
                                         driver:
                                           description: Driver is the name of the driver
                                             to use for this volume.
                                           type: string
                                         fsType:
-                                          description: Filesystem type to mount. Must
-                                            be a filesystem type supported by the
-                                            host operating system. Ex. "ext4", "xfs",
-                                            "ntfs". The default filesystem depends
-                                            on FlexVolume script.
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                           type: string
                                         options:
                                           additionalProperties:
@@ -6249,24 +5701,23 @@ spec:
                                             if any.'
                                           type: object
                                         readOnly:
-                                          description: 'Optional: Defaults to false
-                                            (read/write). ReadOnly here will force
-                                            the ReadOnly setting in VolumeMounts.'
+                                          description: |-
+                                            Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: 'Optional: SecretRef is reference
-                                            to the secret object containing sensitive
-                                            information to pass to the plugin scripts.
-                                            This may be empty if no secret object
-                                            is specified. If the secret object contains
-                                            more than one secret, all secrets are
-                                            passed to the plugin scripts.'
+                                          description: |-
+                                            Optional: SecretRef is reference to the secret object containing
+                                            sensitive information to pass to the plugin scripts. This may be
+                                            empty if no secret object is specified. If the secret object
+                                            contains more than one secret, all secrets are passed to the plugin
+                                            scripts.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                       required:
@@ -6279,9 +5730,9 @@ spec:
                                         running
                                       properties:
                                         datasetName:
-                                          description: Name of the dataset stored
-                                            as metadata -> name on the dataset for
-                                            Flocker should be considered as deprecated
+                                          description: |-
+                                            Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                            should be considered as deprecated
                                           type: string
                                         datasetUUID:
                                           description: UUID of the dataset. This is
@@ -6289,61 +5740,55 @@ spec:
                                           type: string
                                       type: object
                                     gcePersistentDisk:
-                                      description: 'GCEPersistentDisk represents a
-                                        GCE Disk resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                      description: |-
+                                        GCEPersistentDisk represents a GCE Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                       properties:
                                         fsType:
-                                          description: 'Filesystem type of the volume
-                                            that you want to mount. Tip: Ensure that
-                                            the filesystem type is supported by the
-                                            host operating system. Examples: "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                          description: |-
+                                            Filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         partition:
-                                          description: 'The partition in the volume
-                                            that you want to mount. If omitted, the
-                                            default is to mount by volume name. Examples:
-                                            For volume /dev/sda1, you specify the
-                                            partition as "1". Similarly, the volume
-                                            partition for /dev/sda is "0" (or you
-                                            can leave the property empty). More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            The partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           format: int32
                                           type: integer
                                         pdName:
-                                          description: 'Unique name of the PD resource
-                                            in GCE. Used to identify the disk in GCE.
-                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            Unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           type: string
                                         readOnly:
-                                          description: 'ReadOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                          description: |-
+                                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           type: boolean
                                       required:
                                       - pdName
                                       type: object
                                     gitRepo:
-                                      description: 'GitRepo represents a git repository
-                                        at a particular revision. DEPRECATED: GitRepo
-                                        is deprecated. To provision a container with
-                                        a git repo, mount an EmptyDir into an InitContainer
-                                        that clones the repo using git, then mount
-                                        the EmptyDir into the Pod''s container.'
+                                      description: |-
+                                        GitRepo represents a git repository at a particular revision.
+                                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                        into the Pod's container.
                                       properties:
                                         directory:
-                                          description: Target directory name. Must
-                                            not contain or start with '..'.  If '.'
-                                            is supplied, the volume directory will
-                                            be the git repository.  Otherwise, if
-                                            specified, the volume will contain the
-                                            git repository in the subdirectory with
-                                            the given name.
+                                          description: |-
+                                            Target directory name.
+                                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                            the subdirectory with the given name.
                                           type: string
                                         repository:
                                           description: Repository URL
@@ -6356,59 +5801,61 @@ spec:
                                       - repository
                                       type: object
                                     glusterfs:
-                                      description: 'Glusterfs represents a Glusterfs
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                      description: |-
+                                        Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                       properties:
                                         endpoints:
-                                          description: 'EndpointsName is the endpoint
-                                            name that details Glusterfs topology.
-                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            EndpointsName is the endpoint name that details Glusterfs topology.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: string
                                         path:
-                                          description: 'Path is the Glusterfs volume
-                                            path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            Path is the Glusterfs volume path.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: string
                                         readOnly:
-                                          description: 'ReadOnly here will force the
-                                            Glusterfs volume to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                          description: |-
+                                            ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                           type: boolean
                                       required:
                                       - endpoints
                                       - path
                                       type: object
                                     hostPath:
-                                      description: 'HostPath represents a pre-existing
-                                        file or directory on the host machine that
-                                        is directly exposed to the container. This
-                                        is generally used for system agents or other
-                                        privileged things that are allowed to see
-                                        the host machine. Most containers will NOT
-                                        need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                        --- TODO(jonesdl) We need to restrict who
-                                        can use host directory mounts and who can/can
-                                        not mount host directories as read/write.'
+                                      description: |-
+                                        HostPath represents a pre-existing file or directory on the host
+                                        machine that is directly exposed to the container. This is generally
+                                        used for system agents or other privileged things that are allowed
+                                        to see the host machine. Most containers will NOT need this.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        ---
+                                        TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                        mount host directories as read/write.
                                       properties:
                                         path:
-                                          description: 'Path of the directory on the
-                                            host. If the path is a symlink, it will
-                                            follow the link to the real path. More
-                                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: |-
+                                            Path of the directory on the host.
+                                            If the path is a symlink, it will follow the link to the real path.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                           type: string
                                         type:
-                                          description: 'Type for HostPath Volume Defaults
-                                            to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                          description: |-
+                                            Type for HostPath Volume
+                                            Defaults to ""
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                           type: string
                                       required:
                                       - path
                                       type: object
                                     iscsi:
-                                      description: 'ISCSI represents an ISCSI Disk
-                                        resource that is attached to a kubelet''s
-                                        host machine and then exposed to the pod.
-                                        More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                      description: |-
+                                        ISCSI represents an ISCSI Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://examples.k8s.io/volumes/iscsi/README.md
                                       properties:
                                         chapAuthDiscovery:
                                           description: whether support iSCSI Discovery
@@ -6419,63 +5866,58 @@ spec:
                                             CHAP authentication
                                           type: boolean
                                         fsType:
-                                          description: 'Filesystem type of the volume
-                                            that you want to mount. Tip: Ensure that
-                                            the filesystem type is supported by the
-                                            host operating system. Examples: "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                          description: |-
+                                            Filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         initiatorName:
-                                          description: Custom iSCSI Initiator Name.
-                                            If initiatorName is specified with iscsiInterface
-                                            simultaneously, new iSCSI interface <target
-                                            portal>:<volume name> will be created
-                                            for the connection.
+                                          description: |-
+                                            Custom iSCSI Initiator Name.
+                                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                            <target portal>:<volume name> will be created for the connection.
                                           type: string
                                         iqn:
                                           description: Target iSCSI Qualified Name.
                                           type: string
                                         iscsiInterface:
-                                          description: iSCSI Interface Name that uses
-                                            an iSCSI transport. Defaults to 'default'
-                                            (tcp).
+                                          description: |-
+                                            iSCSI Interface Name that uses an iSCSI transport.
+                                            Defaults to 'default' (tcp).
                                           type: string
                                         lun:
                                           description: iSCSI Target Lun number.
                                           format: int32
                                           type: integer
                                         portals:
-                                          description: iSCSI Target Portal List. The
-                                            portal is either an IP or ip_addr:port
-                                            if the port is other than default (typically
-                                            TCP ports 860 and 3260).
+                                          description: |-
+                                            iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
                                           items:
                                             type: string
                                           type: array
                                         readOnly:
-                                          description: ReadOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false.
+                                          description: |-
+                                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
                                           type: boolean
                                         secretRef:
                                           description: CHAP Secret for iSCSI target
                                             and initiator authentication
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                         targetPortal:
-                                          description: iSCSI Target Portal. The Portal
-                                            is either an IP or ip_addr:port if the
-                                            port is other than default (typically
-                                            TCP ports 860 and 3260).
+                                          description: |-
+                                            iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
                                           type: string
                                       required:
                                       - iqn
@@ -6483,47 +5925,52 @@ spec:
                                       - targetPortal
                                       type: object
                                     name:
-                                      description: 'Volume''s name. Must be a DNS_LABEL
-                                        and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      description: |-
+                                        Volume's name.
+                                        Must be a DNS_LABEL and unique within the pod.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       type: string
                                     nfs:
-                                      description: 'NFS represents an NFS mount on
-                                        the host that shares a pod''s lifetime More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                      description: |-
+                                        NFS represents an NFS mount on the host that shares a pod's lifetime
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                       properties:
                                         path:
-                                          description: 'Path that is exported by the
-                                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            Path that is exported by the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: string
                                         readOnly:
-                                          description: 'ReadOnly here will force the
-                                            NFS export to be mounted with read-only
-                                            permissions. Defaults to false. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            ReadOnly here will force
+                                            the NFS export to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: boolean
                                         server:
-                                          description: 'Server is the hostname or
-                                            IP address of the NFS server. More info:
-                                            https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                          description: |-
+                                            Server is the hostname or IP address of the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                           type: string
                                       required:
                                       - path
                                       - server
                                       type: object
                                     persistentVolumeClaim:
-                                      description: 'PersistentVolumeClaimVolumeSource
-                                        represents a reference to a PersistentVolumeClaim
-                                        in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                      description: |-
+                                        PersistentVolumeClaimVolumeSource represents a reference to a
+                                        PersistentVolumeClaim in the same namespace.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                       properties:
                                         claimName:
-                                          description: 'ClaimName is the name of a
-                                            PersistentVolumeClaim in the same namespace
-                                            as the pod using this volume. More info:
-                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                          description: |-
+                                            ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                           type: string
                                         readOnly:
-                                          description: Will force the ReadOnly setting
-                                            in VolumeMounts. Default false.
+                                          description: |-
+                                            Will force the ReadOnly setting in VolumeMounts.
+                                            Default false.
                                           type: boolean
                                       required:
                                       - claimName
@@ -6534,11 +5981,10 @@ spec:
                                         and mounted on kubelets host machine
                                       properties:
                                         fsType:
-                                          description: Filesystem type to mount. Must
-                                            be a filesystem type supported by the
-                                            host operating system. Ex. "ext4", "xfs",
-                                            "ntfs". Implicitly inferred to be "ext4"
-                                            if unspecified.
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         pdID:
                                           description: ID that identifies Photon Controller
@@ -6553,16 +5999,15 @@ spec:
                                         machine
                                       properties:
                                         fsType:
-                                          description: FSType represents the filesystem
-                                            type to mount Must be a filesystem type
-                                            supported by the host operating system.
-                                            Ex. "ext4", "xfs". Implicitly inferred
-                                            to be "ext4" if unspecified.
+                                          description: |-
+                                            FSType represents the filesystem type to mount
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: Defaults to false (read/write).
-                                            ReadOnly here will force the ReadOnly
-                                            setting in VolumeMounts.
+                                          description: |-
+                                            Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         volumeID:
                                           description: VolumeID uniquely identifies
@@ -6576,17 +6021,13 @@ spec:
                                         secrets, configmaps, and downward API
                                       properties:
                                         defaultMode:
-                                          description: Mode bits used to set permissions
-                                            on created files by default. Must be an
-                                            octal value between 0000 and 0777 or a
-                                            decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. Directories within the path are
-                                            not affected by this setting. This might
-                                            be in conflict with other options that
-                                            affect the file mode, like fsGroup, and
-                                            the result can be other mode bits set.
+                                          description: |-
+                                            Mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         sources:
@@ -6600,23 +6041,14 @@ spec:
                                                   configMap data to project
                                                 properties:
                                                   items:
-                                                    description: If unspecified, each
-                                                      key-value pair in the Data field
-                                                      of the referenced ConfigMap
-                                                      will be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the ConfigMap, the volume
-                                                      setup will error unless it is
-                                                      marked optional. Paths must
-                                                      be relative and may not contain
-                                                      the '..' path or start with
-                                                      '..'.
+                                                    description: |-
+                                                      If unspecified, each key-value pair in the Data field of the referenced
+                                                      ConfigMap will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the ConfigMap,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
                                                     items:
                                                       description: Maps a string key
                                                         to a path within a volume.
@@ -6626,34 +6058,21 @@ spec:
                                                             project.
                                                           type: string
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
+                                                          description: |-
+                                                            Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: The relative
-                                                            path of the file to map
-                                                            the key to. May not be
-                                                            an absolute path. May
-                                                            not contain the path element
-                                                            '..'. May not start with
-                                                            the string '..'.
+                                                          description: |-
+                                                            The relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -6661,10 +6080,10 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -6709,24 +6128,13 @@ spec:
                                                           - fieldPath
                                                           type: object
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file,
-                                                            must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
+                                                          description: |-
+                                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
                                                           format: int32
                                                           type: integer
                                                         path:
@@ -6742,13 +6150,9 @@ spec:
                                                             ''..'''
                                                           type: string
                                                         resourceFieldRef:
-                                                          description: 'Selects a
-                                                            resource of the container:
-                                                            only resources limits
-                                                            and requests (limits.cpu,
-                                                            limits.memory, requests.cpu
-                                                            and requests.memory) are
-                                                            currently supported.'
+                                                          description: |-
+                                                            Selects a resource of the container: only resources limits and requests
+                                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                           properties:
                                                             containerName:
                                                               description: 'Container
@@ -6783,22 +6187,14 @@ spec:
                                                   secret data to project
                                                 properties:
                                                   items:
-                                                    description: If unspecified, each
-                                                      key-value pair in the Data field
-                                                      of the referenced Secret will
-                                                      be projected into the volume
-                                                      as a file whose name is the
-                                                      key and content is the value.
-                                                      If specified, the listed keys
-                                                      will be projected into the specified
-                                                      paths, and unlisted keys will
-                                                      not be present. If a key is
-                                                      specified which is not present
-                                                      in the Secret, the volume setup
-                                                      will error unless it is marked
-                                                      optional. Paths must be relative
-                                                      and may not contain the '..'
-                                                      path or start with '..'.
+                                                    description: |-
+                                                      If unspecified, each key-value pair in the Data field of the referenced
+                                                      Secret will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the Secret,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
                                                     items:
                                                       description: Maps a string key
                                                         to a path within a volume.
@@ -6808,34 +6204,21 @@ spec:
                                                             project.
                                                           type: string
                                                         mode:
-                                                          description: 'Optional:
-                                                            mode bits used to set
-                                                            permissions on this file.
-                                                            Must be an octal value
-                                                            between 0000 and 0777
-                                                            or a decimal value between
-                                                            0 and 511. YAML accepts
-                                                            both octal and decimal
-                                                            values, JSON requires
-                                                            decimal values for mode
-                                                            bits. If not specified,
-                                                            the volume defaultMode
-                                                            will be used. This might
-                                                            be in conflict with other
-                                                            options that affect the
-                                                            file mode, like fsGroup,
-                                                            and the result can be
-                                                            other mode bits set.'
+                                                          description: |-
+                                                            Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
                                                           format: int32
                                                           type: integer
                                                         path:
-                                                          description: The relative
-                                                            path of the file to map
-                                                            the key to. May not be
-                                                            an absolute path. May
-                                                            not contain the path element
-                                                            '..'. May not start with
-                                                            the string '..'.
+                                                          description: |-
+                                                            The relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
                                                           type: string
                                                       required:
                                                       - key
@@ -6843,10 +6226,10 @@ spec:
                                                       type: object
                                                     type: array
                                                   name:
-                                                    description: 'Name of the referent.
+                                                    description: |-
+                                                      Name of the referent.
                                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                      TODO: Add other useful fields.
-                                                      apiVersion, kind, uid?'
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                                     type: string
                                                   optional:
                                                     description: Specify whether the
@@ -6858,37 +6241,26 @@ spec:
                                                   serviceAccountToken data to project
                                                 properties:
                                                   audience:
-                                                    description: Audience is the intended
-                                                      audience of the token. A recipient
-                                                      of a token must identify itself
-                                                      with an identifier specified
-                                                      in the audience of the token,
-                                                      and otherwise should reject
-                                                      the token. The audience defaults
-                                                      to the identifier of the apiserver.
+                                                    description: |-
+                                                      Audience is the intended audience of the token. A recipient of a token
+                                                      must identify itself with an identifier specified in the audience of the
+                                                      token, and otherwise should reject the token. The audience defaults to the
+                                                      identifier of the apiserver.
                                                     type: string
                                                   expirationSeconds:
-                                                    description: ExpirationSeconds
-                                                      is the requested duration of
-                                                      validity of the service account
-                                                      token. As the token approaches
-                                                      expiration, the kubelet volume
-                                                      plugin will proactively rotate
-                                                      the service account token. The
-                                                      kubelet will start trying to
-                                                      rotate the token if the token
-                                                      is older than 80 percent of
-                                                      its time to live or if the token
-                                                      is older than 24 hours.Defaults
-                                                      to 1 hour and must be at least
-                                                      10 minutes.
+                                                    description: |-
+                                                      ExpirationSeconds is the requested duration of validity of the service
+                                                      account token. As the token approaches expiration, the kubelet volume
+                                                      plugin will proactively rotate the service account token. The kubelet will
+                                                      start trying to rotate the token if the token is older than 80 percent of
+                                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                      and must be at least 10 minutes.
                                                     format: int64
                                                     type: integer
                                                   path:
-                                                    description: Path is the path
-                                                      relative to the mount point
-                                                      of the file to project the token
-                                                      into.
+                                                    description: |-
+                                                      Path is the path relative to the mount point of the file to project the
+                                                      token into.
                                                     type: string
                                                 required:
                                                 - path
@@ -6903,30 +6275,29 @@ spec:
                                         on the host that shares a pod's lifetime
                                       properties:
                                         group:
-                                          description: Group to map volume access
-                                            to Default is no group
+                                          description: |-
+                                            Group to map volume access to
+                                            Default is no group
                                           type: string
                                         readOnly:
-                                          description: ReadOnly here will force the
-                                            Quobyte volume to be mounted with read-only
-                                            permissions. Defaults to false.
+                                          description: |-
+                                            ReadOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                            Defaults to false.
                                           type: boolean
                                         registry:
-                                          description: Registry represents a single
-                                            or multiple Quobyte Registry services
-                                            specified as a string as host:port pair
-                                            (multiple entries are separated with commas)
-                                            which acts as the central registry for
-                                            volumes
+                                          description: |-
+                                            Registry represents a single or multiple Quobyte Registry services
+                                            specified as a string as host:port pair (multiple entries are separated with commas)
+                                            which acts as the central registry for volumes
                                           type: string
                                         tenant:
-                                          description: Tenant owning the given Quobyte
-                                            volume in the Backend Used with dynamically
-                                            provisioned Quobyte volumes, value is
-                                            set by the plugin
+                                          description: |-
+                                            Tenant owning the given Quobyte volume in the Backend
+                                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                           type: string
                                         user:
-                                          description: User to map volume access to
+                                          description: |-
+                                            User to map volume access to
                                             Defaults to serivceaccount user
                                           type: string
                                         volume:
@@ -6938,59 +6309,67 @@ spec:
                                       - volume
                                       type: object
                                     rbd:
-                                      description: 'RBD represents a Rados Block Device
-                                        mount on the host that shares a pod''s lifetime.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                      description: |-
+                                        RBD represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md
                                       properties:
                                         fsType:
-                                          description: 'Filesystem type of the volume
-                                            that you want to mount. Tip: Ensure that
-                                            the filesystem type is supported by the
-                                            host operating system. Examples: "ext4",
-                                            "xfs", "ntfs". Implicitly inferred to
-                                            be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                            TODO: how do we prevent errors in the
-                                            filesystem from compromising the machine'
+                                          description: |-
+                                            Filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                            TODO: how do we prevent errors in the filesystem from compromising the machine
                                           type: string
                                         image:
-                                          description: 'The rados image name. More
-                                            info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            The rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         keyring:
-                                          description: 'Keyring is the path to key
-                                            ring for RBDUser. Default is /etc/ceph/keyring.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            Keyring is the path to key ring for RBDUser.
+                                            Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         monitors:
-                                          description: 'A collection of Ceph monitors.
-                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            A collection of Ceph monitors.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           items:
                                             type: string
                                           type: array
                                         pool:
-                                          description: 'The rados pool name. Default
-                                            is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            The rados pool name.
+                                            Default is rbd.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                         readOnly:
-                                          description: 'ReadOnly here will force the
-                                            ReadOnly setting in VolumeMounts. Defaults
-                                            to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: boolean
                                         secretRef:
-                                          description: 'SecretRef is name of the authentication
-                                            secret for RBDUser. If provided overrides
-                                            keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            SecretRef is name of the authentication secret for RBDUser. If provided
+                                            overrides keyring.
+                                            Default is nil.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                         user:
-                                          description: 'The rados user name. Default
-                                            is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                          description: |-
+                                            The rados user name.
+                                            Default is admin.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                           type: string
                                       required:
                                       - image
@@ -7002,10 +6381,11 @@ spec:
                                         nodes.
                                       properties:
                                         fsType:
-                                          description: Filesystem type to mount. Must
-                                            be a filesystem type supported by the
-                                            host operating system. Ex. "ext4", "xfs",
-                                            "ntfs". Default is "xfs".
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs".
+                                            Default is "xfs".
                                           type: string
                                         gateway:
                                           description: The host address of the ScaleIO
@@ -7016,21 +6396,20 @@ spec:
                                             Domain for the configured storage.
                                           type: string
                                         readOnly:
-                                          description: Defaults to false (read/write).
-                                            ReadOnly here will force the ReadOnly
-                                            setting in VolumeMounts.
+                                          description: |-
+                                            Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: SecretRef references to the
-                                            secret for ScaleIO user and other sensitive
-                                            information. If this is not provided,
-                                            Login operation will fail.
+                                          description: |-
+                                            SecretRef references to the secret for ScaleIO user and other
+                                            sensitive information. If this is not provided, Login operation will fail.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                         sslEnabled:
@@ -7038,9 +6417,9 @@ spec:
                                             communication with Gateway, default false
                                           type: boolean
                                         storageMode:
-                                          description: Indicates whether the storage
-                                            for a volume should be ThickProvisioned
-                                            or ThinProvisioned. Default is ThinProvisioned.
+                                          description: |-
+                                            Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                            Default is ThinProvisioned.
                                           type: string
                                         storagePool:
                                           description: The ScaleIO Storage Pool associated
@@ -7051,9 +6430,9 @@ spec:
                                             as configured in ScaleIO.
                                           type: string
                                         volumeName:
-                                          description: The name of a volume already
-                                            created in the ScaleIO system that is
-                                            associated with this volume source.
+                                          description: |-
+                                            The name of a volume already created in the ScaleIO system
+                                            that is associated with this volume source.
                                           type: string
                                       required:
                                       - gateway
@@ -7061,37 +6440,30 @@ spec:
                                       - system
                                       type: object
                                     secret:
-                                      description: 'Secret represents a secret that
-                                        should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                      description: |-
+                                        Secret represents a secret that should populate this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                       properties:
                                         defaultMode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on created files by default.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. Defaults to 0644. Directories
-                                            within the path are not affected by this
-                                            setting. This might be in conflict with
-                                            other options that affect the file mode,
-                                            like fsGroup, and the result can be other
-                                            mode bits set.'
+                                          description: |-
+                                            Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values
+                                            for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         items:
-                                          description: If unspecified, each key-value
-                                            pair in the Data field of the referenced
-                                            Secret will be projected into the volume
-                                            as a file whose name is the key and content
-                                            is the value. If specified, the listed
-                                            keys will be projected into the specified
-                                            paths, and unlisted keys will not be present.
-                                            If a key is specified which is not present
-                                            in the Secret, the volume setup will error
-                                            unless it is marked optional. Paths must
-                                            be relative and may not contain the '..'
-                                            path or start with '..'.
+                                          description: |-
+                                            If unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
                                           items:
                                             description: Maps a string key to a path
                                               within a volume.
@@ -7100,27 +6472,21 @@ spec:
                                                 description: The key to project.
                                                 type: string
                                               mode:
-                                                description: 'Optional: mode bits
-                                                  used to set permissions on this
-                                                  file. Must be an octal value between
-                                                  0000 and 0777 or a decimal value
-                                                  between 0 and 511. YAML accepts
-                                                  both octal and decimal values, JSON
-                                                  requires decimal values for mode
-                                                  bits. If not specified, the volume
-                                                  defaultMode will be used. This might
-                                                  be in conflict with other options
-                                                  that affect the file mode, like
-                                                  fsGroup, and the result can be other
-                                                  mode bits set.'
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
                                                 format: int32
                                                 type: integer
                                               path:
-                                                description: The relative path of
-                                                  the file to map the key to. May
-                                                  not be an absolute path. May not
-                                                  contain the path element '..'. May
-                                                  not start with the string '..'.
+                                                description: |-
+                                                  The relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
                                                 type: string
                                             required:
                                             - key
@@ -7132,8 +6498,9 @@ spec:
                                             or its keys must be defined
                                           type: boolean
                                         secretName:
-                                          description: 'Name of the secret in the
-                                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          description: |-
+                                            Name of the secret in the pod's namespace to use.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                           type: string
                                       type: object
                                     storageos:
@@ -7142,47 +6509,41 @@ spec:
                                         nodes.
                                       properties:
                                         fsType:
-                                          description: Filesystem type to mount. Must
-                                            be a filesystem type supported by the
-                                            host operating system. Ex. "ext4", "xfs",
-                                            "ntfs". Implicitly inferred to be "ext4"
-                                            if unspecified.
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         readOnly:
-                                          description: Defaults to false (read/write).
-                                            ReadOnly here will force the ReadOnly
-                                            setting in VolumeMounts.
+                                          description: |-
+                                            Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
                                           type: boolean
                                         secretRef:
-                                          description: SecretRef specifies the secret
-                                            to use for obtaining the StorageOS API
-                                            credentials.  If not specified, default
-                                            values will be attempted.
+                                          description: |-
+                                            SecretRef specifies the secret to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default values will be attempted.
                                           properties:
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                           type: object
                                         volumeName:
-                                          description: VolumeName is the human-readable
-                                            name of the StorageOS volume.  Volume
+                                          description: |-
+                                            VolumeName is the human-readable name of the StorageOS volume.  Volume
                                             names are only unique within a namespace.
                                           type: string
                                         volumeNamespace:
-                                          description: VolumeNamespace specifies the
-                                            scope of the volume within StorageOS.  If
-                                            no namespace is specified then the Pod's
-                                            namespace will be used.  This allows the
-                                            Kubernetes name scoping to be mirrored
-                                            within StorageOS for tighter integration.
-                                            Set VolumeName to any name to override
-                                            the default behaviour. Set to "default"
-                                            if you are not using namespaces within
-                                            StorageOS. Namespaces that do not pre-exist
-                                            within StorageOS will be created.
+                                          description: |-
+                                            VolumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                            namespace is specified then the Pod's namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override the default behaviour.
+                                            Set to "default" if you are not using namespaces within StorageOS.
+                                            Namespaces that do not pre-exist within StorageOS will be created.
                                           type: string
                                       type: object
                                     vsphereVolume:
@@ -7191,11 +6552,10 @@ spec:
                                         machine
                                       properties:
                                         fsType:
-                                          description: Filesystem type to mount. Must
-                                            be a filesystem type supported by the
-                                            host operating system. Ex. "ext4", "xfs",
-                                            "ntfs". Implicitly inferred to be "ext4"
-                                            if unspecified.
+                                          description: |-
+                                            Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                           type: string
                                         storagePolicyID:
                                           description: Storage Policy Based Management
@@ -7222,16 +6582,16 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: ttlSecondsAfterFinished limits the lifetime of
-                          a Job that has finished execution (either Complete or Failed).
-                          If this field is set, ttlSecondsAfterFinished after the
-                          Job finishes, it is eligible to be automatically deleted.
-                          When the Job is being deleted, its lifecycle guarantees
-                          (e.g. finalizers) will be honored. If this field is unset,
-                          the Job won't be automatically deleted. If this field is
-                          set to zero, the Job becomes eligible to be deleted immediately
-                          after it finishes. This field is alpha-level and is only
-                          honored by servers that enable the TTLAfterFinished feature.
+                        description: |-
+                          ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                          execution (either Complete or Failed). If this field is set,
+                          ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                          automatically deleted. When the Job is being deleted, its lifecycle
+                          guarantees (e.g. finalizers) will be honored. If this field is unset,
+                          the Job won't be automatically deleted. If this field is set to zero,
+                          the Job becomes eligible to be deleted immediately after it finishes.
+                          This field is alpha-level and is only honored by servers that enable the
+                          TTLAfterFinished feature.
                         format: int32
                         type: integer
                     required:
@@ -7324,8 +6684,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               nestedStructWithSeveralFieldsDoubleMarked:
-                description: A struct that can only be entirely replaced via a nested
-                  type and field markers.
+                description: |-
+                  A struct that can only be entirely replaced via a nested type and
+                  field markers.
                 properties:
                   bar:
                     type: boolean
@@ -7357,8 +6718,9 @@ spec:
                 - secondary
                 x-kubernetes-list-type: map
               noReallySuspend:
-                description: This flag is like suspend, but for when you really mean
-                  it. It helps test the +kubebuilder:validation:Type marker.
+                description: |-
+                  This flag is like suspend, but for when you really mean it.
+                  It helps test the +kubebuilder:validation:Type marker.
                 type: string
               patternObject:
                 description: This tests that pattern validator is properly applied.
@@ -7375,9 +6737,9 @@ spec:
               schemaless:
                 description: This tests that the schemaless marker works
               startingDeadlineSeconds:
-                description: Optional deadline in seconds for starting the job if
-                  it misses scheduled time for any reason.  Missed jobs executions
-                  will be counted as failed ones.
+                description: |-
+                  Optional deadline in seconds for starting the job if it misses scheduled
+                  time for any reason.  Missed jobs executions will be counted as failed ones.
                 format: int64
                 type: integer
               stringSliceData:
@@ -7408,14 +6770,15 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               successfulJobsHistoryLimit:
-                description: The number of successful finished jobs to retain. This
-                  is a pointer to distinguish between explicit zero and not specified.
+                description: |-
+                  The number of successful finished jobs to retain.
+                  This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
               suspend:
-                description: This flag tells the controller to suspend subsequent
-                  executions, it does not apply to already started executions.  Defaults
-                  to false.
+                description: |-
+                  This flag tells the controller to suspend subsequent executions, it does
+                  not apply to already started executions.  Defaults to false.
                 type: boolean
               twoOfAKindPart0:
                 description: This tests that markers that are allowed on both fields
@@ -7490,75 +6853,75 @@ spec:
               active:
                 description: A list of pointers to currently running jobs.
                 items:
-                  description: 'ObjectReference contains enough information to let
-                    you inspect or modify the referred object. --- New uses of this
-                    type are discouraged because of difficulty describing its usage
-                    when embedded in APIs. 1. Ignored fields.  It includes many fields
-                    which are not generally honored.  For instance, ResourceVersion
-                    and FieldPath are both very rarely valid in actual usage. 2. Invalid
-                    usage help.  It is impossible to add specific help for individual
-                    usage.  In most embedded usages, there are particular restrictions
-                    like, "must refer only to types A and B" or "UID not honored"
-                    or "name must be restricted". Those cannot be well described when
-                    embedded. 3. Inconsistent validation.  Because the usages are
-                    different, the validation rules are different by usage, which
-                    makes it hard for users to predict what will happen. 4. The fields
-                    are both imprecise and overly precise.  Kind is not a precise
-                    mapping to a URL. This can produce ambiguity during interpretation
-                    and require a REST mapping.  In most cases, the dependency is
-                    on the group,resource tuple and the version of the actual struct
-                    is irrelevant. 5. We cannot easily change it.  Because this type
-                    is embedded in many locations, updates to this type will affect
-                    numerous schemas.  Don''t make new APIs embed an underspecified
-                    API type they do not control. Instead of using this type, create
-                    a locally provided and used type that is well-focused on your
-                    reference. For example, ServiceReferences for admission registration:
-                    https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                    .'
+                  description: |-
+                    ObjectReference contains enough information to let you inspect or modify the referred object.
+                    ---
+                    New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                     1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                     2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                        restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                        Those cannot be well described when embedded.
+                     3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                     4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                        during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                        and the version of the actual struct is irrelevant.
+                     5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+                    Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                    For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
                   properties:
                     apiVersion:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                        an entire object, this string should contain a valid JSON/Go
-                        field access statement, such as desiredState.manifest.containers[2].
-                        For example, if the object reference is to a container within
-                        a pod, this would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that triggered
-                        the event) or if no container name is specified "spec.containers[2]"
-                        (container with index 2 in this pod). This syntax is chosen
-                        only to have some well-defined way of referencing a part of
-                        an object. TODO: this design is not final and this field is
-                        subject to change in the future.'
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
                   type: object
                 type: array
               duration:
-                description: Duration has a custom Marshaler but no markers. We want
-                  the CRD generation to infer type information from the go types and
-                  ignore the presense of the Marshaler.
+                description: |-
+                  Duration has a custom Marshaler but no markers.
+                  We want the CRD generation to infer type information
+                  from the go types and ignore the presense of the Marshaler.
                 properties:
                   value:
-                    description: A Duration represents the elapsed time between two
-                      instants as an int64 nanosecond count. The representation limits
-                      the largest representable duration to approximately 290 years.
+                    description: |-
+                      A Duration represents the elapsed time between two instants
+                      as an int64 nanosecond count. The representation limits the
+                      largest representable duration to approximately 290 years.
                     format: int64
                     type: integer
                 required:
@@ -7573,8 +6936,9 @@ spec:
                   started job
                 type: string
               lastScheduleMicroTime:
-                description: Information about the last time the job was successfully
-                  scheduled, with microsecond precision.
+                description: |-
+                  Information about the last time the job was successfully scheduled,
+                  with microsecond precision.
                 format: date-time
                 type: string
               lastScheduleTime:
@@ -7594,14 +6958,19 @@ spec:
         description: CronJob is the Schema for the cronjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -7637,14 +7006,19 @@ spec:
         description: CronJob is the Schema for the cronjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
@@ -20,14 +20,19 @@ spec:
         description: Job is the Schema for the jobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object

--- a/pkg/markers/collect_test.go
+++ b/pkg/markers/collect_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Collecting", func() {
 			})
 
 			It("should have docs without markers", func() {
-				Expect(docsByType).To(HaveKeyWithValue("Foo", "normal godoc normal godoc"))
+				Expect(docsByType).To(HaveKeyWithValue("Foo", "normal godoc\nnormal godoc"))
 			})
 
 			It("should associate markers in the closest non-godoc block", func() {
@@ -133,7 +133,20 @@ var _ = Describe("Collecting", func() {
 
 			It("should have doc without extraneous spaces, even over multiple lines", func() {
 				Expect(docsByType).To(HaveKeyWithValue("HasDocsWithSpaces2",
-					"This type of doc has spaces preserved in go-ast, but we'd like to trim them, especially when formatted like this."))
+					"This type of doc has spaces preserved in go-ast, but we'd like to trim them,\nespecially when formatted like this."))
+			})
+		})
+		Context("types with //-style comments and yaml embeeded", func() {
+			It("should keep spaces and multiline", func() {
+				Expect(docsByType).To(HaveKeyWithValue("HasNonAsteriskDocWithYamlEmbeeded",
+					`This is a description
+this is an example as yaml:
+---
+foo:
+  bar:
+    dar:
+    - value1
+    - value2`))
 			})
 		})
 

--- a/pkg/markers/markers_suite_test.go
+++ b/pkg/markers/markers_suite_test.go
@@ -99,6 +99,17 @@ var _ = BeforeSuite(func() {
 					type HasDocsWithSpaces2 struct {
 					}
 
+					// This is a description
+					// this is an example as yaml:
+					// ---
+					// foo:
+					//   bar:
+					//     dar:
+					//     - value1
+					//     - value2
+					type HasNonAsteriskDocWithYamlEmbeeded struct {
+					}
+
 					type Baz interface {
 						// +testing:pkglvl="not here in interface"
 					}

--- a/pkg/markers/zip.go
+++ b/pkg/markers/zip.go
@@ -58,6 +58,13 @@ func extractDoc(node ast.Node, decl *ast.GenDecl) string {
 		}
 		outGroup.List = append(outGroup.List, comment)
 	}
+	isAsteriskComment := false
+	for _, l := range outGroup.List {
+		if strings.HasPrefix(l.Text, "/*") {
+			isAsteriskComment = true
+			break
+		}
+	}
 
 	// split lines, and re-join together as a single
 	// paragraph, respecting double-newlines as
@@ -69,10 +76,12 @@ func extractDoc(node ast.Node, decl *ast.GenDecl) string {
 	}
 
 	for i, line := range outLines {
-		// Trim any extranous whitespace,
-		// for handling /*…*/-style comments,
-		// which have whitespace preserved in go/ast:
-		line = strings.TrimSpace(line)
+		if isAsteriskComment {
+			// Trim any extranous whitespace,
+			// for handling /*…*/-style comments,
+			// which have whitespace preserved in go/ast:
+			line = strings.TrimSpace(line)
+		}
 
 		// Respect that double-newline means
 		// actual newline:
@@ -82,8 +91,7 @@ func extractDoc(node ast.Node, decl *ast.GenDecl) string {
 			outLines[i] = line
 		}
 	}
-
-	return strings.Join(outLines, " ")
+	return strings.Join(outLines, "\n")
 }
 
 // PackageMarkers collects all the package-level marker values for the given package.

--- a/pkg/schemapatcher/gen_integration_test.go
+++ b/pkg/schemapatcher/gen_integration_test.go
@@ -91,7 +91,7 @@ var _ = Describe("CRD Patching From Parsing to Editing", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("checking that the expected and actual files for " + expectedFile.Name() + " are identical")
-			Expect(actualContents).To(Equal(expectedContents), "contents not as expected, check pkg/schemapatcher/testdata/README.md for more details.\n\nDiff:\n\n%s", cmp.Diff(string(actualContents), string(expectedContents)))
+			Expect(actualContents).To(MatchYAML(expectedContents), "contents not as expected, check pkg/schemapatcher/testdata/README.md for more details.\n\nDiff:\n\n%s", cmp.Diff(string(actualContents), string(expectedContents)))
 		}
 	})
 })

--- a/pkg/schemapatcher/testdata/expected/kubebuilder-example-crd.v1.yaml
+++ b/pkg/schemapatcher/testdata/expected/kubebuilder-example-crd.v1.yaml
@@ -20,10 +20,19 @@ spec:
             - spec
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/pkg/schemapatcher/testdata/expected/kubebuilder-unchanged-crd.yaml
+++ b/pkg/schemapatcher/testdata/expected/kubebuilder-unchanged-crd.yaml
@@ -20,10 +20,19 @@ spec:
             - spec
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
Sometimes at type has examples about how to use it embedding something like a yaml on it, yamls should not be truncated and they are white space sensitive. This change keep the new lines and also remove the white space trimming only on /* comments.

Golang struct example with problematic comment.

```golang
// DnsState  DNS resolver state. Example partial yaml output of [NetworkState] with
// static DNS config:                                                           
// ```yaml                                                                      
// ---                                                                          
// dns-resolver:                                                                
//                                                                              
//  running:                                                                    
//     server:                                                                  
//     - 2001:db8:1::250                                                        
//     - 192.0.2.250                                                            
//     search:                                                                  
//     - example.org                                                            
//     - example.net                                                            
//  config:                                                                     
//     search:                                                                  
//     - example.org                                                            
//     - example.net                                                            
//     server:                                                                  
//     - 2001:db8:1::250                                                        
//     - 192.0.2.250                                                            
//     options:                                                                 
//     - trust-ad                                                               
//     - rotate                                                                 
//                                                                              
// ```                                                                          
// To purge all static DNS configuration:                                       
// ```yml                                                                       
// ---                                                                          
// dns-resolver:                                                                
//                                                                              
//  config: {}                                                                  
//                                                                              
// ```                                                                          
// +k8s:deepcopy-gen=true                                                       
type DnsState struct {                                                          
...
}
```

Part of the probem was introduced at https://github.com/kubernetes-sigs/controller-tools/pull/517