### PR TITLE
:sparkles: crd: allow specifying spec.preserveUnknownFields

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -86,12 +86,19 @@ type Generator struct {
 	// Year specifies the year to substitute for " YEAR" in the header file.
 	Year string `marker:",optional"`
 
-	// PreserveUnknownFields indicates whether or not we should turn off pruning.
+	// DeprecatedV1beta1CompatibilityPreserveUnknownFields indicates whether
+	// or not we should turn off field pruning for this resource.
 	//
 	// Specifies spec.preserveUnknownFields value that is false and omitted by default.
+	// This value can only be specified for CustomResourceDefinitions that were created with
+	// `apiextensions.k8s.io/v1beta1`.
 	//
-	// It's required to be false for v1 CRDs.
-	PreserveUnknownFields *bool `marker:",optional"`
+	// The field can be set for compatiblity reasons, although strongly discouraged, resource
+	// authors should move to a structural OpenAPI schema instead.
+	//
+	// See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning
+	// for more information about field pruning and v1beta1 resources compatibility.
+	DeprecatedV1beta1CompatibilityPreserveUnknownFields *bool `marker:",optional"`
 }
 
 func (Generator) CheckFilter() loader.NodeFilter {
@@ -167,8 +174,8 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		genall.WithTransform(transformRemoveCRDStatus),
 		genall.WithTransform(genall.TransformRemoveCreationTimestamp),
 	}
-	if g.PreserveUnknownFields != nil {
-		yamlOpts = append(yamlOpts, genall.WithTransform(transformPreserveUnknownFields(*g.PreserveUnknownFields)))
+	if g.DeprecatedV1beta1CompatibilityPreserveUnknownFields != nil {
+		yamlOpts = append(yamlOpts, genall.WithTransform(transformPreserveUnknownFields(*g.DeprecatedV1beta1CompatibilityPreserveUnknownFields)))
 	}
 
 	for _, groupKind := range kubeKinds {

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -119,6 +119,43 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		expectedOut := string(expectedFileFoos) + string(expectedFileZoos)
 		Expect(out.buf.String()).To(Equal(expectedOut), cmp.Diff(out.buf.String(), expectedOut))
 	})
+
+	It("should add preserveUnknownFields=false when specified", func() {
+		By("calling Generate")
+		no := false
+		gen := &crd.Generator{
+			CRDVersions:           []string{"v1"},
+			PreserveUnknownFields: &no,
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("searching preserveUnknownFields")
+		Expect(out.buf.String()).To(ContainSubstring("preserveUnknownFields: false"))
+	})
+
+	It("should add preserveUnknownFields=true when specified", func() {
+		By("calling Generate")
+		yes := true
+		gen := &crd.Generator{
+			CRDVersions:           []string{"v1"},
+			PreserveUnknownFields: &yes,
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("searching preserveUnknownFields")
+		Expect(out.buf.String()).To(ContainSubstring("preserveUnknownFields: true"))
+	})
+
+	It("should not add preserveUnknownFields when not specified", func() {
+		By("calling Generate")
+		gen := &crd.Generator{
+			CRDVersions: []string{"v1"},
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("searching preserveUnknownFields")
+		Expect(out.buf.String()).NotTo(ContainSubstring("preserveUnknownFields"))
+	})
 })
 
 // fixAnnotations fixes the attribution annotation for tests.

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -124,8 +124,8 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		By("calling Generate")
 		no := false
 		gen := &crd.Generator{
-			CRDVersions:           []string{"v1"},
-			PreserveUnknownFields: &no,
+			CRDVersions: []string{"v1"},
+			DeprecatedV1beta1CompatibilityPreserveUnknownFields: &no,
 		}
 		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
 
@@ -137,8 +137,8 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		By("calling Generate")
 		yes := true
 		gen := &crd.Generator{
-			CRDVersions:           []string{"v1"},
-			PreserveUnknownFields: &yes,
+			CRDVersions: []string{"v1"},
+			DeprecatedV1beta1CompatibilityPreserveUnknownFields: &yes,
 		}
 		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Reinstate crd:preserveUnknownFields option removed by #607 to allow specifying the value of deprecated spec.preserveUnknownFields CRD field.

This is useful for updating CRDs that were automatically converted from v1beta1 version which had true as a default value and resulted in:
```
$ kubectl get crd foo.bar -o yaml | grep preserveUnknownFields
  preserveUnknownFields: true
    message: 'spec.preserveUnknownFields: Invalid value: true: must be false'
```

For #476

