### PR TITLE
:bug: Applyconfiguration: Use correct groupVersion

### DIFF
--- a/pkg/applyconfiguration/gen.go
+++ b/pkg/applyconfiguration/gen.go
@@ -17,6 +17,7 @@ limitations under the License.
 package applyconfiguration
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"os"
@@ -33,6 +34,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
 	"sigs.k8s.io/controller-tools/pkg/genall"
+	"sigs.k8s.io/controller-tools/pkg/internal/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -204,6 +206,18 @@ func (ctx *ObjectGenCtx) generateForPackage(root *loader.Package) error {
 	if !ok {
 		return fmt.Errorf("package %q not found in universe", root.Name)
 	}
+
+	pkgMarkers, err := markers.PackageMarkers(ctx.Collector, root)
+	if err != nil {
+		return fmt.Errorf("failed to get package markers: %w", err)
+	}
+
+	gv := crd.GroupVersionForPackage(pkgMarkers, root)
+	if gv.Empty() {
+		return errors.New("could not infer groupVersion for package - Is the `// +groupName` marker set?")
+	}
+
+	pkg.Comments = append(pkg.Comments, "+groupName="+gv.Group)
 
 	// For each type we think should be generated, make sure it has a genclient
 	// marker else the apply generator will not generate it.

--- a/pkg/applyconfiguration/testdata/cronjob/api/v1/applyconfiguration/api/v1/cronjob.go
+++ b/pkg/applyconfiguration/testdata/cronjob/api/v1/applyconfiguration/api/v1/cronjob.go
@@ -24,7 +24,7 @@ func CronJob(name, namespace string) *CronJobApplyConfiguration {
 	b.WithName(name)
 	b.WithNamespace(namespace)
 	b.WithKind("CronJob")
-	b.WithAPIVersion("api/v1")
+	b.WithAPIVersion("testdata.kubebuilder.io/v1")
 	return b
 }
 

--- a/pkg/applyconfiguration/testdata/cronjob/api/v1/applyconfiguration/utils.go
+++ b/pkg/applyconfiguration/testdata/cronjob/api/v1/applyconfiguration/utils.go
@@ -15,7 +15,7 @@ import (
 // apply configuration type exists for the given GroupVersionKind.
 func ForKind(kind schema.GroupVersionKind) interface{} {
 	switch kind {
-	// Group=api, Version=v1
+	// Group=testdata.kubebuilder.io, Version=v1
 	case v1.SchemeGroupVersion.WithKind("AssociativeType"):
 		return &apiv1.AssociativeTypeApplyConfiguration{}
 	case v1.SchemeGroupVersion.WithKind("ContainsNestedMap"):

--- a/pkg/applyconfiguration/testdata/cronjob/api/v1/cronjob_types.go
+++ b/pkg/applyconfiguration/testdata/cronjob/api/v1/cronjob_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 // TODO(directxman12): test this across both versions (right now we're just
 // trusting k/k conversion, which is probably fine though)
 
-//go:generate ../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true,allowDangerousTypes=true paths=./;./deprecated;./unserved;./job/... output:dir=.
+//go:generate ../../../../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true,allowDangerousTypes=true paths=./;./deprecated;./unserved;./job/... output:dir=.
 
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1

--- a/pkg/crd/parser.go
+++ b/pkg/crd/parser.go
@@ -21,6 +21,7 @@ import (
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-tools/pkg/internal/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -132,17 +133,8 @@ func (p *Parser) indexTypes(pkg *loader.Package) {
 		if skipPkg := pkgMarkers.Get("kubebuilder:skip"); skipPkg != nil {
 			return
 		}
-		if nameVal := pkgMarkers.Get("groupName"); nameVal != nil {
-			versionVal := pkg.Name // a reasonable guess
-			if versionMarker := pkgMarkers.Get("versionName"); versionMarker != nil {
-				versionVal = versionMarker.(string)
-			}
 
-			p.GroupVersions[pkg] = schema.GroupVersion{
-				Version: versionVal,
-				Group:   nameVal.(string),
-			}
-		}
+		p.GroupVersions[pkg] = crd.GroupVersionForPackage(pkgMarkers, pkg)
 	}
 
 	if err := markers.EachType(p.Collector, pkg, func(info *markers.TypeInfo) {

--- a/pkg/internal/crd/crd.go
+++ b/pkg/internal/crd/crd.go
@@ -1,0 +1,23 @@
+package crd
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+func GroupVersionForPackage(pkgMarkers markers.MarkerValues, pkg *loader.Package) schema.GroupVersion {
+	if nameVal := pkgMarkers.Get("groupName"); nameVal != nil {
+		versionVal := pkg.Name // a reasonable guess
+		if versionMarker := pkgMarkers.Get("versionName"); versionMarker != nil {
+			versionVal = versionMarker.(string)
+		}
+
+		return schema.GroupVersion{
+			Version: versionVal,
+			Group:   nameVal.(string),
+		}
+	}
+
+	return schema.GroupVersion{}
+}


### PR DESCRIPTION
The upstream generator we import infers the groupVersion from the package path: https://github.com/kubernetes/kubernetes/blob/b0b52f4fb29223f829b50ae58323c20a7764dfc9/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go#L263

The path might not be reflective of the groupVersion, so use the override mechanism: https://github.com/kubernetes/kubernetes/blob/b0b52f4fb29223f829b50ae58323c20a7764dfc9/staging/src/k8s.io/code-generator/cmd/applyconfiguration-gen/generators/targets.go#L270

Fixes https://github.com/kubernetes-sigs/controller-tools/issues/1194

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
