### PR TITLE
🐛 pkg/crd: support validation on type alias to basic types

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -247,6 +247,21 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiext.JSONSchema
 		if err != nil {
 			ctx.pkg.AddError(loader.ErrFromNode(err, ident))
 		}
+		// Check for type aliasing to a basic type. Note that this is no longer
+		// needed with gotypesalias=1 as the above isBasic check is false. See
+		// more https://pkg.go.dev/go/types#Alias:
+		// > For gotypesalias=1, alias declarations produce an Alias type.
+		// > Otherwise, the alias information is only in the type name, which
+		// > points directly to the actual (aliased) type.
+		if basicInfo.Name() != ident.Name {
+			ctx.requestSchema("", ident.Name)
+			link := TypeRefLink("", ident.Name)
+			return &apiext.JSONSchemaProps{
+				Type:   typ,
+				Format: fmt,
+				Ref:    &link,
+			}
+		}
 		return &apiext.JSONSchemaProps{
 			Type:   typ,
 			Format: fmt,

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -330,6 +330,14 @@ type CronJobSpec struct {
 	// This tests that string alias is handled correctly.
 	StringAlias StringAlias `json:"stringAlias,omitempty"`
 
+	// This tests that validation on a string alias type is handled correctly.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=255
+	StringAliasAddedValidation StringAlias `json:"stringAliasAddedValidation,omitempty"`
+
+	// This tests that validation on a the string alias type itself is handled correctly.
+	StringAliasAlreadyValidated StringAliasWithValidation `json:"stringAliasAlreadyValidated,omitempty"`
+
 	// This tests string slice validation.
 	// +kubebuilder:validation:MinItems=2
 	// +kubebuilder:validation:MaxItems=2
@@ -358,6 +366,10 @@ type CronJobSpec struct {
 }
 
 type StringAlias = string
+
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=255
+type StringAliasWithValidation = string
 
 type ContainsNestedMap struct {
 	InnerMap map[string]string `json:"innerMap,omitempty"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -8978,6 +8978,16 @@ spec:
               stringAlias:
                 description: This tests that string alias is handled correctly.
                 type: string
+              stringAliasAddedValidation:
+                description: This tests that validation on a string alias type is handled correctly.
+                maxLength: 255
+                minLength: 1
+                type: string
+              stringAliasAlreadyValidated:
+                description: This tests that validation on a the string alias type itself is handled correctly.
+                maxLength: 255
+                minLength: 1
+                type: string
               stringPair:
                 description: This tests string slice validation.
                 items:


### PR DESCRIPTION
Fixes #1071 

Without the type Alias being its own type (Go 1.22 see gotypesalias), in localNamedToSchema, the link is missing.

[ Upstream port of d944debcff34 ("Support type aliasing to basic types") ]

Previously, validation schema generation was skipped on a type alias:

	type A = B

Whereas, a new type was fine:

	type A B

This commit implements support for generating validation schemas for type aliases to basic types, i.e. string, int, etc.
