### PR TITLE
✨ Allow customizing generated webhook configuration's name

### DIFF
--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -42,14 +43,29 @@ const (
 )
 
 var (
-	// ConfigDefinition s a marker for defining Webhook manifests.
+	// ConfigDefinition is a marker for defining Webhook manifests.
 	// Call ToWebhook on the value to get a Kubernetes Webhook.
 	ConfigDefinition = markers.Must(markers.MakeDefinition("kubebuilder:webhook", markers.DescribesPackage, Config{}))
+	// WebhookConfigDefinition is a marker for defining MutatingWebhookConfiguration or ValidatingWebhookConfiguration manifests.
+	WebhookConfigDefinition = markers.Must(markers.MakeDefinition("kubebuilder:webhookconfiguration", markers.DescribesPackage, WebhookConfig{}))
 )
 
 // supportedWebhookVersions returns currently supported API version of {Mutating,Validating}WebhookConfiguration.
 func supportedWebhookVersions() []string {
 	return []string{defaultWebhookVersion}
+}
+
+// +controllertools:marker:generateHelp
+
+type WebhookConfig struct {
+	// Mutating marks this as a mutating webhook (it's validating only if false)
+	//
+	// Mutating webhooks are allowed to change the object in their response,
+	// and are called *before* all validating webhooks.  Mutating webhooks may
+	// choose to reject an object, similarly to a validating webhook.
+	Mutating bool
+	// Name indicates the name of the K8s MutatingWebhookConfiguration or ValidatingWebhookConfiguration object.
+	Name string `marker:"name,optional"`
 }
 
 // +controllertools:marker:generateHelp:category=Webhook
@@ -152,6 +168,32 @@ func verbToAPIVariant(verbRaw string) admissionregv1.OperationType {
 	default:
 		return admissionregv1.OperationType(verbRaw)
 	}
+}
+
+// ToMutatingWebhookConfiguration converts this WebhookConfig to its Kubernetes API form.
+func (c WebhookConfig) ToMutatingWebhookConfiguration() (admissionregv1.MutatingWebhookConfiguration, error) {
+	if !c.Mutating {
+		return admissionregv1.MutatingWebhookConfiguration{}, fmt.Errorf("%s is a validating webhook", c.Name)
+	}
+
+	return admissionregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.Name,
+		},
+	}, nil
+}
+
+// ToValidatingWebhookConfiguration converts this WebhookConfig to its Kubernetes API form.
+func (c WebhookConfig) ToValidatingWebhookConfiguration() (admissionregv1.ValidatingWebhookConfiguration, error) {
+	if c.Mutating {
+		return admissionregv1.ValidatingWebhookConfiguration{}, fmt.Errorf("%s is a mutating webhook", c.Name)
+	}
+
+	return admissionregv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.Name,
+		},
+	}, nil
 }
 
 // ToMutatingWebhook converts this rule to its Kubernetes API form.
@@ -362,7 +404,11 @@ func (Generator) RegisterMarkers(into *markers.Registry) error {
 	if err := into.Register(ConfigDefinition); err != nil {
 		return err
 	}
+	if err := into.Register(WebhookConfigDefinition); err != nil {
+		return err
+	}
 	into.AddHelp(ConfigDefinition, Config{}.Help())
+	into.AddHelp(WebhookConfigDefinition, Config{}.Help())
 	return nil
 }
 
@@ -370,10 +416,41 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	supportedWebhookVersions := supportedWebhookVersions()
 	mutatingCfgs := make(map[string][]admissionregv1.MutatingWebhook, len(supportedWebhookVersions))
 	validatingCfgs := make(map[string][]admissionregv1.ValidatingWebhook, len(supportedWebhookVersions))
+	var mutatingWebhookCfgs admissionregv1.MutatingWebhookConfiguration
+	var validatingWebhookCfgs admissionregv1.ValidatingWebhookConfiguration
+
 	for _, root := range ctx.Roots {
 		markerSet, err := markers.PackageMarkers(ctx.Collector, root)
 		if err != nil {
 			root.AddError(err)
+		}
+
+		webhookCfgs := markerSet[WebhookConfigDefinition.Name]
+		var hasValidatingWebhookConfig, hasMutatingWebhookConfig bool = false, false
+		for _, webhookCfg := range webhookCfgs {
+			webhookCfg := webhookCfg.(WebhookConfig)
+
+			if webhookCfg.Mutating {
+				if hasMutatingWebhookConfig {
+					return fmt.Errorf("duplicate mutating %s with name %s", WebhookConfigDefinition.Name, webhookCfg.Name)
+				}
+
+				if mutatingWebhookCfgs, err = webhookCfg.ToMutatingWebhookConfiguration(); err != nil {
+					return err
+				}
+
+				hasMutatingWebhookConfig = true
+			} else {
+				if hasValidatingWebhookConfig {
+					return fmt.Errorf("duplicate validating %s with name %s", WebhookConfigDefinition.Name, webhookCfg.Name)
+				}
+
+				if validatingWebhookCfgs, err = webhookCfg.ToValidatingWebhookConfiguration(); err != nil {
+					return err
+				}
+
+				hasValidatingWebhookConfig = true
+			}
 		}
 
 		cfgs := markerSet[ConfigDefinition.Name]
@@ -410,16 +487,22 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	versionedWebhooks := make(map[string][]interface{}, len(supportedWebhookVersions))
 	for _, version := range supportedWebhookVersions {
 		if cfgs, ok := mutatingCfgs[version]; ok {
-			// The only possible version in supportedWebhookVersions is v1,
-			// so use it for all versioned types in this context.
-			objRaw := &admissionregv1.MutatingWebhookConfiguration{}
+			var objRaw *admissionregv1.MutatingWebhookConfiguration
+			if mutatingWebhookCfgs.Name != "" {
+				objRaw = &mutatingWebhookCfgs
+			} else {
+				// The only possible version in supportedWebhookVersions is v1,
+				// so use it for all versioned types in this context.
+				objRaw = &admissionregv1.MutatingWebhookConfiguration{}
+				objRaw.SetName("mutating-webhook-configuration")
+			}
 			objRaw.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   admissionregv1.SchemeGroupVersion.Group,
 				Version: version,
 				Kind:    "MutatingWebhookConfiguration",
 			})
-			objRaw.SetName("mutating-webhook-configuration")
 			objRaw.Webhooks = cfgs
+
 			for i := range objRaw.Webhooks {
 				// SideEffects is required in admissionregistration/v1, if this is not set or set to `Some` or `Known`,
 				// return an error
@@ -441,16 +524,22 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 
 		if cfgs, ok := validatingCfgs[version]; ok {
-			// The only possible version in supportedWebhookVersions is v1,
-			// so use it for all versioned types in this context.
-			objRaw := &admissionregv1.ValidatingWebhookConfiguration{}
+			var objRaw *admissionregv1.ValidatingWebhookConfiguration
+			if validatingWebhookCfgs.Name != "" {
+				objRaw = &validatingWebhookCfgs
+			} else {
+				// The only possible version in supportedWebhookVersions is v1,
+				// so use it for all versioned types in this context.
+				objRaw = &admissionregv1.ValidatingWebhookConfiguration{}
+				objRaw.SetName("validating-webhook-configuration")
+			}
 			objRaw.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   admissionregv1.SchemeGroupVersion.Group,
 				Version: version,
 				Kind:    "ValidatingWebhookConfiguration",
 			})
-			objRaw.SetName("validating-webhook-configuration")
 			objRaw.Webhooks = cfgs
+
 			for i := range objRaw.Webhooks {
 				// SideEffects is required in admissionregistration/v1, if this is not set or set to `Some` or `Known`,
 				// return an error

--- a/pkg/webhook/testdata/invalid-multiple-webhookconfigurations/cronjob_types.go
+++ b/pkg/webhook/testdata/invalid-multiple-webhookconfigurations/cronjob_types.go
@@ -1,0 +1,71 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:generate ../../../../.run-controller-gen.sh webhook paths=. output:dir=.
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package cronjob
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
+// CronJobSpec defines the desired state of CronJob
+type CronJobSpec struct {
+	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	Schedule string `json:"schedule"`
+}
+
+// CronJobStatus defines the observed state of CronJob
+type CronJobStatus struct {
+	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+	// Important: Run "make" to regenerate code after modifying this file
+
+	// Information when was the last time the job was successfully scheduled.
+	// +optional
+	LastScheduleTime *metav1.Time `json:"lastScheduleTime,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=mycronjob
+
+// CronJob is the Schema for the cronjobs API
+type CronJob struct {
+	/*
+	 */
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   CronJobSpec   `json:"spec,omitempty"`
+	Status CronJobStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// CronJobList contains a list of CronJob
+type CronJobList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CronJob `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&CronJob{}, &CronJobList{})
+}

--- a/pkg/webhook/testdata/invalid-multiple-webhookconfigurations/webhook.go
+++ b/pkg/webhook/testdata/invalid-multiple-webhookconfigurations/webhook.go
@@ -1,0 +1,52 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cronjob
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (c *CronJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(c).
+		Complete()
+}
+
+// +kubebuilder:webhook:webhookVersions=v1,verbs=create;update,path=/validate-testdata-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=validation.cronjob.testdata.kubebuilder.io,sideEffects=None,timeoutSeconds=10,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-testdata-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=validation.cronjob.testdata.kubebuilder.io,sideEffects=NoneOnDryRun,timeoutSeconds=10,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:webhookVersions=v1,verbs=create;update,path=/mutate-testdata-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=default.cronjob.testdata.kubebuilder.io,sideEffects=None,timeoutSeconds=10,admissionReviewVersions=v1;v1beta1,reinvocationPolicy=IfNeeded
+// +kubebuilder:webhookconfiguration:mutating=true,name=foo
+// +kubebuilder:webhookconfiguration:mutating=true,name=bar
+
+var _ webhook.Defaulter = &CronJob{}
+var _ webhook.Validator = &CronJob{}
+
+func (c *CronJob) Default() {
+}
+
+func (c *CronJob) ValidateCreate() error {
+	return nil
+}
+
+func (c *CronJob) ValidateUpdate(_ runtime.Object) error {
+	return nil
+}
+
+func (c *CronJob) ValidateDelete() error {
+	return nil
+}

--- a/pkg/webhook/testdata/valid-custom-name/cronjob_types.go
+++ b/pkg/webhook/testdata/valid-custom-name/cronjob_types.go
@@ -1,0 +1,71 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:generate ../../../../.run-controller-gen.sh webhook paths=. output:dir=.
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package cronjob
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
+// CronJobSpec defines the desired state of CronJob
+type CronJobSpec struct {
+	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	Schedule string `json:"schedule"`
+}
+
+// CronJobStatus defines the observed state of CronJob
+type CronJobStatus struct {
+	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+	// Important: Run "make" to regenerate code after modifying this file
+
+	// Information when was the last time the job was successfully scheduled.
+	// +optional
+	LastScheduleTime *metav1.Time `json:"lastScheduleTime,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=mycronjob
+
+// CronJob is the Schema for the cronjobs API
+type CronJob struct {
+	/*
+	 */
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   CronJobSpec   `json:"spec,omitempty"`
+	Status CronJobStatus `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// CronJobList contains a list of CronJob
+type CronJobList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CronJob `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&CronJob{}, &CronJobList{})
+}

--- a/pkg/webhook/testdata/valid-custom-name/manifests.yaml
+++ b/pkg/webhook/testdata/valid-custom-name/manifests.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: foo
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-testdata-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cronjob.testdata.kubebuilder.io
+  rules:
+  - apiGroups:
+    - testdata.kubebuiler.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+  timeoutSeconds: 10
+  reinvocationPolicy: IfNeeded
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: bar
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-testdata-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cronjob.testdata.kubebuilder.io
+  rules:
+  - apiGroups:
+    - testdata.kubebuiler.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+  timeoutSeconds: 10
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-testdata-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cronjob.testdata.kubebuilder.io
+  rules:
+  - apiGroups:
+    - testdata.kubebuiler.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: NoneOnDryRun
+  timeoutSeconds: 10

--- a/pkg/webhook/testdata/valid-custom-name/webhook.go
+++ b/pkg/webhook/testdata/valid-custom-name/webhook.go
@@ -1,0 +1,52 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cronjob
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (c *CronJob) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(c).
+		Complete()
+}
+
+// +kubebuilder:webhook:webhookVersions=v1,verbs=create;update,path=/validate-testdata-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=validation.cronjob.testdata.kubebuilder.io,sideEffects=None,timeoutSeconds=10,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-testdata-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=validation.cronjob.testdata.kubebuilder.io,sideEffects=NoneOnDryRun,timeoutSeconds=10,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:webhookVersions=v1,verbs=create;update,path=/mutate-testdata-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=testdata.kubebuiler.io,resources=cronjobs,versions=v1,name=default.cronjob.testdata.kubebuilder.io,sideEffects=None,timeoutSeconds=10,admissionReviewVersions=v1;v1beta1,reinvocationPolicy=IfNeeded
+// +kubebuilder:webhookconfiguration:mutating=true,name=foo
+// +kubebuilder:webhookconfiguration:mutating=false,name=bar
+
+var _ webhook.Defaulter = &CronJob{}
+var _ webhook.Validator = &CronJob{}
+
+func (c *CronJob) Default() {
+}
+
+func (c *CronJob) ValidateCreate() error {
+	return nil
+}
+
+func (c *CronJob) ValidateUpdate(_ runtime.Object) error {
+	return nil
+}
+
+func (c *CronJob) ValidateDelete() error {
+	return nil
+}

--- a/pkg/webhook/zz_generated.markerhelp.go
+++ b/pkg/webhook/zz_generated.markerhelp.go
@@ -115,3 +115,23 @@ func (Generator) Help() *markers.DefinitionHelp {
 		},
 	}
 }
+
+func (WebhookConfig) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "",
+			Details: "",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{
+			"Mutating": {
+				Summary: "marks this as a mutating webhook (it's validating only if false)",
+				Details: "Mutating webhooks are allowed to change the object in their response,\nand are called *before* all validating webhooks.  Mutating webhooks may\nchoose to reject an object, similarly to a validating webhook.",
+			},
+			"Name": {
+				Summary: "indicates the name of the K8s MutatingWebhookConfiguration or ValidatingWebhookConfiguration object.",
+				Details: "",
+			},
+		},
+	}
+}


### PR DESCRIPTION

## example usage

```
❯ GOBIN=(pwd)/bin go install ./cmd/*

❯ ./bin/controller-gen webhook -w

Webhook

+kubebuilder:webhook:admissionReviewVersions=<[]string>,failurePolicy=<string>,groups=<[]string>[,matchPolicy=<string>],mutating=<bool>,name=<string>[,path=<string>][,reinvocationPolicy=<string>],resources=<[]string>[,sideEffects=<string>][,timeoutSeconds=<int>][,url=<string>],verbs=<[]string>,versions=<[]string>[,webhookVersions=<[]string>]  package  specifies how a webhook should be served.  
+kubebuilder:webhookconfiguration:mutating=<bool>[,name=<string>]                                                                                                                                                                                                                                                                                        package  specifies how a webhook should be served.  
```

contributes to https://github.com/kubernetes-sigs/controller-tools/issues/865