### PR TITLE
:sparkles: Parametrize filename for generated RBAC

### DIFF
--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -161,6 +161,9 @@ type Generator struct {
 	// RoleName sets the name of the generated ClusterRole.
 	RoleName string
 
+	// FileName sets the file name for the generated manifest(s). If not set, defaults to "role.yaml".
+	FileName string `marker:",optional"`
+
 	// HeaderFile specifies the header text (e.g. license) to prepend to generated files.
 	HeaderFile string `marker:",optional"`
 
@@ -383,5 +386,10 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	}
 	headerText = strings.ReplaceAll(headerText, " YEAR", " "+g.Year)
 
-	return ctx.WriteYAML("role.yaml", headerText, objs, genall.WithTransform(genall.TransformRemoveCreationTimestamp))
+	fileName := "role.yaml"
+	if g.FileName != "" {
+		fileName = g.FileName
+	}
+
+	return ctx.WriteYAML(fileName, headerText, objs, genall.WithTransform(genall.TransformRemoveCreationTimestamp))
 }

--- a/pkg/rbac/zz_generated.markerhelp.go
+++ b/pkg/rbac/zz_generated.markerhelp.go
@@ -36,6 +36,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "sets the name of the generated ClusterRole.",
 				Details: "",
 			},
+			"FileName": {
+				Summary: "sets the file name for the generated manifest(s). If not set, defaults to \"role.yaml\".",
+				Details: "",
+			},
 			"HeaderFile": {
 				Summary: "specifies the header text (e.g. license) to prepend to generated files.",
 				Details: "",


### PR DESCRIPTION
Before this change, the file name of the role/clusterrole generated from `+rbac` markers was hardcoded to `role.yaml`.

This change introduces a parameter `fileName` to the RBAC generator, so that one can do
```
controller-gen rbac:fileName=my-rbac-my-choice.yaml
```
and have the file be `my-rbac-my-choice.yaml` instead. (Given no specified `output` in the above example, the full path of the output file will be `/config/rbac/my-rbac-my-choice.yaml`.)

This is useful e.g. in cases where the target directory structure is not the standard Kustomize-packaged Kubebuilder one, but instead e.g. a Helm chart where multiple sources of information may contribute to the final set of files.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
