### PR TITLE
🐛 rbac: fix deduplication of core group and add test coverage

### DIFF
--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -146,12 +146,6 @@ func removeDupAndSort(strs []string) []string {
 
 // ToRule converts this rule to its Kubernetes API form.
 func (r *Rule) ToRule() rbacv1.PolicyRule {
-	// fix the group names first, since letting people type "core" is nice
-	for i, group := range r.Groups {
-		if group == "core" {
-			r.Groups[i] = ""
-		}
-	}
 	return rbacv1.PolicyRule{
 		APIGroups:       r.Groups,
 		Verbs:           r.Verbs,
@@ -230,6 +224,13 @@ func GenerateRoles(ctx *genall.GenerationContext, roleName string) ([]interface{
 		ruleMap := make(map[ruleKey]*Rule)
 		// all the Rules having the same ruleKey will be merged into the first Rule
 		for _, rule := range rules {
+			// fix the group name first, since letting people type "core" is nice
+			for i, name := range rule.Groups {
+				if name == "core" {
+					rule.Groups[i] = ""
+				}
+			}
+
 			key := rule.key()
 			if _, ok := ruleMap[key]; !ok {
 				ruleMap[key] = rule

--- a/pkg/rbac/testdata/controller.go
+++ b/pkg/rbac/testdata/controller.go
@@ -30,3 +30,6 @@ package controller
 // +kubebuilder:rbac:groups=not-deduplicate-groups2,resources=some,verbs=list
 // +kubebuilder:rbac:urls=/url-to-duplicate,verbs=get
 // +kubebuilder:rbac:urls=/another/url-to-duplicate,verbs=get
+// +kubebuilder:rbac:groups=core,resources=deduplicate,verbs=list
+// +kubebuilder:rbac:groups="",resources=me,verbs=list
+// +kubebuilder:rbac:groups=core;"";some-other-to-deduplicate-with-core,resources=me,verbs=list;get

--- a/pkg/rbac/testdata/role.yaml
+++ b/pkg/rbac/testdata/role.yaml
@@ -10,6 +10,21 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - deduplicate
+  - me
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  - some-other-to-deduplicate-with-core
+  resources:
+  - me
+  verbs:
+  - get
+  - list
+- apiGroups:
   - art
   resources:
   - jobs


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes: #1036

Deduplication happened before renaming.

Now renaming before doing deduplication to fix this case for the core group.