### PR TITLE
🏃 Optimize dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,37 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
+# GitHub Actions
+- package-ecosystem: "github-actions"
+  # Workflow files stored in the
+  # default location of `.github/workflows`
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"
 
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
-
-  # Maintain dependencies for go
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: ":seedling:"
-    # Ignore K8 packages as these are done manually
-    ignore:
-      - dependency-name: "k8s.io/api"
-      - dependency-name: "k8s.io/apiextensions-apiserver"
-      - dependency-name: "k8s.io/apimachinery"
-      - dependency-name: "k8s.io/client-go"
-      - dependency-name: "k8s.io/component-base"
-    labels:
-      - "ok-to-test"
-
+# Go modules
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  # group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    all-go-mod-patch-and-minor:
+      patterns: [ "*" ]
+      update-types: [ "patch", "minor" ]
+  ignore:
+  # Ignore k8s and its transitives modules as they are upgraded manually.
+  - dependency-name: "k8s.io/*"
+    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
After this PR dependabot:
* only creates at most one PR for go dependencies and one PR for GitHub actions
* only ignores k8s.io major & minor versions. Patch versions are bumped automatically

