### PR TITLE
🐛 Applyconfiguration: register CRD markers

### DIFF
--- a/pkg/applyconfiguration/applyconfiguration_integration_test.go
+++ b/pkg/applyconfiguration/applyconfiguration_integration_test.go
@@ -106,11 +106,9 @@ var _ = Describe("ApplyConfiguration generation from API types", func() {
 		By("Initializing the runtime")
 		optionsRegistry := &markers.Registry{}
 		Expect(genall.RegisterOptionsMarkers(optionsRegistry)).To(Succeed())
-		Expect(optionsRegistry.Register(markers.Must(markers.MakeDefinition("crd", markers.DescribesPackage, crd.Generator{})))).To(Succeed())
 		Expect(optionsRegistry.Register(markers.Must(markers.MakeDefinition("applyconfiguration", markers.DescribesPackage, Generator{})))).To(Succeed())
 
 		rt, err := genall.FromOptions(optionsRegistry, []string{
-			"crd:allowDangerousTypes=true,ignoreUnexportedFields=true", // Run another generator first to make sure they don't interfere; see also: the comment on cronjob_types.go:UntypedBlob
 			"applyconfiguration",
 			"paths=./api/v1",
 		})
@@ -197,6 +195,41 @@ var _ = Describe("ApplyConfiguration generation from API types", func() {
 
 			Expect(string(filesInOutput[name])).To(BeComparableTo(string(content)), "Generated files should match the checked in files, diff found in %s", name)
 		}
+	},
+		Entry("with the default applyconfiguration output package", "applyconfiguration"),
+		Entry("with the an alternative output package", "other"),
+		Entry("with a package outside of the current directory", "../../clients"),
+	)
+
+	DescribeTable("should be able to run another generator for the CronJob schema without interfering", func(outputPackage string) {
+		Expect(replaceOutputPkgMarker("./api/v1", outputPackage)).To(Succeed())
+
+		// The output is used to capture the generated CRD file.
+		// The output of the applyconfiguration cannot be generated to memory, gengo handles all of the writing to disk directly.
+		output := make(outputToMap)
+
+		By("Initializing the runtime")
+		optionsRegistry := &markers.Registry{}
+		generator := Generator{}
+		Expect(genall.RegisterOptionsMarkers(optionsRegistry)).To(Succeed())
+		Expect(optionsRegistry.Register(markers.Must(markers.MakeDefinition("crd", markers.DescribesPackage, crd.Generator{})))).To(Succeed())
+		Expect(optionsRegistry.Register(markers.Must(markers.MakeDefinition("applyconfiguration", markers.DescribesPackage, generator)))).To(Succeed())
+		Expect(generator.RegisterMarkers(optionsRegistry)).To(Succeed())
+
+		rt, err := genall.FromOptions(optionsRegistry, []string{
+			"crd:allowDangerousTypes=true,ignoreUnexportedFields=true", // Run another generator first to make sure they don't interfere; see also: the comment on cronjob_types.go:UntypedBlob
+			"applyconfiguration",
+			"paths=./api/v1",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		rt.OutputRules = genall.OutputRules{Default: output}
+
+		By("Running the generator")
+		hadErrs := rt.Run()
+
+		By("Checking for generation errors")
+		Expect(hadErrs).To(BeFalse(), "Generator should run without errors")
 	},
 		Entry("with the default applyconfiguration output package", "applyconfiguration"),
 		Entry("with the an alternative output package", "other"),

--- a/pkg/applyconfiguration/gen.go
+++ b/pkg/applyconfiguration/gen.go
@@ -72,6 +72,10 @@ func (Generator) RegisterMarkers(into *markers.Registry) error {
 		return err
 	}
 
+	if err := crdmarkers.Register(into); err != nil {
+		return err
+	}
+
 	into.AddHelp(isCRDMarker,
 		markers.SimpleHelp("apply", "enables apply configuration generation for this type"))
 	into.AddHelp(


### PR DESCRIPTION
It seems the markers collector will only collect markers which have been explicitly registered to the markers registry. Since `groupName` is never registered, it always fails with
```
could not infer groupVersion for package - Is the `// +groupName` marker set?
Error: not all generators ran successfully
run `controller-gen applyconfiguration paths=./api/v1beta1/ -w` to see all available markers, or `controller-gen applyconfiguration paths=./api/v1beta1/ -h` for usage
```
because the marker will not be in the map of markers despite the marker being set on the package.

This registers the CRD markers (`groupName`, `versionName`, etc) so they can be collected and used to infer the group version.

Fixes #1218 
