### PR TITLE
🐛markers/OneOf: make order deterministic relative to XValidation

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -660,6 +660,10 @@ func (m XValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	return nil
 }
 
+func (XValidation) ApplyPriority() ApplyPriority {
+	return ApplyPriorityDefault
+}
+
 func (fields AtMostOneOf) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	if len(fields) == 0 {
 		return nil
@@ -672,9 +676,9 @@ func (fields AtMostOneOf) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	return xvalidation.ApplyToSchema(schema)
 }
 
-func (_ AtMostOneOf) ApplyPriority() ApplyPriority {
+func (AtMostOneOf) ApplyPriority() ApplyPriority {
 	// explicitly go after XValidation markers so that the ordering is deterministic
-	return ApplyPriorityDefault + 1
+	return XValidation{}.ApplyPriority() + 1
 }
 
 func (fields ExactlyOneOf) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
@@ -689,9 +693,9 @@ func (fields ExactlyOneOf) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	return xvalidation.ApplyToSchema(schema)
 }
 
-func (_ ExactlyOneOf) ApplyPriority() ApplyPriority {
+func (ExactlyOneOf) ApplyPriority() ApplyPriority {
 	// explicitly go after XValidation markers so that the ordering is deterministic
-	return ApplyPriorityDefault + 1
+	return XValidation{}.ApplyPriority() + 1
 }
 
 // fieldsToOneOfCelRuleStr converts a slice of field names to a string representation

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -672,6 +672,11 @@ func (fields AtMostOneOf) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	return xvalidation.ApplyToSchema(schema)
 }
 
+func (_ AtMostOneOf) ApplyPriority() ApplyPriority {
+	// explicitly go after XValidation markers so that the ordering is deterministic
+	return ApplyPriorityDefault + 1
+}
+
 func (fields ExactlyOneOf) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	if len(fields) == 0 {
 		return nil
@@ -682,6 +687,11 @@ func (fields ExactlyOneOf) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 		Message: fmt.Sprintf("exactly one of the fields in %v must be set", fields),
 	}
 	return xvalidation.ApplyToSchema(schema)
+}
+
+func (_ ExactlyOneOf) ApplyPriority() ApplyPriority {
+	// explicitly go after XValidation markers so that the ordering is deterministic
+	return ApplyPriorityDefault + 1
 }
 
 // fieldsToOneOfCelRuleStr converts a slice of field names to a string representation

--- a/pkg/crd/testdata/oneof/types.go
+++ b/pkg/crd/testdata/oneof/types.go
@@ -34,6 +34,7 @@ type OneofSpec struct {
 	SecondTypeWithExactOneof *TypeWithMultipleExactOneofs `json:"secondTypeWithExactOneof,omitempty"`
 }
 
+// +kubebuilder:validation:XValidation:message="only one of foo|bar may be set",rule="!(has(self.foo) && has(self.bar))"
 // +kubebuilder:validation:AtMostOneOf=foo;bar
 type TypeWithOneofs struct {
 	Foo *string `json:"foo,omitempty"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
@@ -56,6 +56,8 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: only one of foo|bar may be set
+                  rule: '!(has(self.foo) && has(self.bar))'
                 - message: at most one of the fields in [foo bar] may be set
                   rule: '[has(self.foo),has(self.bar)].filter(x,x==true).size() <=
                     1'


### PR DESCRIPTION
Currently, if both XValidation and AtMostOneOf/ExactlyOneOf constraints are specified, the ordering of CEL rules can change due to both sets of markers have the same apply priority. This change ensures that OneOf markers always run **after** XValidation markers. Without this, the generated CRD can change without any API changes, which is undesirable. 

