### PR TITLE
✨ Fix deprecated things

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -458,7 +458,7 @@ func builtinToType(basic *types.Basic, allowDangerousTypes bool) (typ string, fo
 // Open coded go/types representation of encoding/json.Marshaller
 var jsonMarshaler = types.NewInterfaceType([]*types.Func{
 	types.NewFunc(token.NoPos, nil, "MarshalJSON",
-		types.NewSignature(nil, nil,
+		types.NewSignatureType(nil, nil, nil, nil,
 			types.NewTuple(
 				types.NewVar(token.NoPos, nil, "", types.NewSlice(types.Universe.Lookup("byte").Type())),
 				types.NewVar(token.NoPos, nil, "", types.Universe.Lookup("error").Type())), false)),

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -370,7 +370,7 @@ func LoadRootsWithConfig(cfg *packages.Config, roots ...string) ([]*Package, err
 		cfg:      cfg,
 		packages: make(map[*packages.Package]*Package),
 	}
-	l.cfg.Mode |= packages.LoadImports | packages.NeedTypesSizes
+	l.cfg.Mode |= packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedTypesSizes
 	if l.cfg.Fset == nil {
 		l.cfg.Fset = token.NewFileSet()
 	}
@@ -393,7 +393,7 @@ func LoadRootsWithConfig(cfg *packages.Config, roots ...string) ([]*Package, err
 	// and try and prevent packages from showing up twice when nested module
 	// support is enabled. there is not harm that comes from this per se, but
 	// it makes testing easier when a known number of modules can be asserted
-	uniquePkgIDs := sets.String{}
+	uniquePkgIDs := sets.Set[string]{}
 
 	// loadPackages returns the Go packages for the provided roots
 	//
@@ -604,9 +604,9 @@ func LoadRootsWithConfig(cfg *packages.Config, roots ...string) ([]*Package, err
 // references with those from the rootPkgs list. This ensures the
 // kubebuilder marker generation is handled correctly. For more info,
 // please see issue 680.
-func visitImports(rootPkgs []*Package, pkg *Package, seen sets.String) {
+func visitImports(rootPkgs []*Package, pkg *Package, seen sets.Set[string]) {
 	if seen == nil {
-		seen = sets.String{}
+		seen = sets.Set[string]{}
 	}
 	for importedPkgID, importedPkg := range pkg.Imports() {
 		for i := range rootPkgs {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Fix deprecated following:

- `types.NewSignature` -> `types.NewSignatureType`
- `packages.LoadImports` -> `packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports`
- `sets.String` -> `sets.Set[string]`