### PR TITLE
:bug: pkg/crd: fix alias type parsing for struct type alias

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -268,7 +268,7 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiext.JSONSchema
 	// This reproduces the behavior we had pre gotypesalias=1 (needed if this
 	// project is compiled with default settings and Go >= 1.23).
 	if aliasInfo, isAlias := typeInfo.(*types.Alias); isAlias {
-		typeInfo = aliasInfo.Underlying()
+		typeInfo = aliasInfo.Rhs()
 	}
 	if basicInfo, isBasic := typeInfo.(*types.Basic); isBasic {
 		typ, fmt, err := builtinToType(basicInfo, ctx.allowDangerousTypes)

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -374,6 +374,17 @@ type CronJobSpec struct {
 
 	// This tests that selectable field.
 	SelectableFieldString string `json:"selectableFieldString,omitempty"`
+
+	// This tests that embedded struct, which is an alias type, is handled correctly.
+	InlineAlias `json:",inline"`
+}
+
+type InlineAlias = EmbeddedStruct
+
+// EmbeddedStruct is for testing that embedded struct is handled correctly when it is used through an alias type.
+type EmbeddedStruct struct {
+	// FromEmbedded is a field from the embedded struct that was used through an alias type.
+	FromEmbedded string `json:"fromEmbedded,omitempty"`
 }
 
 type StringAlias = string

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -41,6 +41,12 @@ spec:
           spec:
             description: CronJobSpec defines the desired state of CronJob
             properties:
+              aliasFromPackage:
+                description: |-
+                  This tests that alias imported from a package is handled correctly. The
+                  corev1.IPFamilyPolicyType is just reused since it's available from
+                  imported package. We can create our own in a separate package if needed.
+                type: string
               array:
                 description: Checks that fixed-length arrays work
                 items:
@@ -184,13 +190,13 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               enumSlice:
                 description: This tests slice item validation with enum
-                type: array
                 items:
-                  type: integer
                   enum:
                   - 0
                   - 1
                   - 3
+                  type: integer
+                type: array
               explicitlyOptionalKubebuilder:
                 description: This tests explicitly optional kubebuilder fields
                 type: string
@@ -8984,22 +8990,18 @@ spec:
                   time for any reason.  Missed jobs executions will be counted as failed ones.
                 format: int64
                 type: integer
-              aliasFromPackage:
-                description: |-
-                  This tests that alias imported from a package is handled correctly. The
-                  corev1.IPFamilyPolicyType is just reused since it's available from
-                  imported package. We can create our own in a separate package if needed.
-                type: string
               stringAlias:
                 description: This tests that string alias is handled correctly.
                 type: string
               stringAliasAddedValidation:
-                description: This tests that validation on a string alias type is handled correctly.
+                description: This tests that validation on a string alias type is
+                  handled correctly.
                 maxLength: 255
                 minLength: 1
                 type: string
               stringAliasAlreadyValidated:
-                description: This tests that validation on a the string alias type itself is handled correctly.
+                description: This tests that validation on a the string alias type
+                  itself is handled correctly.
                 maxLength: 255
                 minLength: 1
                 type: string

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -234,6 +234,10 @@ spec:
                   Test that we can add a forbidden field using XValidation Reason and FieldPath.
                   The validation is applied to the spec struct itself and not the field.
                 type: integer
+              fromEmbedded:
+                description: FromEmbedded is a field from the embedded struct that
+                  was used through an alias type.
+                type: string
               hosts:
                 description: This tests string slice item validation.
                 items:


### PR DESCRIPTION
Fixes #1088.

This was actually breaking all struct type alias I think, not especially when using embedded/inline struct.

I tested that both should pass:
```shell-session
$ GODEBUG=gotypesalias=1 go test ./pkg/crd
ok      sigs.k8s.io/controller-tools/pkg/crd    2.888s
$ GODEBUG=gotypesalias=0 go test ./pkg/crd
ok      sigs.k8s.io/controller-tools/pkg/crd    2.928s
```