### PR TITLE
🐛 pkg/crd: fix a missed type casting panic with new *types.Alias

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -274,7 +274,7 @@ func namedToSchema(ctx *schemaContext, named *ast.SelectorExpr) *apiext.JSONSche
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unknown type %v.%s", named.X, named.Sel.Name), named))
 		return &apiext.JSONSchemaProps{}
 	}
-	typeInfo := typeInfoRaw.(*types.Named)
+	typeInfo := typeInfoRaw.(interface{ Obj() *types.TypeName })
 	typeNameInfo := typeInfo.Obj()
 	nonVendorPath := loader.NonVendorPath(typeNameInfo.Pkg().Path())
 	ctx.requestSchema(nonVendorPath, typeNameInfo.Name())

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -327,6 +327,11 @@ type CronJobSpec struct {
 
 	HostsAlias Hosts `json:"hostsAlias,omitempty"`
 
+	// This tests that alias imported from a package is handled correctly. The
+	// corev1.IPFamilyPolicyType is just reused since it's available from
+	// imported package. We can create our own in a separate package if needed.
+	AliasFromPackage corev1.IPFamilyPolicyType `json:"aliasFromPackage,omitempty"`
+
 	// This tests that string alias is handled correctly.
 	StringAlias StringAlias `json:"stringAlias,omitempty"`
 

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -8975,6 +8975,12 @@ spec:
                   time for any reason.  Missed jobs executions will be counted as failed ones.
                 format: int64
                 type: integer
+              aliasFromPackage:
+                description: |-
+                  This tests that alias imported from a package is handled correctly. The
+                  corev1.IPFamilyPolicyType is just reused since it's available from
+                  imported package. We can create our own in a separate package if needed.
+                type: string
               stringAlias:
                 description: This tests that string alias is handled correctly.
                 type: string


### PR DESCRIPTION
Fixes #1076.

This is a follow up on 0a52475258f0 ("pkg/crd: fix type casting panic with new default *types.Alias"). Look for the commit message of the cited commit for more context.

/cc @markussiebert @sbueringer 