### PR TITLE
:sparkles:  Add support for k8s:enum tag.

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -34,6 +34,9 @@ const (
 
 	ValidationExactlyOneOfPrefix = validationPrefix + "ExactlyOneOf"
 	ValidationAtMostOneOfPrefix  = validationPrefix + "AtMostOneOf"
+
+	// K8sEnumTag indicates that the given type is an enum; all const values of this type are considered values in the enum
+	K8sEnumTag = "k8s:enum"
 )
 
 // ValidationMarkers lists all available markers that affect CRD schema generation,
@@ -84,6 +87,8 @@ var TypeOnlyMarkers = []*definitionWithHelp{
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies a list of field names that must conform to the AtMostOneOf constraint.")),
 	must(markers.MakeDefinition(ValidationExactlyOneOfPrefix, markers.DescribesType, ExactlyOneOf(nil))).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies a list of field names that must conform to the ExactlyOneOf constraint.")),
+	must(markers.MakeDefinition(K8sEnumTag, markers.DescribesType, struct{}{})).
+		WithHelp(markers.SimpleHelp("CRD", "indicates that the given type is an enum; all const values of this type are considered values in the enum")),
 }
 
 // FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -186,6 +186,16 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 			})
 		})
 
+		Context("Enum API", func() {
+			BeforeEach(func() {
+				pkgPaths = []string{"./enum/..."}
+				expPkgLen = 1
+			})
+			It("should successfully generate the CRD with enum validation constraints", func() {
+				assertCRD(pkgs[0], "Enum", "testdata.kubebuilder.io_enums.yaml")
+			})
+		})
+
 		Context("OneOf API with invalid marker", func() {
 			BeforeEach(func() {
 				pkgPaths = []string{"./oneof_error/..."}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -61,6 +61,14 @@ type CronJobSpec struct {
 	// +optional
 	ConcurrencyPolicy ConcurrencyPolicy `json:"concurrencyPolicy,omitempty"`
 
+	// Specifies how to treat concurrent executions of a Job.
+	// Valid values are:
+	// - "Allow" (default): allows CronJobs to run concurrently;
+	// - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+	// - "Replace": cancels currently running job and replaces it with a new one
+	// +optional
+	K8sConcurrencyPolicy K8sConcurrencyPolicy `json:"k8sConcurrencyPolicy,omitempty"`
+
 	// This flag tells the controller to suspend subsequent executions, it does
 	// not apply to already started executions.  Defaults to false.
 	// +optional
@@ -694,6 +702,21 @@ const (
 
 	// ReplaceConcurrent cancels currently running job and replaces it with a new one.
 	ReplaceConcurrent ConcurrencyPolicy = "Replace"
+)
+
+// +k8s:enum
+type K8sConcurrencyPolicy string
+
+const (
+	// AllowK8sConcurrencyPolicy allows CronJobs to run concurrently.
+	AllowK8sConcurrencyPolicy K8sConcurrencyPolicy = "Allow"
+
+	// ForbidK8sConcurrencyPolicy forbids concurrent runs, skipping next run if previous
+	// hasn't finished yet.
+	ForbidK8sConcurrencyPolicy K8sConcurrencyPolicy = "Forbid"
+
+	// ReplaceK8sConcurrencyPolicy cancels currently running job and replaces it with a new one.
+	ReplaceK8sConcurrencyPolicy K8sConcurrencyPolicy = "Replace"
 )
 
 // StringEvenType is a type that includes an expression-based validation.

--- a/pkg/crd/testdata/enum/api.go
+++ b/pkg/crd/testdata/enum/api.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package enum
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +k8s:enum
+type EnumType string
+
+const (
+	Value1 EnumType = "Value1"
+	Value2 EnumType = "Value2"
+)
+
+// +kubebuilder:object:root=true
+
+// Enum is a test CRD that contains an enum.
+type Enum struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec EnumSpec `json:"spec,omitempty"`
+}
+
+// EnumSpec defines the desired state of Enum
+type EnumSpec struct {
+	Field EnumType `json:"field,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// EnumList contains a list of Enum
+type EnumList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Enum `json:"items"`
+}

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -108,6 +108,18 @@ spec:
                 - Forbid
                 - Replace
                 type: string
+              k8sConcurrencyPolicy:
+                description: |-
+                  Specifies how to treat concurrent executions of a Job.
+                  Valid values are:
+                  - "Allow" (default): allows CronJobs to run concurrently;
+                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+                  - "Replace": cancels currently running job and replaces it with a new one
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
               defaultedEmptyMap:
                 additionalProperties:
                   type: string

--- a/pkg/crd/testdata/testdata.kubebuilder.io_enums.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_enums.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enums.testdata.kubebuilder.io
+spec:
+  group: testdata.kubebuilder.io
+  names:
+    kind: Enum
+    listKind: EnumList
+    plural: enums
+    singular: enum
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Enum is a test CRD that contains an enum.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnumSpec defines the desired state of Enum
+            properties:
+              field:
+                enum:
+                - Value1
+                - Value2
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
This PR introduces support for a +k8s:enum marker to automatically generate enum validation for Custom Resource Definitions (CRDs). This tag is used by native types to validate enums using declarative Validations.

This change simplifies the process of defining enums in CRDs. Previously, developers had to manually specify all enum values using the +kubebuilder:validation:Enum marker for every field of an enum type. This was repetitive and prone to errors, especially when enum values changed.

With this new +k8s:enum type-level marker, controller-gen automatically discovers all constant values associated with a string-based enum type and generates the corresponding validation in the OpenAPI schema. This makes the process more maintainable and less error-prone.