### PR TITLE
📖 Document compatibility with k8s.io/*, client-go and Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ export `GO111MODULE=on`.
 
 See [VERSIONING.md](VERSIONING.md).
 
+
+## Compatibility
+
+Every minor version of controller-tools has been tested with a specific minor version of client-go. A controller-tools minor version *may* be compatible with
+other client-go minor versions, but this is by chance and neither supported nor tested. In general, we create one minor version of controller-tools
+for each minor version of client-go and other k8s.io/* dependencies.
+
+The minimum Go version of controller-tools is the highest minimum Go version of our Go dependencies. Usually, this will
+be identical to the minimum Go version of the corresponding k8s.io/* dependencies.
+
+Compatible k8s.io/*, client-go and minimum Go versions can be looked up in our [go.mod](go.mod) file.
+
+|          | k8s.io/*, client-go | minimum Go version |
+|----------|:-------------------:|:------------------:|
+| CR v0.16 |        v0.31        |        1.22        |
+| CR v0.15 |        v0.30        |        1.22        |
+| CR v0.14 |        v0.29        |        1.20        |
+| CR v0.13 |        v0.28        |        1.20        |
+| CR v0.12 |        v0.27        |        1.20        |
+
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes #886 