### PR TITLE
✨ Add support for +default markers

### DIFF
--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -116,6 +116,22 @@ func (Format) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (KubernetesDefault) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "Default sets the default value for this field.",
+			Details: "A default value will be accepted as any value valid for the field.\nOnly JSON-formatted values are accepted. `ref(...)` values are ignored.\nFormatting for common types include: boolean: `true`, string:\n`\"Cluster\"`, numerical: `1.24`, array: `[1,2]`, object: `{\"policy\":\n\"delete\"}`). Defaults should be defined in pruned form, and only best-effort\nvalidation will be performed. Full validation of a default requires\nsubmission of the containing CRD to an apiserver.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{
+			"Value": {
+				Summary: "",
+				Details: "",
+			},
+		},
+	}
+}
+
 func (ListMapKey) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD processing",

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -38,6 +38,8 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const DefaultRefValue = "defaultRefValue"
+
 // CronJobSpec defines the desired state of CronJob
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.forbiddenInt) || !has(self.forbiddenInt)",message="forbiddenInt is not allowed",fieldPath=".forbiddenInt",reason="FieldValueForbidden"
 type CronJobSpec struct {
@@ -116,9 +118,9 @@ type CronJobSpec struct {
 	// +kubebuilder:example={a,b}
 	DefaultedSlice []string `json:"defaultedSlice"`
 
-	// This tests that object defaulting can be performed.
-	// +kubebuilder:default={{nested: {foo: "baz", bar: true}},{nested: {bar: false}}}
-	// +kubebuilder:example={{nested: {foo: "baz", bar: true}},{nested: {bar: false}}}
+	// This tests that slice and object defaulting can be performed.
+	// +kubebuilder:default={{nested: {foo: "baz", bar: true}},{nested: {foo: "qux", bar: false}}}
+	// +kubebuilder:example={{nested: {foo: "baz", bar: true}},{nested: {foo: "qux", bar: false}}}
 	DefaultedObject []RootObject `json:"defaultedObject"`
 
 	// This tests that empty slice defaulting can be performed.
@@ -132,6 +134,39 @@ type CronJobSpec struct {
 	// This tests that an empty object defaulting can be performed on an object.
 	// +kubebuilder:default={}
 	DefaultedEmptyObject EmpiableObject `json:"defaultedEmptyObject"`
+
+	// This tests that kubebuilder defaulting takes precedence.
+	// +kubebuilder:default="kubebuilder-default"
+	// +default="kubernetes-default"
+	DoubleDefaultedString string `json:"doubleDefaultedString"`
+
+	// This tests that primitive defaulting can be performed.
+	// +default="forty-two"
+	KubernetesDefaultedString string `json:"kubernetesDefaultedString"`
+
+	// This tests that slice defaulting can be performed.
+	// +default=["a","b"]
+	KubernetesDefaultedSlice []string `json:"kubernetesDefaultedSlice"`
+
+	// This tests that slice and object defaulting can be performed.
+	// +default=[{"nested": {"foo": "baz", "bar": true}},{"nested": {"foo": "qux", "bar": false}}]
+	KubernetesDefaultedObject []RootObject `json:"kubernetesDefaultedObject"`
+
+	// This tests that empty slice defaulting can be performed.
+	// +default=[]
+	KubernetesDefaultedEmptySlice []string `json:"kubernetesDefaultedEmptySlice"`
+
+	// This tests that an empty object defaulting can be performed on a map.
+	// +default={}
+	KubernetesDefaultedEmptyMap map[string]string `json:"kubernetesDefaultedEmptyMap"`
+
+	// This tests that an empty object defaulting can be performed on an object.
+	// +default={}
+	KubernetesDefaultedEmptyObject EmpiableObject `json:"kubernetesDefaultedEmptyObject"`
+
+	// This tests that use of +default=ref(...) doesn't break generation
+	// +default=ref(DefaultRefValue)
+	KubernetesDefaultedRef string `json:"kubernetesDefaultedRef,omitempty"`
 
 	// This tests that pattern validator is properly applied.
 	// +kubebuilder:validation:Pattern=`^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -133,13 +133,15 @@ spec:
                     foo: baz
                 - nested:
                     bar: false
-                description: This tests that object defaulting can be performed.
+                    foo: qux
+                description: This tests that slice and object defaulting can be performed.
                 example:
                 - nested:
                     bar: true
                     foo: baz
                 - nested:
                     bar: false
+                    foo: qux
                 items:
                   properties:
                     nested:
@@ -183,6 +185,74 @@ spec:
                 type: string
               explicitlyRequiredKubernetes:
                 description: This tests explicitly required kubernetes fields
+                type: string
+              doubleDefaultedString:
+                default: kubebuilder-default
+                description: This tests that kubebuilder defaulting takes precedence.
+                type: string
+              kubernetesDefaultedEmptyMap:
+                additionalProperties:
+                  type: string
+                default: {}
+                description: This tests that an empty object defaulting can be performed
+                  on a map.
+                type: object
+              kubernetesDefaultedEmptyObject:
+                default: {}
+                description: This tests that an empty object defaulting can be performed
+                  on an object.
+                properties:
+                  bar:
+                    type: string
+                  foo:
+                    default: forty-two
+                    type: string
+                type: object
+              kubernetesDefaultedEmptySlice:
+                default: []
+                description: This tests that empty slice defaulting can be performed.
+                items:
+                  type: string
+                type: array
+              kubernetesDefaultedObject:
+                default:
+                - nested:
+                    bar: true
+                    foo: baz
+                - nested:
+                    bar: false
+                    foo: qux
+                description: This tests that slice and object defaulting can be performed.
+                items:
+                  properties:
+                    nested:
+                      properties:
+                        bar:
+                          type: boolean
+                        foo:
+                          type: string
+                      required:
+                      - bar
+                      - foo
+                      type: object
+                  required:
+                  - nested
+                  type: object
+                type: array
+              kubernetesDefaultedSlice:
+                default:
+                - a
+                - b
+                description: This tests that slice defaulting can be performed.
+                items:
+                  type: string
+                type: array
+              kubernetesDefaultedString:
+                default: forty-two
+                description: This tests that primitive defaulting can be performed.
+                type: string
+              kubernetesDefaultedRef:
+                description: This tests that use of +default=ref(...) doesn't break generation
                 type: string
               embeddedResource:
                 type: object
@@ -6898,6 +6968,7 @@ spec:
             - defaultedObject
             - defaultedSlice
             - defaultedString
+            - doubleDefaultedString
             - embeddedResource
             - explicitlyRequiredKubebuilder
             - explicitlyRequiredKubernetes
@@ -6907,6 +6978,12 @@ spec:
             - int32WithValidations
             - intWithValidations
             - jobTemplate
+            - kubernetesDefaultedEmptyMap
+            - kubernetesDefaultedEmptyObject
+            - kubernetesDefaultedEmptySlice
+            - kubernetesDefaultedObject
+            - kubernetesDefaultedSlice
+            - kubernetesDefaultedString
             - mapOfInfo
             - nestedMapOfInfo
             - nestedStructWithSeveralFields

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -820,13 +820,23 @@ func parserScanner(raw string, err func(*sc.Scanner, string)) *sc.Scanner {
 	return scanner
 }
 
+type markerParser interface {
+	ParseMarker(name string, anonymousName string, restFields string) error
+}
+
 // Parse uses the type information in this Definition to parse the given
 // raw marker in the form `+a:b:c=arg,d=arg` into an output object of the
 // type specified in the definition.
 func (d *Definition) Parse(rawMarker string) (interface{}, error) {
 	name, anonName, fields := splitMarker(rawMarker)
 
-	out := reflect.Indirect(reflect.New(d.Output))
+	outPointer := reflect.New(d.Output)
+	out := reflect.Indirect(outPointer)
+
+	if parser, ok := outPointer.Interface().(markerParser); ok {
+		err := parser.ParseMarker(name, anonName, fields)
+		return out.Interface(), err
+	}
 
 	// if we're a not a struct or have no arguments, treat the full `a:b:c` as the name,
 	// otherwise, treat `c` as a field name, and `a:b` as the marker name.


### PR DESCRIPTION
This adds annotation support for `+default` markers for specifying default values in JSON format, as is done in core Kubernetes types and described in https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1929-built-in-default#summary

If both `+default` and `+kubebuilder:default` are specified, the kubebuilder-specific annotation wins.

Fixes https://github.com/kubernetes-sigs/controller-tools/issues/939