### PR TITLE
✨ feat(schema): Add marker to skip fields

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -88,6 +88,9 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 	must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional.")),
 
+	must(markers.MakeDefinition("kubebuilder:skip", markers.DescribesField, struct{}{})).
+		WithHelp(markers.SimpleHelp("CRD generation", "specifies that this field should be skipped for schema generation.")),
+
 	must(markers.MakeDefinition("nullable", markers.DescribesField, Nullable{})).
 		WithHelp(Nullable{}.Help()),
 

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -373,6 +373,11 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 			continue
 		}
 
+		if field.Markers.Get("kubebuilder:skip") != nil {
+			// Explicitly ignore this field for schema generation
+			continue
+		}
+
 		jsonTag, hasTag := field.Tag.Lookup("json")
 		if !hasTag {
 			// if the field doesn't have a JSON tag, it doesn't belong in output (and shouldn't exist in a serialized type)

--- a/pkg/crd/testdata/gen/foo_types.go
+++ b/pkg/crd/testdata/gen/foo_types.go
@@ -30,6 +30,10 @@ type FooSpec struct {
 	// +kubebuilder:default=fooDefaultString
 	// +kubebuilder:example=fooExampleString
 	DefaultedString string `json:"defaultedString"`
+
+	// This field is explicitly ignored for schema generation.
+	// +kubebuilder:skip
+	Skipped string `json:"skipped"`
 }
 type FooStatus struct{}
 


### PR DESCRIPTION
This adds a new field marker `+kubebuilder:skip` that allows explicitly ignoring properties during schema generation but keeping them in the Go struct for JSON marshalling at the same time.