### PR TITLE
🌱chore: Add golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,26 +1,52 @@
 run:
+  allow-parallel-runners: true
   modules-download-mode: readonly
   # Increase the default deadline from 1m as some module operations can take a
   # while if uncached!
   timeout: 10m
+  go: "1.23"
 
 linters:
+  # sync from https://github.com/kubernetes-sigs/controller-runtime/blob/main/.golangci.yml
+  disable-all: true
   enable:
-  - errcheck
-  - gosimple
-  - govet
-  - ineffassign
-  - staticcheck
-  - unused
-  - testifylint
-  - revive
-  - errorlint
-  - whitespace
-  - gci
-  - misspell
-  - iface
-  - exptostd
-  - nilnesserr
+    # - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - copyloopvar
+    - dogsled
+    - dupl
+    - errcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - ginkgolinter
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nilerr
+    - nolintlint
+    - prealloc
+    - revive
+    - staticcheck
+    - stylecheck
+    - tagliatelle
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
 
 issues:
   exclude-rules:
@@ -32,43 +58,56 @@ issues:
   - path: "pkg/loader/loader.go"
     linters:
       - errorlint
-
+    # Ignore test files
+  - linters:
+      - dupl
+      - ginkgolinter
+    path: _test\.go
+  - linters:
+      - gocritic
+    path: "pkg/markers/help.go"
+  - linters:
+      - exhaustive
+    path: "pkg/markers/parse.go|pkg/deepcopy/traverse.go|pkg/genall/help/types.go|pkg/crd/schema.go|pkg/crd/flatten.go"
+    # Ignore consider pre-allocating variables
+  - linters:
+      - prealloc
+    text: Consider pre-allocating
 linters-settings:
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
+  importas:
+    no-unaliased: true
   revive:
     # By default, revive will enable only the linting rules that are named in the configuration file.
     # So, it's needed to explicitly enable all required rules here.
     rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+      # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
       - name: blank-imports
-      - name: comment-spacings
       - name: context-as-argument
-        arguments:
-          # Allow functions with test or bench signatures.
-          - allowTypesBefore: "*testing.T,testing.TB"
       - name: context-keys-type
       - name: dot-imports
-      # A lot of false positives: incorrectly identifies channel draining as "empty code block".
-      # See https://github.com/mgechev/revive/issues/386
-      - name: empty-block
-        disabled: true
-      - name: error-naming
       - name: error-return
       - name: error-strings
-      - name: errorf
+      - name: error-naming
+      - name: if-return
       - name: increment-decrement
-      - name: indent-error-flow
+      - name: var-naming
+      - name: var-declaration
       - name: range
       - name: receiver-naming
-      - name: redefines-builtin-id
-      - name: superfluous-else
       - name: time-naming
       - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: superfluous-else
       - name: unreachable-code
-      - name: unused-parameter
-        disabled: true
-      - name: var-declaration
-      - name: var-naming
-  gci:
-    sections:
-      - standard
-      - default
+      - name: redefines-builtin-id
+      #
+      # Rules in addition to the recommended configuration above.
+      #
+      - name: bool-literal-in-expr
+      - name: constant-logical-expr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
   # sync from https://github.com/kubernetes-sigs/controller-runtime/blob/main/.golangci.yml
   disable-all: true
   enable:
-    # - asasalint
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,11 @@ linters:
   - staticcheck
   - unused
   - testifylint
+  - revive
+  - errorlint
+  - whitespace
+  - gci
+  - misspell
   - iface
   - exptostd
   - nilnesserr
@@ -23,3 +28,47 @@ issues:
     # within test files.
   - path: _test\.go
     text: should not use dot imports
+    # Ignore error type switch case
+  - path: "pkg/loader/loader.go"
+    linters:
+      - errorlint
+
+linters-settings:
+  revive:
+    # By default, revive will enable only the linting rules that are named in the configuration file.
+    # So, it's needed to explicitly enable all required rules here.
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
+      - name: blank-imports
+      - name: comment-spacings
+      - name: context-as-argument
+        arguments:
+          # Allow functions with test or bench signatures.
+          - allowTypesBefore: "*testing.T,testing.TB"
+      - name: context-keys-type
+      - name: dot-imports
+      # A lot of false positives: incorrectly identifies channel draining as "empty code block".
+      # See https://github.com/mgechev/revive/issues/386
+      - name: empty-block
+        disabled: true
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+        disabled: true
+      - name: var-declaration
+      - name: var-naming
+  gci:
+    sections:
+      - standard
+      - default

--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -202,7 +202,7 @@ func main() {
 		if !errors.As(err, &errNoUsage) {
 			// print the usage unless we suppressed it
 			if err := cmd.Usage(); err != nil {
-				panic(errNoUsage)
+				panic(err)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStderr(), "run `%[1]s %[2]s -w` to see all available markers, or `%[1]s %[2]s -h` for usage\n", cmd.CalledAs(), strings.Join(os.Args[1:], " "))

--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -17,13 +17,13 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
-
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/deepcopy"
 	"sigs.k8s.io/controller-tools/pkg/genall"
@@ -198,10 +198,11 @@ func main() {
 	})
 
 	if err := cmd.Execute(); err != nil {
-		if _, noUsage := err.(noUsageError); !noUsage {
+		var errNoUsage noUsageError
+		if !errors.As(err, &errNoUsage) {
 			// print the usage unless we suppressed it
 			if err := cmd.Usage(); err != nil {
-				panic(err)
+				panic(errNoUsage)
 			}
 		}
 		fmt.Fprintf(cmd.OutOrStderr(), "run `%[1]s %[2]s -w` to see all available markers, or `%[1]s %[2]s -h` for usage\n", cmd.CalledAs(), strings.Join(os.Args[1:], " "))

--- a/pkg/crd/desc_visitor.go
+++ b/pkg/crd/desc_visitor.go
@@ -73,7 +73,7 @@ func truncateString(desc string, maxLen int) string {
 
 	// Trying to chop off at closest word boundary (i.e. whitespace).
 	if n := strings.LastIndexFunc(desc, isWhiteSpace); n > 0 {
-		return desc[0 : n] + "..."
+		return desc[0:n] + "..."
 	}
 
 	return desc[0:maxLen] + "..."

--- a/pkg/crd/desc_visitor_test.go
+++ b/pkg/crd/desc_visitor_test.go
@@ -19,9 +19,7 @@ package crd_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"sigs.k8s.io/controller-tools/pkg/crd"
 )
 

--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -294,8 +294,8 @@ func RefParts(ref string) (typ string, pkgName string, err error) {
 	}
 	ref = ref[len(defPrefix):]
 	// decode the json pointer encodings
-	ref = strings.Replace(ref, "~1", "/", -1)
-	ref = strings.Replace(ref, "~0", "~", -1)
+	ref = strings.ReplaceAll(ref, "~1", "/")
+	ref = strings.ReplaceAll(ref, "~0", "~")
 	nameParts := strings.SplitN(ref, "~", 2)
 
 	if len(nameParts) == 1 {

--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 )
 

--- a/pkg/crd/flatten_all_of_test.go
+++ b/pkg/crd/flatten_all_of_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"sigs.k8s.io/controller-tools/pkg/crd"
 )
 

--- a/pkg/crd/flatten_type_test.go
+++ b/pkg/crd/flatten_type_test.go
@@ -21,9 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"golang.org/x/tools/go/packages"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 )

--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -25,7 +25,6 @@ import (
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/loader"

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -158,7 +158,7 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 
 	It("should truncate CRD descriptions", func() {
 		By("calling Generate")
-		var fifty int = 50
+		fifty := 50
 		gen := &crd.Generator{
 			CRDVersions: []string{"v1"},
 			MaxDescLen:  &fifty,

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 	"sigs.k8s.io/controller-tools/pkg/genall"
@@ -162,7 +161,7 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		var fifty int = 50
 		gen := &crd.Generator{
 			CRDVersions: []string{"v1"},
-			MaxDescLen: &fifty,
+			MaxDescLen:  &fifty,
 		}
 		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
 

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -18,7 +18,6 @@ package crd
 import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 )
 

--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 

--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -66,6 +66,16 @@ func init() {
 //     are typically manipulated together by the same actor.
 type ListType string
 
+const (
+	Map     ListType = "map"
+	Set     ListType = "set"
+	Atomic  ListType = "atomic"
+	Array   ListType = "array"
+	Object  ListType = "object"
+	Integer ListType = "integer"
+	Number  ListType = "number"
+)
+
 // +controllertools:marker:generateHelp:category="CRD processing"
 
 // ListMapKey specifies the keys to map listTypes.
@@ -108,10 +118,10 @@ type MapType string
 type StructType string
 
 func (l ListType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "array" {
+	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply listType to an array, found %s", schema.Type)
 	}
-	if l != "map" && l != "atomic" && l != "set" {
+	if l != Map && l != Atomic && l != Set {
 		return fmt.Errorf(`ListType must be either "map", "set" or "atomic"`)
 	}
 	p := string(l)
@@ -124,10 +134,10 @@ func (l ListType) ApplyPriority() ApplyPriority {
 }
 
 func (l ListMapKey) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "array" {
+	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply listMapKey to an array, found %s", schema.Type)
 	}
-	if schema.XListType == nil || *schema.XListType != "map" {
+	if schema.XListType == nil || *schema.XListType != string(Map) {
 		return fmt.Errorf("must apply listMapKey to an associative-list")
 	}
 	schema.XListMapKeys = append(schema.XListMapKeys, string(l))
@@ -135,7 +145,7 @@ func (l ListMapKey) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 }
 
 func (m MapType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "object" {
+	if schema.Type != string(Object) {
 		return fmt.Errorf("must apply mapType to an object")
 	}
 
@@ -150,7 +160,7 @@ func (m MapType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 }
 
 func (s StructType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "object" && schema.Type != "" {
+	if schema.Type != string(Object) && schema.Type != "" {
 		return fmt.Errorf("must apply structType to an object; either explicitly set or defaulted through an empty schema type")
 	}
 

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -312,7 +312,7 @@ type XIntOrString struct{}
 type Schemaless struct{}
 
 func hasNumericType(schema *apiext.JSONSchemaProps) bool {
-	return schema.Type == "integer" || schema.Type == "number"
+	return schema.Type == string(Integer) || schema.Type == string(Number)
 }
 
 func hasTextualType(schema *apiext.JSONSchemaProps) bool {
@@ -342,7 +342,7 @@ func (m Maximum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 		return fmt.Errorf("must apply maximum to a numeric value, found %s", schema.Type)
 	}
 
-	if schema.Type == "integer" && !isIntegral(m.Value()) {
+	if schema.Type == string(Integer) && !isIntegral(m.Value()) {
 		return fmt.Errorf("cannot apply non-integral maximum validation (%v) to integer value", m.Value())
 	}
 
@@ -423,7 +423,7 @@ func (m Pattern) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 }
 
 func (m MaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "array" {
+	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply maxitem to an array")
 	}
 	val := int64(m)
@@ -432,7 +432,7 @@ func (m MaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 }
 
 func (m MinItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "array" {
+	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply minitems to an array")
 	}
 	val := int64(m)

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 

--- a/pkg/crd/parser.go
+++ b/pkg/crd/parser.go
@@ -21,7 +21,6 @@ import (
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -26,12 +26,11 @@ import (
 	"golang.org/x/tools/go/packages"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/yaml"
-
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
+	"sigs.k8s.io/yaml"
 )
 
 func packageErrors(pkg *loader.Package, filterKinds ...packages.ErrorKind) error {

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -27,7 +27,6 @@ import (
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -448,12 +447,12 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiext.JSON
 
 		switch {
 		case field.Markers.Get("kubebuilder:validation:Optional") != nil:
-			// explicity optional - kubebuilder
+			// explicitly optional - kubebuilder
 		case field.Markers.Get("kubebuilder:validation:Required") != nil:
 			// explicitly required - kubebuilder
 			props.Required = append(props.Required, fieldName)
 		case field.Markers.Get("optional") != nil:
-			// explicity optional - kubernetes
+			// explicitly optional - kubernetes
 		case field.Markers.Get("required") != nil:
 			// explicitly required - kubernetes
 			props.Required = append(props.Required, fieldName)

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -246,7 +246,7 @@ func typeToSchema(ctx *schemaContext, rawType ast.Expr) *apiext.JSONSchemaProps 
 // escapes).
 func qualifiedName(pkgName, typeName string) string {
 	if pkgName != "" {
-		return strings.Replace(pkgName, "/", "~1", -1) + "~0" + typeName
+		return strings.ReplaceAll(pkgName, "/", "~1") + "~0" + typeName
 	}
 	return typeName
 }

--- a/pkg/crd/spec.go
+++ b/pkg/crd/spec.go
@@ -21,11 +21,9 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/flect"
-
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 )
 

--- a/pkg/deepcopy/deepcopy_integration_test.go
+++ b/pkg/deepcopy/deepcopy_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/deepcopy"
 	"sigs.k8s.io/controller-tools/pkg/genall"

--- a/pkg/deepcopy/traverse.go
+++ b/pkg/deepcopy/traverse.go
@@ -349,14 +349,15 @@ func (c *copyMethodMaker) genMapDeepCopy(actualName *namingInfo, mapType *types.
 				// If we're calling DeepCopy, check if it's receiver needs a pointer
 				inIsPtr = copyOnPtr
 			}
-			if inIsPtr == fieldIsPtr {
+			switch {
+			case inIsPtr == fieldIsPtr:
 				c.Line("(*out)[key] = val.DeepCopy()")
-			} else if fieldIsPtr {
+			case fieldIsPtr:
 				c.Line("{") // use a block because we use `x` as a temporary
 				c.Line("x := val.DeepCopy()")
 				c.Line("(*out)[key] = &x")
 				c.Line("}")
-			} else {
+			default:
 				c.Line("(*out)[key] = *val.DeepCopy()")
 			}
 		case fineToShallowCopy(mapType.Elem()):

--- a/pkg/genall/genall.go
+++ b/pkg/genall/genall.go
@@ -24,7 +24,6 @@ import (
 
 	"golang.org/x/tools/go/packages"
 	rawyaml "gopkg.in/yaml.v2"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -175,7 +174,7 @@ func (g GenerationContext) WriteYAML(itemPath, headerText string, objs []interfa
 func yamlMarshal(o interface{}, options ...*WriteYAMLOptions) ([]byte, error) {
 	j, err := json.Marshal(o)
 	if err != nil {
-		return nil, fmt.Errorf("error marshaling into JSON: %v", err)
+		return nil, fmt.Errorf("error marshaling into JSON: %w", err)
 	}
 
 	return yamlJSONToYAMLWithFilter(j, options...)

--- a/pkg/genall/help/pretty/help.go
+++ b/pkg/genall/help/pretty/help.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"sigs.k8s.io/controller-tools/pkg/genall/help"
-
 	"github.com/fatih/color"
+	"sigs.k8s.io/controller-tools/pkg/genall/help"
 )
 
 var (

--- a/pkg/genall/help/pretty/help.go
+++ b/pkg/genall/help/pretty/help.go
@@ -76,7 +76,8 @@ func MarkersDetails(fullDetail bool, groupName string, markers []help.MarkerDoc)
 			}
 		}
 
-		if marker.AnonymousField() {
+		switch {
+		case marker.AnonymousField():
 			out.Print(Indented(1, Line(fieldDetailStyle.Containing(FieldSyntaxHelp(marker.Fields[0])))))
 			out.Print(Text("  "))
 			out.Print(summary)
@@ -84,7 +85,7 @@ func MarkersDetails(fullDetail bool, groupName string, markers []help.MarkerDoc)
 				out.Print(Indented(2, Line(Text(marker.Details))))
 			}
 			out.Print(Newlines(1))
-		} else if !marker.Empty() {
+		case !marker.Empty():
 			out.Print(Newlines(1))
 			if fullDetail {
 				for _, arg := range marker.Fields {
@@ -107,7 +108,7 @@ func MarkersDetails(fullDetail bool, groupName string, markers []help.MarkerDoc)
 
 				out.Print(Indented(1, table))
 			}
-		} else {
+		default:
 			out.Print(Newlines(1))
 		}
 	}

--- a/pkg/genall/help/pretty/table.go
+++ b/pkg/genall/help/pretty/table.go
@@ -43,13 +43,13 @@ func (c *TableCalculator) ColumnWidths() []int {
 	maxColWidths := make([]int, len(c.cellSizesByCol))
 
 	for colInd, cellSizes := range c.cellSizesByCol {
-		max := 0
+		maxValue := 0
 		for _, cellSize := range cellSizes {
-			if max < cellSize {
-				max = cellSize
+			if maxValue < cellSize {
+				maxValue = cellSize
 			}
 		}
-		maxColWidths[colInd] = max
+		maxColWidths[colInd] = maxValue
 	}
 
 	actualMaxWidth := c.MaxWidth - c.Padding

--- a/pkg/genall/options.go
+++ b/pkg/genall/options.go
@@ -168,7 +168,7 @@ func protoFromOptions(optionsRegistry *markers.Registry, options []string) (prot
 
 	return protoRuntime{
 		Paths:            paths,
-		Generators:       Generators(gens),
+		Generators:       gens,
 		OutputRules:      rules,
 		GeneratorsByName: gensByName,
 	}, nil

--- a/pkg/loader/errors.go
+++ b/pkg/loader/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package loader
 
 import (
+	"errors"
 	"fmt"
 	"go/token"
 )
@@ -37,7 +38,8 @@ type Node interface {
 // attaching it to the given AST node.  It will automatically map
 // over error lists.
 func ErrFromNode(err error, node Node) error {
-	if asList, isList := err.(ErrList); isList {
+	var asList ErrList
+	if isList := errors.As(err, &asList); isList {
 		resList := make(ErrList, len(asList))
 		for i, baseErr := range asList {
 			resList[i] = ErrFromNode(baseErr, node)

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 )
 

--- a/pkg/loader/testutils/helpers.go
+++ b/pkg/loader/testutils/helpers.go
@@ -46,11 +46,11 @@ func (t fakeT) Cleanup(f func()) {
 }
 
 func (t fakeT) Error(args ...interface{}) {
-	t.g.Error(args)
+	t.g.Error(args...)
 }
 
 func (t fakeT) Errorf(format string, args ...interface{}) {
-	t.g.Errorf(format, args)
+	t.g.Errorf(format, args...)
 }
 
 func (t fakeT) Fail() {
@@ -66,11 +66,11 @@ func (t fakeT) Failed() bool {
 }
 
 func (t fakeT) Fatal(args ...interface{}) {
-	t.g.Fatal(args)
+	t.g.Fatal(args...)
 }
 
 func (t fakeT) Fatalf(format string, args ...interface{}) {
-	t.g.Fatalf(format, args)
+	t.g.Fatalf(format, args...)
 }
 
 func (t fakeT) Helper() {
@@ -78,11 +78,11 @@ func (t fakeT) Helper() {
 }
 
 func (t fakeT) Log(args ...interface{}) {
-	t.g.Log(args)
+	t.g.Log(args...)
 }
 
 func (t fakeT) Logf(format string, args ...interface{}) {
-	t.g.Logf(format, args)
+	t.g.Logf(format, args...)
 }
 
 func (t fakeT) Name() string {
@@ -94,7 +94,7 @@ func (t fakeT) Setenv(key, value string) {
 }
 
 func (t fakeT) Skip(args ...interface{}) {
-	t.g.Skip(args)
+	t.g.Skip(args...)
 }
 
 func (t fakeT) SkipNow() {
@@ -102,7 +102,7 @@ func (t fakeT) SkipNow() {
 }
 
 func (t fakeT) Skipf(format string, args ...interface{}) {
-	t.g.Skipf(format, args)
+	t.g.Skipf(format, args...)
 }
 
 func (t fakeT) Skipped() bool {

--- a/pkg/loader/testutils/helpers.go
+++ b/pkg/loader/testutils/helpers.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/onsi/ginkgo"
 	pkgstest "golang.org/x/tools/go/packages/packagestest"
-
 	"sigs.k8s.io/controller-tools/pkg/loader"
 )
 

--- a/pkg/markers/collect_test.go
+++ b/pkg/markers/collect_test.go
@@ -19,7 +19,6 @@ package markers_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	. "sigs.k8s.io/controller-tools/pkg/markers"
 )
 

--- a/pkg/markers/markers_suite_test.go
+++ b/pkg/markers/markers_suite_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	pkgstest "golang.org/x/tools/go/packages/packagestest"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -495,7 +495,6 @@ func (a *Argument) parseMap(scanner *sc.Scanner, raw string, out reflect.Value) 
 // parse functions like Parse, except that it allows passing down whether or not we're
 // already in a slice, to avoid duplicate legacy slice detection for AnyType
 func (a *Argument) parse(scanner *sc.Scanner, raw string, out reflect.Value, inSlice bool) {
-	// nolint:gocyclo
 	if a.Type == InvalidType {
 		scanner.Error(scanner, "cannot parse invalid type")
 		return
@@ -757,8 +756,7 @@ func argumentInfo(fieldName string, tag reflect.StructTag) (argName string, opti
 	}
 	optionalOpt = false
 	for _, tagOption := range markerTagParts[1:] {
-		switch tagOption {
-		case "optional":
+		if tagOption == "optional" {
 			optionalOpt = true
 		}
 	}

--- a/pkg/markers/parse_test.go
+++ b/pkg/markers/parse_test.go
@@ -24,7 +24,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	. "sigs.k8s.io/controller-tools/pkg/markers"
 )
 

--- a/pkg/markers/zip.go
+++ b/pkg/markers/zip.go
@@ -75,7 +75,7 @@ func extractDoc(node ast.Node, decl *ast.GenDecl) string {
 		lines = lines[:len(lines)-1]
 	}
 
-	var outLines []string
+	outLines := make([]string, 0, len(lines))
 	var insideCodeBlock bool
 	for i, line := range lines {
 		if isAsteriskComment {

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -29,7 +29,6 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )

--- a/pkg/rbac/parser_integration_test.go
+++ b/pkg/rbac/parser_integration_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	rbacv1 "k8s.io/api/rbac/v1"
-
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"

--- a/pkg/schemapatcher/gen.go
+++ b/pkg/schemapatcher/gen.go
@@ -26,14 +26,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kyaml "sigs.k8s.io/yaml"
-
 	crdgen "sigs.k8s.io/controller-tools/pkg/crd"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 	yamlop "sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml"
+	kyaml "sigs.k8s.io/yaml"
 )
 
 // NB(directxman12): this code is quite fragile, but there are a sufficient

--- a/pkg/schemapatcher/gen_integration_test.go
+++ b/pkg/schemapatcher/gen_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	. "sigs.k8s.io/controller-tools/pkg/schemapatcher"
 )

--- a/pkg/schemapatcher/internal/yaml/delete_test.go
+++ b/pkg/schemapatcher/internal/yaml/delete_test.go
@@ -30,22 +30,24 @@ var _ = Describe("DeleteNode", func() {
 		want    interface{}
 		wantErr bool
 	}{
-		/*{name: "non-empty, unknown path",
-			obj: map[string]interface{}{
-				"bar": int64(42),
+		/*
+			{name: "non-empty, unknown path",
+				obj: map[string]interface{}{
+					"bar": int64(42),
+				},
+				path:  []string{"foo"},
+				want: map[string]interface{}{
+					"bar": int64(42),
+				},
 			},
-			path:  []string{"foo"},
-			want: map[string]interface{}{
-				"bar": int64(42),
+			{name: "non-empty, existing path",
+				obj: map[string]interface{}{
+					"bar": int64(42),
+				},
+				path:  []string{"bar"},
+				want: map[string]interface{}{},
 			},
-		},
-		{name: "non-empty, existing path",
-			obj: map[string]interface{}{
-				"bar": int64(42),
-			},
-			path:  []string{"bar"},
-			want: map[string]interface{}{},
-		},*/
+		*/
 		{name: "non-empty, long path",
 			obj: map[string]interface{}{
 				"foo": map[string]interface{}{

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -50,4 +50,3 @@ var _ = Describe("TestVersion", func() {
 		})
 	}
 })
-

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -28,10 +28,9 @@ import (
 	"strings"
 
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )

--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -411,6 +411,7 @@ func (Generator) RegisterMarkers(into *markers.Registry) error {
 	return nil
 }
 
+//gocyclo:ignore
 func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	supportedWebhookVersions := supportedWebhookVersions()
 	mutatingCfgs := make(map[string][]admissionregv1.MutatingWebhook, len(supportedWebhookVersions))
@@ -425,7 +426,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 
 		webhookCfgs := markerSet[WebhookConfigDefinition.Name]
-		var hasValidatingWebhookConfig, hasMutatingWebhookConfig bool = false, false
+		hasValidatingWebhookConfig, hasMutatingWebhookConfig := false, false
 		for _, webhookCfg := range webhookCfgs {
 			webhookCfg := webhookCfg.(WebhookConfig)
 

--- a/pkg/webhook/parser_integration_test.go
+++ b/pkg/webhook/parser_integration_test.go
@@ -25,12 +25,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
-	"sigs.k8s.io/yaml"
-
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 	"sigs.k8s.io/controller-tools/pkg/webhook"
+	"sigs.k8s.io/yaml"
 )
 
 // TODO(directxman12): test generation across multiple versions (right


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->

This PR is the next PR for #1132

Add golangci-lint linters to controller-tools

Sync golangci-lint linters from [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/main/.golangci.yml)

More info see: https://golangci-lint.run/usage/linters/#disabled-by-default