### PR TITLE
:sparkles: Change CRD generation logic to honor k8s:immutable

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -106,6 +106,9 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeAnyTypeDefinition("kubebuilder:title", markers.DescribesField, Title{})).
 		WithHelp(Title{}.Help()),
+
+	must(markers.MakeDefinition("k8s:immutable", markers.DescribesField, Immutable{})).
+		WithHelp(Immutable{}.Help()),
 }
 
 // ValidationIshMarkers are field-and-type markers that don't fall under the
@@ -324,6 +327,19 @@ type XIntOrString struct{}
 // Because this field disables all type checking, it is recommended
 // to be used only as a last resort.
 type Schemaless struct{}
+
+// +controllertools:marker:generateHelp:category="CRD validation"
+// Immutable marks a field as immutable.
+// The value of an immutable field may not be changed after creation.
+type Immutable struct{}
+
+func (Immutable) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	schema.XValidations = append(schema.XValidations, apiext.ValidationRule{
+		Message: "Value is immutable",
+		Rule:    "self == oldSelf",
+	})
+	return nil
+}
 
 func hasNumericType(schema *apiext.JSONSchemaProps) bool {
 	return schema.Type == string(Integer) || schema.Type == string(Number)

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -116,6 +116,17 @@ func (Format) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (Immutable) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "marks a field as immutable.",
+			Details: "The value of an immutable field may not be changed after creation.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (KubernetesDefault) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",


### PR DESCRIPTION
This change adds logic to understand and interpret k8s:immutable tag in controller-gen. This tag is getting introduced for native types in K8s as part of [5073-declarative-validation-with-validation-gen](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen) KEP.  

On detecting the tag, A CEL validation is added for the corresponding field. 

