### PR TITLE
🐛 Guard before type assertion

### DIFF
--- a/pkg/deepcopy/testdata/cronjob_types.go
+++ b/pkg/deepcopy/testdata/cronjob_types.go
@@ -153,7 +153,12 @@ type SpecificCases struct {
 
 	// Case: kubernetes-sigs/controller-tools#262 part 2 (see type definition)
 	StringMap MapOfStrings `json:"stringMap"`
+
+	// Case: kubernetes-sigs/controller-tools#813
+	StringAlias StringAlias `json:"stringAlias,omitempty"`
 }
+
+type StringAlias = string
 
 // Test aliases to basic types
 type TotallyAString string

--- a/pkg/deepcopy/traverse.go
+++ b/pkg/deepcopy/traverse.go
@@ -618,14 +618,15 @@ func shouldBeCopied(pkg *loader.Package, info *markers.TypeInfo) bool {
 		return false
 	}
 
-	// according to gengo, everything named is an alias, except for an alias to a pointer,
-	// which is just a pointer, afaict.  Just roll with it.
-	if asPtr, isPtr := typeInfo.(*types.Named).Underlying().(*types.Pointer); isPtr {
-		typeInfo = asPtr
-	}
-
 	lastType := typeInfo
 	if _, isNamed := typeInfo.(*types.Named); isNamed {
+		// according to gengo, everything named is an alias, except for an alias to a pointer,
+		// which is just a pointer, afaict.  Just roll with it.
+		if asPtr, isPtr := typeInfo.(*types.Named).Underlying().(*types.Pointer); isPtr {
+			lastType = asPtr
+			typeInfo = asPtr
+		}
+
 		// if it has a manual deepcopy or deepcopyinto, we're fine
 		if hasAnyDeepCopyMethod(pkg, typeInfo) {
 			return true


### PR DESCRIPTION
Without this, Go type aliases cause a panic.

Fixes #813
