### PR TITLE
📖 Sync admins & maintainers with kubernetes/org

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,13 +4,17 @@ aliases:
   # active folks who can be contacted to perform admin-related
   # tasks on the repo, or otherwise approve any PRS.
   controller-tools-admins:
-    - vincepri
+    - alvaroaleman
     - joelanford
+    - sbueringer
+    - vincepri
 
   # non-admin folks who can approve any PRs in the repo
   controller-tools-maintainers:
     - alvaroaleman
+    - joelanford
     - sbueringer
+    - vincepri
 
   # non-admin folks who can approve any PRs in the repo
   controller-tools-approvers:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
Sync after https://github.com/kubernetes/org/pull/5691