### PR TITLE
🐛 Fix panic when using embedded type aliases 

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -280,6 +280,17 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiext.JSONSchema
 			Format: fmt,
 		}
 	}
+	// Handle embedded structs, they do not have a type name.
+	if _, isNamed := typeInfo.(*types.Named); !isNamed {
+		// TODO: Following uses deprecated "ident.Obj" so alternative solution is needed.
+		typeSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
+		if !ok {
+			ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unknown error"), ident))
+			return &apiext.JSONSchemaProps{}
+		}
+		return typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), typeSpec.Type)
+	}
+
 	// NB(directxman12): if there are dot imports, this might be an external reference,
 	// so use typechecking info to get the actual object
 	typeNameInfo := typeInfo.(interface{ Obj() *types.TypeName }).Obj()

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -372,6 +372,9 @@ type CronJobSpec struct {
 
 	// This tests that selectable field.
 	SelectableFieldString string `json:"selectableFieldString,omitempty"`
+
+	// This tests that embedded struct, which is an alias type, is handled correctly.
+	InlineAlias `json:",inline"`
 }
 
 type StringAlias = string
@@ -379,6 +382,14 @@ type StringAlias = string
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=255
 type StringAliasWithValidation = string
+
+type InlineAlias = EmbeddedStruct
+
+// EmbeddedStruct is for testing that embedded struct is handled correctly when it is used through an alias type.
+type EmbeddedStruct struct {
+	// FromEmbedded is a field from the embedded struct that was used through an alias type.
+	FromEmbedded string `json:"fromEmbedded,omitempty"`
+}
 
 type ContainsNestedMap struct {
 	InnerMap map[string]string `json:"innerMap,omitempty"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -41,6 +41,12 @@ spec:
           spec:
             description: CronJobSpec defines the desired state of CronJob
             properties:
+              aliasFromPackage:
+                description: |-
+                  This tests that alias imported from a package is handled correctly. The
+                  corev1.IPFamilyPolicyType is just reused since it's available from
+                  imported package. We can create our own in a separate package if needed.
+                type: string
               array:
                 description: Checks that fixed-length arrays work
                 items:
@@ -184,13 +190,13 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               enumSlice:
                 description: This tests slice item validation with enum
-                type: array
                 items:
-                  type: integer
                   enum:
                   - 0
                   - 1
                   - 3
+                  type: integer
+                type: array
               explicitlyOptionalKubebuilder:
                 description: This tests explicitly optional kubebuilder fields
                 type: string
@@ -8984,22 +8990,18 @@ spec:
                   time for any reason.  Missed jobs executions will be counted as failed ones.
                 format: int64
                 type: integer
-              aliasFromPackage:
-                description: |-
-                  This tests that alias imported from a package is handled correctly. The
-                  corev1.IPFamilyPolicyType is just reused since it's available from
-                  imported package. We can create our own in a separate package if needed.
-                type: string
               stringAlias:
                 description: This tests that string alias is handled correctly.
                 type: string
               stringAliasAddedValidation:
-                description: This tests that validation on a string alias type is handled correctly.
+                description: This tests that validation on a string alias type is
+                  handled correctly.
                 maxLength: 255
                 minLength: 1
                 type: string
               stringAliasAlreadyValidated:
-                description: This tests that validation on a the string alias type itself is handled correctly.
+                description: This tests that validation on a the string alias type
+                  itself is handled correctly.
                 maxLength: 255
                 minLength: 1
                 type: string

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -234,6 +234,10 @@ spec:
                   Test that we can add a forbidden field using XValidation Reason and FieldPath.
                   The validation is applied to the spec struct itself and not the field.
                 type: integer
+              fromEmbedded:
+                description: FromEmbedded is a field from the embedded struct that
+                  was used through an alias type.
+                type: string
               hosts:
                 description: This tests string slice item validation.
                 items:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
This pull request is NOT to be merged!

Controller-gen panics when parsing an embedded/inline struct that uses a type alias. This PR includes a test to reproduce the problem, however the panic only happens when type aliases are enabled so the test needs to be run like this in order to trigger panic

```console
$ go version
go version go1.23.2 linux/amd64
$ cd pkg/crd/testdata
$ GODEBUG=gotypesalias=1 go generate
``` 

PR also includes a workaround for the panic that I found while troubleshooting the issue. It avoids panic but it isn’t the correct solution. As of now, I don't know how to do it properly, so I'm marking this PR as a Draft.

Fixes #1088