### PR TITLE
:sparkles: markers: add support for optionalOldSelf in XValidation marker

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -335,6 +335,7 @@ type XValidation struct {
 	MessageExpression string `marker:"messageExpression,optional"`
 	Reason            string `marker:"reason,optional"`
 	FieldPath         string `marker:"fieldPath,optional"`
+	OptionalOldSelf   *bool  `marker:"optionalOldSelf,optional"`
 }
 
 func (m Maximum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
@@ -603,6 +604,7 @@ func (m XValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 		MessageExpression: m.MessageExpression,
 		Reason:            reason,
 		FieldPath:         m.FieldPath,
+		OptionalOldSelf:   m.OptionalOldSelf,
 	})
 	return nil
 }

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -563,6 +563,10 @@ func (XValidation) Help() *markers.DefinitionHelp {
 				Summary: "",
 				Details: "",
 			},
+			"OptionalOldSelf": {
+				Summary: "",
+				Details: "",
+			},
 		},
 	}
 }

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -381,6 +381,10 @@ type CronJobSpec struct {
 
 	// This tests that embedded struct, which is an alias type, is handled correctly.
 	InlineAlias `json:",inline"`
+
+	// Test that we can add a field that can only be set to a non-default value on updates using XValidation OptionalOldSelf.
+	// +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || self == 0",message="must be set to 0 on creation. can be set to any value on an update.",optionalOldSelf=true
+	OnlyAllowSettingOnUpdate int32 `json:"onlyAllowSettingOnUpdate,omitempty"`
 }
 
 type InlineAlias = EmbeddedStruct

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -8967,6 +8967,16 @@ spec:
                   This flag is like suspend, but for when you really mean it.
                   It helps test the +kubebuilder:validation:Type marker.
                 type: string
+              onlyAllowSettingOnUpdate:
+                description: Test that we can add a field that can only be set to
+                  a non-default value on updates using XValidation OptionalOldSelf.
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must be set to 0 on creation. can be set to any value on
+                    an update.
+                  optionalOldSelf: true
+                  rule: oldSelf.hasValue() || self == 0
               patternObject:
                 description: This tests that pattern validator is properly applied.
                 pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->

Adds a new field to the `+kubebuilder:validation:XValidation` marker to specify `optionalOldSelf`. Adding this configuration option allows writing validation rules that behave one way on create vs update. For example, allow setting a field if it is an update, but don't allow the field to be set at creation.

For more explicit information on the `optionalOldSelf` field for validation rules, see https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-optional-oldself