### PR TITLE
🐛 Fix SIGSERV when RawSpec is nil (due to anonymous struct)

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -404,7 +404,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 		Properties: make(map[string]apiext.JSONSchemaProps),
 	}
 
-	if ctx.info.RawSpec.Type != structType {
+	if ctx.info.RawSpec != nil && ctx.info.RawSpec.Type != structType {
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("encountered non-top-level struct (possibly embedded), those aren't allowed"), structType))
 		return props
 	}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -217,6 +217,9 @@ type CronJobSpec struct {
 	// A struct that can only be entirely replaced via a nested type.
 	NestedStructWithSeveralFields NestedStructWithSeveralFields `json:"nestedStructWithSeveralFields"`
 
+	// A struct with an anonymous struct as a field.
+	StructWithAnonymousStruct StructWithAnonymousStruct `json:"structWithAnonymousStruct"`
+
 	// A struct that can only be entirely replaced via a nested type and
 	// field markers.
 	// +structType=atomic
@@ -422,6 +425,12 @@ func (p *Preserved) MarshalJSON() ([]byte, error) {
 type NestedObject struct {
 	Foo string `json:"foo"`
 	Bar bool   `json:"bar"`
+}
+
+type StructWithAnonymousStruct struct {
+	Anonymous struct {
+		Baz string `json:"baz"`
+	} `json:"anonymous"`
 }
 
 // +structType=atomic

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9042,6 +9042,15 @@ spec:
                 - messageExpression: '''Length has to be even but is '' + len(self.stringWithEvenLengthAndMessageExpression)
                     + '' instead'''
                   rule: self.size() % 2 == 0
+              structWithAnonymousStruct:
+                description: A struct with an anonymous struct as a field.
+                type: object
+                properties:
+                  anonymous:
+                    type: object
+                    properties: {}
+                required:
+                  - anonymous
               structWithSeveralFields:
                 description: A struct that can only be entirely replaced
                 properties:
@@ -9134,6 +9143,7 @@ spec:
             - patternObject
             - schedule
             - stringPair
+            - structWithAnonymousStruct
             - structWithSeveralFields
             - twoOfAKindPart0
             - twoOfAKindPart1


### PR DESCRIPTION
This is the same PR as https://github.com/kubernetes-sigs/controller-tools/pull/892 but that one was automatically closed. This time testdata is included as requested so I'm hoping to get this merged.

From the original PR:

> Under some circumstances RawSpec can be nil. I've encountred this when generating a CRD of a complex set of structs. Currently the structToSchema func fails hard on this (SIGSERV). This PR fixes the latter.