### PR TITLE
:sparkles: add support for kubernetes +required annotations

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -80,11 +80,13 @@ var ValidationMarkers = mustMakeAllWithPrefix(validationPrefix, markers.Describe
 // sense on a type, and thus aren't in ValidationMarkers).
 var FieldOnlyMarkers = []*definitionWithHelp{
 	must(markers.MakeDefinition("kubebuilder:validation:Required", markers.DescribesField, struct{}{})).
-		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is required, if fields are optional by default.")),
+		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is required.")),
 	must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesField, struct{}{})).
-		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional, if fields are required by default.")),
+		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional.")),
+	must(markers.MakeDefinition("required", markers.DescribesField, struct{}{})).
+		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is required.")),
 	must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})).
-		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional, if fields are required by default.")),
+		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional.")),
 
 	must(markers.MakeDefinition("nullable", markers.DescribesField, Nullable{})).
 		WithHelp(Nullable{}.Help()),

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -189,6 +189,22 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:optional
 	JustNestedObject *JustNestedObject `json:"justNestedObject,omitempty"`
 
+	// This tests explicitly optional kubebuilder fields
+	// +kubebuilder:validation:Optional
+	ExplicitlyOptionalKubebuilder string `json:"explicitlyOptionalKubebuilder"`
+
+	// This tests explicitly optional kubernetes fields
+	// +optional
+	ExplicitlyOptionalKubernetes string `json:"explicitlyOptionalKubernetes"`
+
+	// This tests explicitly required kubebuilder fields
+	// +kubebuilder:validation:Required
+	ExplicitlyRequiredKubebuilder string `json:"explicitlyRequiredKubebuilder,omitempty"`
+
+	// This tests explicitly required kubernetes fields
+	// +required
+	ExplicitlyRequiredKubernetes string `json:"explicitlyRequiredKubernetes,omitempty"`
+
 	// This tests that min/max properties work
 	MinMaxProperties MinMaxObject `json:"minMaxProperties,omitempty"`
 

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -172,6 +172,18 @@ spec:
                 description: This tests that primitive defaulting can be performed.
                 example: forty-two
                 type: string
+              explicitlyOptionalKubebuilder:
+                description: This tests explicitly optional kubebuilder fields
+                type: string
+              explicitlyOptionalKubernetes:
+                description: This tests explicitly optional kubernetes fields
+                type: string
+              explicitlyRequiredKubebuilder:
+                description: This tests explicitly required kubebuilder fields
+                type: string
+              explicitlyRequiredKubernetes:
+                description: This tests explicitly required kubernetes fields
+                type: string
               embeddedResource:
                 type: object
                 x-kubernetes-embedded-resource: true
@@ -6887,6 +6899,8 @@ spec:
             - defaultedSlice
             - defaultedString
             - embeddedResource
+            - explicitlyRequiredKubebuilder
+            - explicitlyRequiredKubernetes
             - float64WithValidations
             - floatWithValidations
             - foo


### PR DESCRIPTION
Fixes #943

Adds support for Kubernetes `+required` annotations on fields, fixes support for `+optional` annotations on fields, adds tests.
