### PR TITLE
:sparkles: Make the anonymous field of the groupName marker optional

### DIFF
--- a/pkg/crd/markers/package.go
+++ b/pkg/crd/markers/package.go
@@ -22,7 +22,7 @@ import (
 
 func init() {
 	AllDefinitions = append(AllDefinitions,
-		must(markers.MakeDefinition("groupName", markers.DescribesPackage, "")).
+		mustOptional(markers.MakeDefinition("groupName", markers.DescribesPackage, "")).
 			WithHelp(markers.SimpleHelp("CRD", "specifies the API group name for this package.")),
 
 		must(markers.MakeDefinition("versionName", markers.DescribesPackage, "")).

--- a/pkg/crd/markers/register.go
+++ b/pkg/crd/markers/register.go
@@ -17,6 +17,7 @@ limitations under the License.
 package markers
 
 import (
+	"fmt"
 	"reflect"
 
 	"sigs.k8s.io/controller-tools/pkg/markers"
@@ -53,6 +54,19 @@ func (d *definitionWithHelp) clone() *definitionWithHelp {
 func must(def *markers.Definition, err error) *definitionWithHelp {
 	return &definitionWithHelp{
 		Definition: markers.Must(def, err),
+	}
+}
+
+func mustOptional(def *markers.Definition, err error) *definitionWithHelp {
+	def = markers.Must(def, err)
+	if !def.AnonymousField() {
+		def = markers.Must(def, fmt.Errorf("not an anonymous field: %v", def))
+	}
+	field := def.Fields[""]
+	field.Optional = true
+	def.Fields[""] = field
+	return &definitionWithHelp{
+		Definition: def,
 	}
 }
 

--- a/pkg/crd/testdata/nogroup/types.go
+++ b/pkg/crd/testdata/nogroup/types.go
@@ -1,0 +1,29 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=
+package nogroup
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+
+// CronJob is the Schema for the cronjobs API
+type CronJob struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}

--- a/pkg/crd/testdata/testdata._cronjobs.yaml
+++ b/pkg/crd/testdata/testdata._cronjobs.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  name: cronjobs.
+spec:
+  group: ""
+  names:
+    kind: CronJob
+    listKind: CronJobList
+    plural: cronjobs
+    singular: cronjob
+  scope: Namespaced
+  versions:
+  - name: nogroup
+    schema:
+      openAPIV3Schema:
+        description: CronJob is the Schema for the cronjobs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
Upstream introduced the use of empty groupName markers in kubernetes/kubernetes#125162. This breaks groupName parsing because its field is non-optional. Add an additional `mustOptional` function that takes anonymous field definitions and turns them into optional ones.