### PR TITLE
:bug: Allow CLI binaries to set a version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
     name: Upload binaries to release
     runs-on: ubuntu-latest
     steps:
+    - name: Set env
+      run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
     - name: Check out code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
     - name: Calculate go version

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,8 @@ release-binary: $(RELEASE_DIR)
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		golang:$(GO_VERSION) \
-		go build -a -trimpath -ldflags "-extldflags '-static'" \
+		go build -a -trimpath \
+		-ldflags "-extldflags '-static' -X sigs.k8s.io/controller-tools/pkg/version.version=$(RELEASE_TAG)" \
 		-o ./out/$(RELEASE_BINARY) ./cmd/controller-gen
 
 ## --------------------------------------

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,7 +23,7 @@ import (
 )
 
 // version to be set using ldflags:
-// -ldflags "-X sigs.k8s.io/controller-tools/pkg/version.version=1.0.0"
+// -ldflags "-X sigs.k8s.io/controller-tools/pkg/version.version=v1.0.0"
 // falls back to module information is unset
 var version = ""
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,8 +22,16 @@ import (
 	"runtime/debug"
 )
 
+// version to be set using ldflags:
+// -ldflags "-X sigs.k8s.io/controller-tools/pkg/version.version=1.0.0"
+// falls back to module information is unset
+var version = ""
+
 // Version returns the version of the main module
 func Version() string {
+	if version != "" {
+		return version
+	}
 	info, ok := debug.ReadBuildInfo()
 	if !ok || info == nil || info.Main.Version == "" {
 		// binary has not been built with module support or doesn't contain a version.

--- a/pkg/version/version_suite_test.go
+++ b/pkg/version/version_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersioning(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Version Suite")
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestVersion", func() {
+	tests := []struct {
+		name     string
+		version  string
+		expected string
+	}{
+		{
+			name:     "empty returns unknown",
+			version:  "",
+			expected: "(unknown)",
+		},
+		{
+			name:     "set to a value returns it",
+			version:  "1.2.3",
+			expected: "1.2.3",
+		},
+	}
+	for _, tc := range tests {
+		It("Version set to "+tc.name, func() {
+			versionBackup := version
+			defer func() {
+				version = versionBackup
+			}()
+			version = tc.version
+			result := Version()
+			Expect(result).To(Equal(tc.expected))
+		})
+	}
+})
+


### PR DESCRIPTION
Solves #1046 so that **`controller-gen`** binaries can show a proper version

---

Local testing:

```shell
% go build -ldflags "-X sigs.k8s.io/controller-tools/pkg/version.version=1.2.4" ./cmd/controller-gen
% ./controller-gen --version
Version: 1.2.4
```