### PR TITLE
✨ Add Title marker

### DIFF
--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -469,6 +469,22 @@ func (SubresourceStatus) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (Title) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "sets the title for this field.",
+			Details: "The title is metadata that makes the OpenAPI documentation more user-friendly,\nmaking the schema more understandable when viewed in documentation tools.\nIt's a metadata field that doesn't affect validation but provides\nimportant context about what the schema represents.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{
+			"Value": {
+				Summary: "",
+				Details: "",
+			},
+		},
+	}
+}
+
 func (Type) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -113,20 +113,24 @@ type CronJobSpec struct {
 	// This tests that primitive defaulting can be performed.
 	// +kubebuilder:default=forty-two
 	// +kubebuilder:example=forty-two
+	// +kubebuilder:title=DefaultedString
 	DefaultedString string `json:"defaultedString"`
 
 	// This tests that slice defaulting can be performed.
 	// +kubebuilder:default={a,b}
 	// +kubebuilder:example={a,b}
+	// +kubebuilder:title=DefaultedSlice
 	DefaultedSlice []string `json:"defaultedSlice"`
 
 	// This tests that slice and object defaulting can be performed.
 	// +kubebuilder:default={{nested: {foo: "baz", bar: true}},{nested: {foo: "qux", bar: false}}}
 	// +kubebuilder:example={{nested: {foo: "baz", bar: true}},{nested: {foo: "qux", bar: false}}}
+	// +kubebuilder:title="124"
 	DefaultedObject []RootObject `json:"defaultedObject"`
 
 	// This tests that empty slice defaulting can be performed.
 	// +kubebuilder:default={}
+	// +kubebuilder:title="{}"
 	DefaultedEmptySlice []string `json:"defaultedEmptySlice"`
 
 	// This tests that an empty object defaulting can be performed on a map.

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -131,6 +131,7 @@ spec:
                 description: This tests that empty slice defaulting can be performed.
                 items:
                   type: string
+                title: '{}'
                 type: array
               defaultedObject:
                 default:
@@ -163,6 +164,7 @@ spec:
                   required:
                   - nested
                   type: object
+                title: "124"
                 type: array
               defaultedSlice:
                 default:
@@ -174,11 +176,13 @@ spec:
                 - b
                 items:
                   type: string
+                title: DefaultedSlice
                 type: array
               defaultedString:
                 default: forty-two
                 description: This tests that primitive defaulting can be performed.
                 example: forty-two
+                title: DefaultedString
                 type: string
               doubleDefaultedString:
                 default: kubebuilder-default


### PR DESCRIPTION
This PR adds support for the `+kubebuilder:title=<string>` marker to the validation package.

The new marker allows users to specify a human-readable title for API resources, which can be used in documentation generation, UI displays, and other contexts where a more descriptive label than the type name is helpful.

This addresses issue #883 "Missing marker for 'title' key" and provides a consistent way to define titles that aligns with other metadata annotations in the controller-tools ecosystem.