### PR TITLE
:bug: Handling Identical Kubebuilder Annotations in Different CRs with * Verbs

### DIFF
--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -303,7 +303,14 @@ func GenerateRoles(ctx *genall.GenerationContext, roleName string) ([]interface{
 			keys = append(keys, key)
 		}
 		sort.Sort(ruleKeys(keys))
-
+		for _, rule := range ruleMap {
+			for _, verb := range rule.Verbs {
+				if verb == "*" {
+					rule.Verbs = []string{"*"}
+					break
+				}
+			}
+		}
 		var policyRules []rbacv1.PolicyRule
 		for _, key := range keys {
 			policyRules = append(policyRules, ruleMap[key].ToRule())
@@ -322,11 +329,6 @@ func GenerateRoles(ctx *genall.GenerationContext, roleName string) ([]interface{
 	var objs []interface{}
 	for _, ns := range namespaces {
 		rules := rulesByNSResource[ns]
-		for _, rule := range rules {
-			if containsAsterisk(rule.Verbs) {
-				rule.Verbs = []string{"*"}
-			}
-		}
 		policyRules := NormalizeRules(rules)
 		if len(policyRules) == 0 {
 			continue
@@ -358,15 +360,6 @@ func GenerateRoles(ctx *genall.GenerationContext, roleName string) ([]interface{
 	}
 
 	return objs, nil
-}
-
-func containsAsterisk(strList []string) bool {
-	for _, str := range strList {
-		if str == "*" {
-			return true
-		}
-	}
-	return false
 }
 
 func (g Generator) Generate(ctx *genall.GenerationContext) error {

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -303,6 +303,8 @@ func GenerateRoles(ctx *genall.GenerationContext, roleName string) ([]interface{
 			keys = append(keys, key)
 		}
 		sort.Sort(ruleKeys(keys))
+
+		// Normalize rule verbs to "*" if any verb in the rule is an asterisk
 		for _, rule := range ruleMap {
 			for _, verb := range rule.Verbs {
 				if verb == "*" {

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -322,6 +322,11 @@ func GenerateRoles(ctx *genall.GenerationContext, roleName string) ([]interface{
 	var objs []interface{}
 	for _, ns := range namespaces {
 		rules := rulesByNSResource[ns]
+		for _, rule := range rules {
+			if containsAsterisk(rule.Verbs) {
+				rule.Verbs = []string{"*"}
+			}
+		}
 		policyRules := NormalizeRules(rules)
 		if len(policyRules) == 0 {
 			continue
@@ -353,6 +358,15 @@ func GenerateRoles(ctx *genall.GenerationContext, roleName string) ([]interface{
 	}
 
 	return objs, nil
+}
+
+func containsAsterisk(strList []string) bool {
+	for _, str := range strList {
+		if str == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 func (g Generator) Generate(ctx *genall.GenerationContext) error {

--- a/pkg/rbac/testdata/controller.go
+++ b/pkg/rbac/testdata/controller.go
@@ -23,6 +23,8 @@ package controller
 // +kubebuilder:rbac:groups=deduplicate-all,resources=foo;bar,verbs=get;list
 // +kubebuilder:rbac:groups=deduplicate-all,resources=foo,verbs=get
 // +kubebuilder:rbac:groups=deduplicate-all,resources=bar,verbs=list
+// +kubebuilder:rbac:groups=deduplicate-groups4,resources=xyz,verbs=get;update;patch
+// +kubebuilder:rbac:groups=deduplicate-groups4,resources=xyz,verbs=*
 // +kubebuilder:rbac:groups=deduplicate-all-group,resources=foo;bar,verbs=get;list
 // +kubebuilder:rbac:groups=not-deduplicate-resources,resources=some,verbs=get
 // +kubebuilder:rbac:groups=not-deduplicate-resources,resources=another,verbs=list

--- a/pkg/rbac/testdata/controller.go
+++ b/pkg/rbac/testdata/controller.go
@@ -35,3 +35,5 @@ package controller
 // +kubebuilder:rbac:groups=core,resources=deduplicate,verbs=list
 // +kubebuilder:rbac:groups="",resources=me,verbs=list
 // +kubebuilder:rbac:groups=core;"";some-other-to-deduplicate-with-core,resources=me,verbs=list;get
+// +kubebuilder:rbac:groups=deduplicate-groups5,resources=abc,verbs=get;update;patch;create,namespace=here
+// +kubebuilder:rbac:groups=deduplicate-groups5,resources=abc,verbs=*,namespace=here

--- a/pkg/rbac/testdata/role.yaml
+++ b/pkg/rbac/testdata/role.yaml
@@ -89,6 +89,12 @@ rules:
   verbs:
   - patch
 - apiGroups:
+  - deduplicate-groups4
+  resources:
+  - xyz
+  verbs:
+  - '*'
+- apiGroups:
   - deduplicate-resources
   resources:
   - one

--- a/pkg/rbac/testdata/role.yaml
+++ b/pkg/rbac/testdata/role.yaml
@@ -133,6 +133,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manager-role
+  namespace: here
+rules:
+- apiGroups:
+  - deduplicate-groups5
+  resources:
+  - abc
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-role
   namespace: park
 rules:
 - apiGroups:
@@ -155,3 +168,4 @@ rules:
   - jobs
   verbs:
   - get
+


### PR DESCRIPTION
#1077
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->

<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
