### PR TITLE
🐛 Stop setting invalid formats int32/int64 for integer types

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -271,7 +271,7 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiext.JSONSchema
 		typeInfo = aliasInfo.Rhs()
 	}
 	if basicInfo, isBasic := typeInfo.(*types.Basic); isBasic {
-		typ, fmt, err := builtinToType(basicInfo, ctx.allowDangerousTypes)
+		typ, err := builtinToType(basicInfo, ctx.allowDangerousTypes)
 		if err != nil {
 			ctx.pkg.AddError(loader.ErrFromNode(err, ident))
 		}
@@ -284,14 +284,12 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiext.JSONSchema
 			ctx.requestSchema("", ident.Name)
 			link := TypeRefLink("", ident.Name)
 			return &apiext.JSONSchemaProps{
-				Type:   typ,
-				Format: fmt,
-				Ref:    &link,
+				Type: typ,
+				Ref:  &link,
 			}
 		}
 		return &apiext.JSONSchemaProps{
-			Type:   typ,
-			Format: fmt,
+			Type: typ,
 		}
 	}
 	// NB(directxman12): if there are dot imports, this might be an external reference,
@@ -554,7 +552,7 @@ func validateOneOfValues(fields ...string) error {
 // builtinToType converts builtin basic types to their equivalent JSON schema form.
 // It *only* handles types allowed by the kubernetes API standards. Floats are not
 // allowed unless allowDangerousTypes is true
-func builtinToType(basic *types.Basic, allowDangerousTypes bool) (typ string, format string, err error) {
+func builtinToType(basic *types.Basic, allowDangerousTypes bool) (typ string, err error) {
 	// NB(directxman12): formats from OpenAPI v3 are slightly different than those defined
 	// in JSONSchema.  This'll use the OpenAPI v3 ones, since they're useful for bounding our
 	// non-string types.
@@ -570,20 +568,13 @@ func builtinToType(basic *types.Basic, allowDangerousTypes bool) (typ string, fo
 		if allowDangerousTypes {
 			typ = "number"
 		} else {
-			return "", "", errors.New("found float, the usage of which is highly discouraged, as support for them varies across languages. Please consider serializing your float as string instead. If you are really sure you want to use them, re-run with crd:allowDangerousTypes=true")
+			return "", errors.New("found float, the usage of which is highly discouraged, as support for them varies across languages. Please consider serializing your float as string instead. If you are really sure you want to use them, re-run with crd:allowDangerousTypes=true")
 		}
 	default:
-		return "", "", fmt.Errorf("unsupported type %q", basic.String())
+		return "", fmt.Errorf("unsupported type %q", basic.String())
 	}
 
-	switch basic.Kind() {
-	case types.Int32, types.Uint32:
-		format = "int32"
-	case types.Int64, types.Uint64:
-		format = "int64"
-	}
-
-	return typ, format, nil
+	return typ, nil
 }
 
 // Open coded go/types representation of encoding/json.Marshaller

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -217,7 +217,6 @@ spec:
                 description: |-
                   The number of failed finished jobs to retain.
                   This is a pointer to distinguish between explicit zero and not specified.
-                format: int32
                 type: integer
               float64WithValidations:
                 maximum: 1.5
@@ -263,7 +262,6 @@ spec:
                 type: array
                 x-kubernetes-list-type: set
               int32WithValidations:
-                format: int32
                 maximum: 2
                 minimum: -2
                 multipleOf: 2
@@ -320,13 +318,11 @@ spec:
                           must be positive integer. If a Job is suspended (at creation or through an
                           update), this timer will effectively be stopped and reset when the Job is
                           resumed again.
-                        format: int64
                         type: integer
                       backoffLimit:
                         description: |-
                           Specifies the number of retries before marking this job failed.
                           Defaults to 6
-                        format: int32
                         type: integer
                       backoffLimitPerIndex:
                         description: |-
@@ -338,7 +334,6 @@ spec:
                           policy is Never. The field is immutable.
                           This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
                           feature gate is enabled (enabled by default).
-                        format: int32
                         type: integer
                       completionMode:
                         description: |-
@@ -373,7 +368,6 @@ spec:
                           value.  Setting to 1 means that parallelism is limited to 1 and the success of that
                           pod signals the success of the job.
                           More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-                        format: int32
                         type: integer
                       managedBy:
                         description: |-
@@ -415,7 +409,6 @@ spec:
                           less than or equal to 10^4 when is completions greater than 10^5.
                           This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
                           feature gate is enabled (enabled by default).
-                        format: int32
                         type: integer
                       parallelism:
                         description: |-
@@ -424,7 +417,6 @@ spec:
                           be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
                           i.e. when the work left to do is less than max parallelism.
                           More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
-                        format: int32
                         type: integer
                       podFailurePolicy:
                         description: |-
@@ -500,7 +492,6 @@ spec:
                                         and must not contain duplicates. Value '0' cannot be used for the In operator.
                                         At least one element is required. At most 255 elements are allowed.
                                       items:
-                                        format: int32
                                         type: integer
                                       type: array
                                       x-kubernetes-list-type: set
@@ -641,7 +632,6 @@ spec:
                                     When this field is null, this doesn't default to any value and
                                     is never evaluated at any time.
                                     When specified it needs to be a positive integer.
-                                  format: int32
                                   type: integer
                                 succeededIndexes:
                                   description: |-
@@ -695,7 +685,6 @@ spec:
                                   Optional duration in seconds the pod may be active on the node relative to
                                   StartTime before the system will actively try to mark it failed and kill associated containers.
                                   Value must be a positive integer.
-                                format: int64
                                 type: integer
                               affinity:
                                 description: If specified, the pod's scheduling constraints
@@ -800,7 +789,6 @@ spec:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
                                                 in the range 1-100.
-                                              format: int32
                                               type: integer
                                           required:
                                           - preference
@@ -1090,7 +1078,6 @@ spec:
                                               description: |-
                                                 weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
-                                              format: int32
                                               type: integer
                                           required:
                                           - podAffinityTerm
@@ -1459,7 +1446,6 @@ spec:
                                               description: |-
                                                 weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
-                                              format: int32
                                               type: integer
                                           required:
                                           - podAffinityTerm
@@ -1980,7 +1966,6 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
-                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -2099,7 +2084,6 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
-                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -2156,7 +2140,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -2166,7 +2149,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -2237,19 +2219,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -2283,14 +2262,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     name:
@@ -2316,7 +2293,6 @@ spec:
                                             description: |-
                                               Number of port to expose on the pod's IP address.
                                               This must be a valid port number, 0 < x < 65536.
-                                            format: int32
                                             type: integer
                                           hostIP:
                                             description: What host IP to bind the
@@ -2328,7 +2304,6 @@ spec:
                                               If specified, this must be a valid port number, 0 < x < 65536.
                                               If HostNetwork is specified, this must match ContainerPort.
                                               Most containers do not need this.
-                                            format: int32
                                             type: integer
                                           name:
                                             description: |-
@@ -2377,7 +2352,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -2387,7 +2361,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -2458,19 +2431,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -2504,14 +2474,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     resizePolicy:
@@ -2709,7 +2677,6 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          format: int64
                                           type: integer
                                         runAsNonRoot:
                                           description: |-
@@ -2727,7 +2694,6 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          format: int64
                                           type: integer
                                         seLinuxOptions:
                                           description: |-
@@ -2844,7 +2810,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -2854,7 +2819,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -2925,19 +2889,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -2971,14 +2932,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     stdin:
@@ -3524,7 +3483,6 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
-                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -3643,7 +3601,6 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
-                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -3697,7 +3654,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -3707,7 +3663,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -3778,19 +3733,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -3824,14 +3776,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     name:
@@ -3850,7 +3800,6 @@ spec:
                                             description: |-
                                               Number of port to expose on the pod's IP address.
                                               This must be a valid port number, 0 < x < 65536.
-                                            format: int32
                                             type: integer
                                           hostIP:
                                             description: What host IP to bind the
@@ -3862,7 +3811,6 @@ spec:
                                               If specified, this must be a valid port number, 0 < x < 65536.
                                               If HostNetwork is specified, this must match ContainerPort.
                                               Most containers do not need this.
-                                            format: int32
                                             type: integer
                                           name:
                                             description: |-
@@ -3908,7 +3856,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -3918,7 +3865,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -3989,19 +3935,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -4035,14 +3978,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     resizePolicy:
@@ -4227,7 +4168,6 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          format: int64
                                           type: integer
                                         runAsNonRoot:
                                           description: |-
@@ -4245,7 +4185,6 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          format: int64
                                           type: integer
                                         seLinuxOptions:
                                           description: |-
@@ -4356,7 +4295,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -4366,7 +4304,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -4437,19 +4374,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -4483,14 +4417,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     stdin:
@@ -5075,7 +5007,6 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
-                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -5194,7 +5125,6 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
-                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -5251,7 +5181,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -5261,7 +5190,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -5332,19 +5260,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -5378,14 +5303,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     name:
@@ -5411,7 +5334,6 @@ spec:
                                             description: |-
                                               Number of port to expose on the pod's IP address.
                                               This must be a valid port number, 0 < x < 65536.
-                                            format: int32
                                             type: integer
                                           hostIP:
                                             description: What host IP to bind the
@@ -5423,7 +5345,6 @@ spec:
                                               If specified, this must be a valid port number, 0 < x < 65536.
                                               If HostNetwork is specified, this must match ContainerPort.
                                               Most containers do not need this.
-                                            format: int32
                                             type: integer
                                           name:
                                             description: |-
@@ -5472,7 +5393,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -5482,7 +5402,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -5553,19 +5472,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -5599,14 +5515,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     resizePolicy:
@@ -5804,7 +5718,6 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          format: int64
                                           type: integer
                                         runAsNonRoot:
                                           description: |-
@@ -5822,7 +5735,6 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
-                                          format: int64
                                           type: integer
                                         seLinuxOptions:
                                           description: |-
@@ -5939,7 +5851,6 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -5949,7 +5860,6 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
-                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -6020,19 +5930,16 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
-                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -6066,14 +5973,12 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
-                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
-                                          format: int32
                                           type: integer
                                       type: object
                                     stdin:
@@ -6315,7 +6220,6 @@ spec:
                                   prevents users from setting this field. The admission controller populates
                                   this field from PriorityClassName.
                                   The higher the value, the higher the priority.
-                                format: int32
                                 type: integer
                               priorityClassName:
                                 description: |-
@@ -6487,7 +6391,6 @@ spec:
 
                                       If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                       Note that this field cannot be set when spec.os.name is windows.
-                                    format: int64
                                     type: integer
                                   fsGroupChangePolicy:
                                     description: |-
@@ -6507,7 +6410,6 @@ spec:
                                       PodSecurityContext, the value specified in SecurityContext takes precedence
                                       for that container.
                                       Note that this field cannot be set when spec.os.name is windows.
-                                    format: int64
                                     type: integer
                                   runAsNonRoot:
                                     description: |-
@@ -6526,7 +6428,6 @@ spec:
                                       PodSecurityContext, the value specified in SecurityContext takes precedence
                                       for that container.
                                       Note that this field cannot be set when spec.os.name is windows.
-                                    format: int64
                                     type: integer
                                   seLinuxOptions:
                                     description: |-
@@ -6590,7 +6491,6 @@ spec:
                                       supplementalGroupsPolicy field.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     items:
-                                      format: int64
                                       type: integer
                                     type: array
                                     x-kubernetes-list-type: atomic
@@ -6697,7 +6597,6 @@ spec:
                                   a termination signal and the time when the processes are forcibly halted with a kill signal.
                                   Set this value longer than the expected cleanup time for your process.
                                   Defaults to 30 seconds.
-                                format: int64
                                 type: integer
                               tolerations:
                                 description: If specified, the pod's tolerations.
@@ -6729,7 +6628,6 @@ spec:
                                         of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                         it is not set, which means tolerate the taint forever (do not evict). Zero and
                                         negative values will be treated as 0 (evict immediately) by the system.
-                                      format: int64
                                       type: integer
                                     value:
                                       description: |-
@@ -6833,7 +6731,6 @@ spec:
                                         When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
                                         to topologies that satisfy it.
                                         It's a required field. Default value is 1 and 0 is not allowed.
-                                      format: int32
                                       type: integer
                                     minDomains:
                                       description: |-
@@ -6856,7 +6753,6 @@ spec:
                                         In this situation, new pod with the same labelSelector cannot be scheduled,
                                         because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
                                         it will violate MaxSkew.
-                                      format: int32
                                       type: integer
                                     nodeAffinityPolicy:
                                       description: |-
@@ -6951,7 +6847,6 @@ spec:
                                             If omitted, the default is to mount by volume name.
                                             Examples: For volume /dev/sda1, you specify the partition as "1".
                                             Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-                                          format: int32
                                           type: integer
                                         readOnly:
                                           description: |-
@@ -7137,7 +7032,6 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
-                                          format: int32
                                           type: integer
                                         items:
                                           description: |-
@@ -7163,7 +7057,6 @@ spec:
                                                   If not specified, the volume defaultMode will be used.
                                                   This might be in conflict with other options that affect the file
                                                   mode, like fsGroup, and the result can be other mode bits set.
-                                                format: int32
                                                 type: integer
                                               path:
                                                 description: |-
@@ -7258,7 +7151,6 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
-                                          format: int32
                                           type: integer
                                         items:
                                           description: Items is a list of downward
@@ -7296,7 +7188,6 @@ spec:
                                                   If not specified, the volume defaultMode will be used.
                                                   This might be in conflict with other options that affect the file
                                                   mode, like fsGroup, and the result can be other mode bits set.
-                                                format: int32
                                                 type: integer
                                               path:
                                                 description: 'Required: Path is  the
@@ -7651,7 +7542,6 @@ spec:
                                         lun:
                                           description: 'lun is Optional: FC target
                                             lun number'
-                                          format: int32
                                           type: integer
                                         readOnly:
                                           description: |-
@@ -7759,7 +7649,6 @@ spec:
                                             Examples: For volume /dev/sda1, you specify the partition as "1".
                                             Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                          format: int32
                                           type: integer
                                         pdName:
                                           description: |-
@@ -7922,7 +7811,6 @@ spec:
                                         lun:
                                           description: lun represents iSCSI Target
                                             Lun number.
-                                          format: int32
                                           type: integer
                                         portals:
                                           description: |-
@@ -8066,7 +7954,6 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
-                                          format: int32
                                           type: integer
                                         sources:
                                           description: |-
@@ -8203,7 +8090,6 @@ spec:
                                                             If not specified, the volume defaultMode will be used.
                                                             This might be in conflict with other options that affect the file
                                                             mode, like fsGroup, and the result can be other mode bits set.
-                                                          format: int32
                                                           type: integer
                                                         path:
                                                           description: |-
@@ -8279,7 +8165,6 @@ spec:
                                                             If not specified, the volume defaultMode will be used.
                                                             This might be in conflict with other options that affect the file
                                                             mode, like fsGroup, and the result can be other mode bits set.
-                                                          format: int32
                                                           type: integer
                                                         path:
                                                           description: 'Required:
@@ -8357,7 +8242,6 @@ spec:
                                                             If not specified, the volume defaultMode will be used.
                                                             This might be in conflict with other options that affect the file
                                                             mode, like fsGroup, and the result can be other mode bits set.
-                                                          format: int32
                                                           type: integer
                                                         path:
                                                           description: |-
@@ -8408,7 +8292,6 @@ spec:
                                                       start trying to rotate the token if the token is older than 80 percent of
                                                       its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                                       and must be at least 10 minutes.
-                                                    format: int64
                                                     type: integer
                                                   path:
                                                     description: |-
@@ -8621,7 +8504,6 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
-                                          format: int32
                                           type: integer
                                         items:
                                           description: |-
@@ -8647,7 +8529,6 @@ spec:
                                                   If not specified, the volume defaultMode will be used.
                                                   This might be in conflict with other options that affect the file
                                                   mode, like fsGroup, and the result can be other mode bits set.
-                                                format: int32
                                                 type: integer
                                               path:
                                                 description: |-
@@ -8767,7 +8648,6 @@ spec:
                           guarantees (e.g. finalizers) will be honored. If this field is unset,
                           the Job won't be automatically deleted. If this field is set to zero,
                           the Job becomes eligible to be deleted immediately after it finishes.
-                        format: int32
                         type: integer
                     required:
                     - template
@@ -8974,7 +8854,6 @@ spec:
               onlyAllowSettingOnUpdate:
                 description: Test that we can add a field that can only be set to
                   a non-default value on updates using XValidation OptionalOldSelf.
-                format: int32
                 type: integer
                 x-kubernetes-validations:
                 - message: must be set to 0 on creation. can be set to any value on
@@ -9009,7 +8888,6 @@ spec:
                 description: |-
                   Optional deadline in seconds for starting the job if it misses scheduled
                   time for any reason.  Missed jobs executions will be counted as failed ones.
-                format: int64
                 type: integer
               stringAlias:
                 description: This tests that string alias is handled correctly.
@@ -9083,7 +8961,6 @@ spec:
                 description: |-
                   The number of successful finished jobs to retain.
                   This is a pointer to distinguish between explicit zero and not specified.
-                format: int32
                 type: integer
               suspend:
                 description: |-
@@ -9233,7 +9110,6 @@ spec:
                       A Duration represents the elapsed time between two instants
                       as an int64 nanosecond count. The representation limits the
                       largest representable duration to approximately 290 years.
-                    format: int64
                     type: integer
                 required:
                 - value
@@ -9304,7 +9180,6 @@ spec:
             description: CronJobSpec defines the desired state of CronJob
             properties:
               int32WithValidations:
-                format: int32
                 maximum: 2
                 minimum: -2
                 multipleOf: 2

--- a/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
@@ -41,7 +41,6 @@ spec:
             properties:
               count:
                 description: Count is the number of times a job may be executed.
-                format: int32
                 maximum: 10
                 minimum: 0
                 type: integer
@@ -49,7 +48,6 @@ spec:
                 description: CronJob is the spec for the related CrongJob.
                 properties:
                   int32WithValidations:
-                    format: int32
                     maximum: 2
                     minimum: -2
                     multipleOf: 2


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
