### PR TITLE
✨ Fix go directive version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-tools
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/fatih/color v1.16.0


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
According to the official Go Modules Reference https://go.dev/ref/mod#go-mod-file-go, it's better for the go directive to not include a minor version number.