### PR TITLE
:bug: Fix SIGSERV when RawSpec is nil (due to anonymous struct)

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -341,7 +341,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 		Properties: make(map[string]apiext.JSONSchemaProps),
 	}
 
-	if ctx.info.RawSpec.Type != structType {
+	if ctx.info.RawSpec != nil && ctx.info.RawSpec.Type != structType {
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("encountered non-top-level struct (possibly embedded), those aren't allowed"), structType))
 		return props
 	}


### PR DESCRIPTION
Under some circumstances `RawSpec` can be nil. I've encountred this when generating a CRD of a complex set of structs. Currently the `structToSchema` func fails hard on this (SIGSERV). This PR fixes the latter.
