### PR TITLE
[WIP] 🌱 Refactor envtest release process to update envtest index locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,6 @@ release-envtest: clean-release ## Build the envtest binaries by operating system
 	OS=darwin ARCH=arm64 $(MAKE) release-envtest-docker-build
 	OS=windows ARCH=amd64 $(MAKE) release-envtest-docker-build
 	OS=windows ARCH=arm64 $(MAKE) release-envtest-docker-build
-	./hack/envtest/update-releases.sh
 
 .PHONY: release-envtest-docker-build
 release-envtest-docker-build: $(RELEASE_DIR) ## Build the envtest binaries.

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,6 @@ release-envtest: clean-release ## Build the envtest binaries by operating system
 	OS=darwin ARCH=arm64 $(MAKE) release-envtest-docker-build
 	OS=windows ARCH=amd64 $(MAKE) release-envtest-docker-build
 	OS=windows ARCH=arm64 $(MAKE) release-envtest-docker-build
-	./hack/envtest/update-releases.sh
 
 .PHONY: release-envtest-docker-build
 release-envtest-docker-build: $(RELEASE_DIR) ## Build the envtest binaries.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
controller-tools repo is now configured in a way that blocks creation of pull requests by actions (see https://github.com/kubernetes-sigs/controller-tools/actions/runs/12463704971).
This PR changes the process. Now it's necessary to run `KUBERNETES_VERSION=v1.32.0 hack/envtest/update-envtest-releases.sh` and open a PR manually

/hold 
for now for further discussion. Maybe there's a better way