### PR TITLE
⚠️  Start from local type declaration when applying schema

### DIFF
--- a/pkg/crd/parser.go
+++ b/pkg/crd/parser.go
@@ -172,7 +172,12 @@ func (p *Parser) NeedSchemaFor(typ TypeIdent) {
 	// avoid tripping recursive schemata, like ManagedFields, by adding an empty WIP schema
 	p.Schemata[typ] = apiext.JSONSchemaProps{}
 
-	schemaCtx := newSchemaContext(typ.Package, p, p.AllowDangerousTypes, p.IgnoreUnexportedFields)
+	schemaCtx := newSchemaContext(typ.Package, p, func(typ TypeIdent) *apiext.JSONSchemaProps {
+		p.NeedSchemaFor(typ)
+
+		props := p.Schemata[typ]
+		return &props
+	}, p.AllowDangerousTypes, p.IgnoreUnexportedFields)
 	ctxForInfo := schemaCtx.ForInfo(info)
 
 	pkgMarkers, err := markers.PackageMarkers(p.Collector, typ.Package)

--- a/pkg/crd/schema_test.go
+++ b/pkg/crd/schema_test.go
@@ -64,7 +64,7 @@ func transform(t *testing.T, expr string) *apiext.JSONSchemaProps {
 	pkg.NeedTypesInfo()
 	failIfErrors(t, pkg.Errors)
 
-	schemaContext := newSchemaContext(pkg, nil, true, false).ForInfo(&markers.TypeInfo{})
+	schemaContext := newSchemaContext(pkg, nil, nil, true, false).ForInfo(&markers.TypeInfo{})
 	// yick: grab the only type definition
 	definedType := pkg.Syntax[0].Decls[0].(*ast.GenDecl).Specs[0].(*ast.TypeSpec).Type
 	result := typeToSchema(schemaContext, definedType)

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -389,6 +389,30 @@ type CronJobSpec struct {
 	// Test that we can add a field that can only be set to a non-default value on updates using XValidation OptionalOldSelf.
 	// +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || self == 0",message="must be set to 0 on creation. can be set to any value on an update.",optionalOldSelf=true
 	OnlyAllowSettingOnUpdate int32 `json:"onlyAllowSettingOnUpdate,omitempty"`
+
+	// This tests that unmarkered types are handled correctly.
+	// When markers are applied at the field level instead of the type level.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=10
+	LocallyBoundedInteger UnmarkeredInteger `json:"locallyBoundedInteger,omitempty"`
+
+	// This tests that unmarkered types are handled correctly.
+	// When markers are applied at the field level instead of the type level.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=10
+	LocallyBoundedString UnmarkeredString `json:"locallyBoundedString,omitempty"`
+
+	// This tests that field-level overrides are handled correctly
+	// for local type aliases.
+	// +kubebuilder:validation:MinLength=10
+	// +kubebuilder:validation:MaxLength=10
+	FieldLevelAliasOverride StringAliasWithValidation `json:"fieldLevelAliasOverride,omitempty"`
+
+	// This tests that field-level overrides are handled correctly
+	// for local type declarations.
+	// +kubebuilder:validation:MinLength=10
+	// +kubebuilder:validation:MaxLength=10
+	FieldLevelLocalDeclarationOverride LongerString `json:"fieldLevelLocalDeclarationOverride,omitempty"`
 }
 
 type InlineAlias = EmbeddedStruct
@@ -517,6 +541,14 @@ type TotallyABool bool
 // +kubebuilder:validation:items:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?([.][a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
 // +listType=set
 type Hosts []string
+
+// This tests that unmarkered types are handled correctly.
+// When markers are applied at the field level instead of the type level.
+type UnmarkeredInteger int32
+
+// This tests that unmarkered types are handled correctly.
+// When markers are applied at the field level instead of the type level.
+type UnmarkeredString string
 
 func (t TotallyABool) MarshalJSON() ([]byte, error) {
 	if t {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -219,6 +219,20 @@ spec:
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
+              fieldLevelAliasOverride:
+                description: |-
+                  This tests that field-level overrides are handled correctly
+                  for local type aliases.
+                maxLength: 10
+                minLength: 10
+                type: string
+              fieldLevelLocalDeclarationOverride:
+                description: |-
+                  This tests that field-level overrides are handled correctly
+                  for local type declarations.
+                maxLength: 10
+                minLength: 10
+                type: string
               float64WithValidations:
                 maximum: 1.5
                 minimum: -0.5
@@ -8849,6 +8863,21 @@ spec:
                 default: forty-two
                 description: This tests that primitive defaulting can be performed.
                 type: string
+              locallyBoundedInteger:
+                description: |-
+                  This tests that unmarkered types are handled correctly.
+                  When markers are applied at the field level instead of the type level.
+                format: int32
+                maximum: 10
+                minimum: 1
+                type: integer
+              locallyBoundedString:
+                description: |-
+                  This tests that unmarkered types are handled correctly.
+                  When markers are applied at the field level instead of the type level.
+                maxLength: 10
+                minLength: 1
+                type: string
               longerStringArray:
                 description: This tests string alias slice item validation.
                 items:
@@ -9055,10 +9084,10 @@ spec:
                   and type.
                 type: string
                 x-kubernetes-validations:
-                - message: must have good prefix
-                  rule: self.startsWith('good-')
                 - message: must have even length
                   rule: self.size() % 2 == 0
+                - message: must have good prefix
+                  rule: self.startsWith('good-')
               stringWithEvenLengthAndMessageExpression:
                 description: Test of the expression-based validation with messageExpression
                   marker.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
A number of our markers require information about the type before they can be applied, for example, `+kubebuilder:validation:Minimum` requires the type of the scheme to be an integer or number.

However, if I'm using a local type declaration
```
type Port int32
```
And I then use this in a field
```
// +kubebuilder:validation:Minimum:=1
Port Port `json:"port"`
```
Currently, this doesn't work.

The reason for this is that while we fetch the type schema, we return a link to the schema, and then try to apply the markers for the field.

Because we only have a link to the schema, the `type` of the schema is empty, and the markers fail to apply.

This change effectively moves some of the flattening logic earlier in the process, so that rather than returning a link to the type schema to be flattened later, we return the actual type schema with its markers already applied.

This allows the field level markers to override (breaking change!) what was on the schema for the type, where previously it would create an `allOf` validation, meaning there was no way to override locally, meaning local field level markers could only tighten, not loosen validation of an existing types markers. Since the local field markers could only tighten validation, this shouldn't actually be a breaking change for the APIs that have done this in the past, but their schemas will change and now only represent the tighter validation.

This could be an issue however if folks have previously tried to override locally (loosening) and not realised that their local field level markers were pointless, the schema will change to loosen the validation with this change in place.

/hold Since this could be breaking, this needs some discussion between maintainers and the community

CC @sbueringer @erikgb @alvaroaleman 