### PR TITLE
✨ Add FieldPath and Reason to XValidation marker

### DIFF
--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -523,6 +523,14 @@ func (XValidation) Help() *markers.DefinitionHelp {
 				Summary: "",
 				Details: "",
 			},
+			"Reason": {
+				Summary: "",
+				Details: "",
+			},
+			"FieldPath": {
+				Summary: "",
+				Details: "",
+			},
 		},
 	}
 }

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -39,6 +39,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // CronJobSpec defines the desired state of CronJob
+// +kubebuilder:validation:XValidation:rule="has(oldSelf.forbiddenInt) || !has(self.forbiddenInt)",message="forbiddenInt is not allowed",fieldPath=".forbiddenInt",reason="FieldValueForbidden"
 type CronJobSpec struct {
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	Schedule string `json:"schedule"`
@@ -250,6 +251,10 @@ type CronJobSpec struct {
 	// Test of the expression-based validation with messageExpression marker.
 	// +kubebuilder:validation:XValidation:rule="self.size() % 2 == 0",messageExpression="'Length has to be even but is ' + len(self.stringWithEvenLengthAndMessageExpression) + ' instead'"
 	StringWithEvenLengthAndMessageExpression string `json:"stringWithEvenLengthAndMessageExpression,omitempty"`
+
+	// Test that we can add a forbidden field using XValidation Reason and FieldPath.
+	// The validation is applied to the spec struct itself and not the field.
+	ForbiddenInt int `json:"forbiddenInt,omitempty"`
 
 	// Checks that fixed-length arrays work
 	Array [3]int `json:"array,omitempty"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -196,6 +196,11 @@ spec:
                 description: This tests that exported fields are not skipped in the
                   schema generation
                 type: string
+              forbiddenInt:
+                description: |-
+                  Test that we can add a forbidden field using XValidation Reason and FieldPath.
+                  The validation is applied to the spec struct itself and not the field.
+                type: integer
               hosts:
                 description: This tests string slice item validation.
                 items:
@@ -6806,11 +6811,12 @@ spec:
                   rule: self.size() % 2 == 0
                 - rule: "true"
               stringWithEvenLengthAndMessageExpression:
-                description: Test of the expression-based validation with
-                  messageExpression marker.
+                description: Test of the expression-based validation with messageExpression
+                  marker.
                 type: string
                 x-kubernetes-validations:
-                - messageExpression: "'Length has to be even but is ' + len(self.stringWithEvenLengthAndMessageExpression) + ' instead'"
+                - messageExpression: '''Length has to be even but is '' + len(self.stringWithEvenLengthAndMessageExpression)
+                    + '' instead'''
                   rule: self.size() % 2 == 0
               structWithSeveralFields:
                 description: A struct that can only be entirely replaced
@@ -6903,6 +6909,11 @@ spec:
             - unprunedFomTypeAndField
             - unprunedJSON
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .forbiddenInt
+              message: forbiddenInt is not allowed
+              reason: FieldValueForbidden
+              rule: has(oldSelf.forbiddenInt) || !has(self.forbiddenInt)
           status:
             description: CronJobStatus defines the observed state of CronJob
             properties:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
This allows you to specify the FieldPath and Reason on an XValidation rule. These can be useful when you are specifying validations that look at multiple fields or if the default reason of Invalid doesn't suit.

One use case would be a field that you no longer want set. You can add a CEL validation to make sure no one adds it to the object going forward. For this you would want the Forbidden reason, but the rule needs to be on the parent, which means you then need to use the field path to construct the correct error message path.