### PR TITLE
🐛 Revert "Stop setting invalid formats int32/int64 for integer types"

### DIFF
--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -217,6 +217,7 @@ spec:
                 description: |-
                   The number of failed finished jobs to retain.
                   This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
                 type: integer
               float64WithValidations:
                 maximum: 1.5
@@ -262,6 +263,7 @@ spec:
                 type: array
                 x-kubernetes-list-type: set
               int32WithValidations:
+                format: int32
                 maximum: 2
                 minimum: -2
                 multipleOf: 2
@@ -318,11 +320,13 @@ spec:
                           must be positive integer. If a Job is suspended (at creation or through an
                           update), this timer will effectively be stopped and reset when the Job is
                           resumed again.
+                        format: int64
                         type: integer
                       backoffLimit:
                         description: |-
                           Specifies the number of retries before marking this job failed.
                           Defaults to 6
+                        format: int32
                         type: integer
                       backoffLimitPerIndex:
                         description: |-
@@ -334,6 +338,7 @@ spec:
                           policy is Never. The field is immutable.
                           This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
                           feature gate is enabled (enabled by default).
+                        format: int32
                         type: integer
                       completionMode:
                         description: |-
@@ -368,6 +373,7 @@ spec:
                           value.  Setting to 1 means that parallelism is limited to 1 and the success of that
                           pod signals the success of the job.
                           More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        format: int32
                         type: integer
                       managedBy:
                         description: |-
@@ -409,6 +415,7 @@ spec:
                           less than or equal to 10^4 when is completions greater than 10^5.
                           This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
                           feature gate is enabled (enabled by default).
+                        format: int32
                         type: integer
                       parallelism:
                         description: |-
@@ -417,6 +424,7 @@ spec:
                           be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
                           i.e. when the work left to do is less than max parallelism.
                           More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        format: int32
                         type: integer
                       podFailurePolicy:
                         description: |-
@@ -492,6 +500,7 @@ spec:
                                         and must not contain duplicates. Value '0' cannot be used for the In operator.
                                         At least one element is required. At most 255 elements are allowed.
                                       items:
+                                        format: int32
                                         type: integer
                                       type: array
                                       x-kubernetes-list-type: set
@@ -632,6 +641,7 @@ spec:
                                     When this field is null, this doesn't default to any value and
                                     is never evaluated at any time.
                                     When specified it needs to be a positive integer.
+                                  format: int32
                                   type: integer
                                 succeededIndexes:
                                   description: |-
@@ -685,6 +695,7 @@ spec:
                                   Optional duration in seconds the pod may be active on the node relative to
                                   StartTime before the system will actively try to mark it failed and kill associated containers.
                                   Value must be a positive integer.
+                                format: int64
                                 type: integer
                               affinity:
                                 description: If specified, the pod's scheduling constraints
@@ -789,6 +800,7 @@ spec:
                                               description: Weight associated with
                                                 matching the corresponding nodeSelectorTerm,
                                                 in the range 1-100.
+                                              format: int32
                                               type: integer
                                           required:
                                           - preference
@@ -1078,6 +1090,7 @@ spec:
                                               description: |-
                                                 weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
+                                              format: int32
                                               type: integer
                                           required:
                                           - podAffinityTerm
@@ -1446,6 +1459,7 @@ spec:
                                               description: |-
                                                 weight associated with matching the corresponding podAffinityTerm,
                                                 in the range 1-100.
+                                              format: int32
                                               type: integer
                                           required:
                                           - podAffinityTerm
@@ -1966,6 +1980,7 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
+                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -2084,6 +2099,7 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
+                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -2140,6 +2156,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -2149,6 +2166,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -2219,16 +2237,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -2262,12 +2283,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     name:
@@ -2293,6 +2316,7 @@ spec:
                                             description: |-
                                               Number of port to expose on the pod's IP address.
                                               This must be a valid port number, 0 < x < 65536.
+                                            format: int32
                                             type: integer
                                           hostIP:
                                             description: What host IP to bind the
@@ -2304,6 +2328,7 @@ spec:
                                               If specified, this must be a valid port number, 0 < x < 65536.
                                               If HostNetwork is specified, this must match ContainerPort.
                                               Most containers do not need this.
+                                            format: int32
                                             type: integer
                                           name:
                                             description: |-
@@ -2352,6 +2377,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -2361,6 +2387,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -2431,16 +2458,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -2474,12 +2504,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     resizePolicy:
@@ -2677,6 +2709,7 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
                                           type: integer
                                         runAsNonRoot:
                                           description: |-
@@ -2694,6 +2727,7 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
                                           type: integer
                                         seLinuxOptions:
                                           description: |-
@@ -2810,6 +2844,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -2819,6 +2854,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -2889,16 +2925,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -2932,12 +2971,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     stdin:
@@ -3483,6 +3524,7 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
+                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -3601,6 +3643,7 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
+                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -3654,6 +3697,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -3663,6 +3707,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -3733,16 +3778,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -3776,12 +3824,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     name:
@@ -3800,6 +3850,7 @@ spec:
                                             description: |-
                                               Number of port to expose on the pod's IP address.
                                               This must be a valid port number, 0 < x < 65536.
+                                            format: int32
                                             type: integer
                                           hostIP:
                                             description: What host IP to bind the
@@ -3811,6 +3862,7 @@ spec:
                                               If specified, this must be a valid port number, 0 < x < 65536.
                                               If HostNetwork is specified, this must match ContainerPort.
                                               Most containers do not need this.
+                                            format: int32
                                             type: integer
                                           name:
                                             description: |-
@@ -3856,6 +3908,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -3865,6 +3918,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -3935,16 +3989,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -3978,12 +4035,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     resizePolicy:
@@ -4168,6 +4227,7 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
                                           type: integer
                                         runAsNonRoot:
                                           description: |-
@@ -4185,6 +4245,7 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
                                           type: integer
                                         seLinuxOptions:
                                           description: |-
@@ -4295,6 +4356,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -4304,6 +4366,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -4374,16 +4437,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -4417,12 +4483,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     stdin:
@@ -5007,6 +5075,7 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
+                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -5125,6 +5194,7 @@ spec:
                                                 seconds:
                                                   description: Seconds is the number
                                                     of seconds to sleep.
+                                                  format: int64
                                                   type: integer
                                               required:
                                               - seconds
@@ -5181,6 +5251,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -5190,6 +5261,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -5260,16 +5332,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -5303,12 +5378,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     name:
@@ -5334,6 +5411,7 @@ spec:
                                             description: |-
                                               Number of port to expose on the pod's IP address.
                                               This must be a valid port number, 0 < x < 65536.
+                                            format: int32
                                             type: integer
                                           hostIP:
                                             description: What host IP to bind the
@@ -5345,6 +5423,7 @@ spec:
                                               If specified, this must be a valid port number, 0 < x < 65536.
                                               If HostNetwork is specified, this must match ContainerPort.
                                               Most containers do not need this.
+                                            format: int32
                                             type: integer
                                           name:
                                             description: |-
@@ -5393,6 +5472,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -5402,6 +5482,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -5472,16 +5553,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -5515,12 +5599,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     resizePolicy:
@@ -5718,6 +5804,7 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
                                           type: integer
                                         runAsNonRoot:
                                           description: |-
@@ -5735,6 +5822,7 @@ spec:
                                             May also be set in PodSecurityContext.  If set in both SecurityContext and
                                             PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
                                           type: integer
                                         seLinuxOptions:
                                           description: |-
@@ -5851,6 +5939,7 @@ spec:
                                           description: |-
                                             Minimum consecutive failures for the probe to be considered failed after having succeeded.
                                             Defaults to 3. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         grpc:
                                           description: GRPC specifies an action involving
@@ -5860,6 +5949,7 @@ spec:
                                               description: Port number of the gRPC
                                                 service. Number must be in the range
                                                 1 to 65535.
+                                              format: int32
                                               type: integer
                                             service:
                                               default: ""
@@ -5930,16 +6020,19 @@ spec:
                                           description: |-
                                             Number of seconds after the container has started before liveness probes are initiated.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                         periodSeconds:
                                           description: |-
                                             How often (in seconds) to perform the probe.
                                             Default to 10 seconds. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         successThreshold:
                                           description: |-
                                             Minimum consecutive successes for the probe to be considered successful after having failed.
                                             Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
                                           type: integer
                                         tcpSocket:
                                           description: TCPSocket specifies an action
@@ -5973,12 +6066,14 @@ spec:
                                             the kill signal (no opportunity to shut down).
                                             This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
                                             Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
                                           type: integer
                                         timeoutSeconds:
                                           description: |-
                                             Number of seconds after which the probe times out.
                                             Defaults to 1 second. Minimum value is 1.
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
                                           type: integer
                                       type: object
                                     stdin:
@@ -6220,6 +6315,7 @@ spec:
                                   prevents users from setting this field. The admission controller populates
                                   this field from PriorityClassName.
                                   The higher the value, the higher the priority.
+                                format: int32
                                 type: integer
                               priorityClassName:
                                 description: |-
@@ -6391,6 +6487,7 @@ spec:
 
                                       If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                       Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
                                     type: integer
                                   fsGroupChangePolicy:
                                     description: |-
@@ -6410,6 +6507,7 @@ spec:
                                       PodSecurityContext, the value specified in SecurityContext takes precedence
                                       for that container.
                                       Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
                                     type: integer
                                   runAsNonRoot:
                                     description: |-
@@ -6428,6 +6526,7 @@ spec:
                                       PodSecurityContext, the value specified in SecurityContext takes precedence
                                       for that container.
                                       Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
                                     type: integer
                                   seLinuxOptions:
                                     description: |-
@@ -6491,6 +6590,7 @@ spec:
                                       supplementalGroupsPolicy field.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     items:
+                                      format: int64
                                       type: integer
                                     type: array
                                     x-kubernetes-list-type: atomic
@@ -6597,6 +6697,7 @@ spec:
                                   a termination signal and the time when the processes are forcibly halted with a kill signal.
                                   Set this value longer than the expected cleanup time for your process.
                                   Defaults to 30 seconds.
+                                format: int64
                                 type: integer
                               tolerations:
                                 description: If specified, the pod's tolerations.
@@ -6628,6 +6729,7 @@ spec:
                                         of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
                                         it is not set, which means tolerate the taint forever (do not evict). Zero and
                                         negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
                                       type: integer
                                     value:
                                       description: |-
@@ -6731,6 +6833,7 @@ spec:
                                         When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
                                         to topologies that satisfy it.
                                         It's a required field. Default value is 1 and 0 is not allowed.
+                                      format: int32
                                       type: integer
                                     minDomains:
                                       description: |-
@@ -6753,6 +6856,7 @@ spec:
                                         In this situation, new pod with the same labelSelector cannot be scheduled,
                                         because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
                                         it will violate MaxSkew.
+                                      format: int32
                                       type: integer
                                     nodeAffinityPolicy:
                                       description: |-
@@ -6847,6 +6951,7 @@ spec:
                                             If omitted, the default is to mount by volume name.
                                             Examples: For volume /dev/sda1, you specify the partition as "1".
                                             Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          format: int32
                                           type: integer
                                         readOnly:
                                           description: |-
@@ -7032,6 +7137,7 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
                                           type: integer
                                         items:
                                           description: |-
@@ -7057,6 +7163,7 @@ spec:
                                                   If not specified, the volume defaultMode will be used.
                                                   This might be in conflict with other options that affect the file
                                                   mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
                                                 type: integer
                                               path:
                                                 description: |-
@@ -7151,6 +7258,7 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
                                           type: integer
                                         items:
                                           description: Items is a list of downward
@@ -7188,6 +7296,7 @@ spec:
                                                   If not specified, the volume defaultMode will be used.
                                                   This might be in conflict with other options that affect the file
                                                   mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
                                                 type: integer
                                               path:
                                                 description: 'Required: Path is  the
@@ -7542,6 +7651,7 @@ spec:
                                         lun:
                                           description: 'lun is Optional: FC target
                                             lun number'
+                                          format: int32
                                           type: integer
                                         readOnly:
                                           description: |-
@@ -7649,6 +7759,7 @@ spec:
                                             Examples: For volume /dev/sda1, you specify the partition as "1".
                                             Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          format: int32
                                           type: integer
                                         pdName:
                                           description: |-
@@ -7811,6 +7922,7 @@ spec:
                                         lun:
                                           description: lun represents iSCSI Target
                                             Lun number.
+                                          format: int32
                                           type: integer
                                         portals:
                                           description: |-
@@ -7954,6 +8066,7 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
                                           type: integer
                                         sources:
                                           description: |-
@@ -8090,6 +8203,7 @@ spec:
                                                             If not specified, the volume defaultMode will be used.
                                                             This might be in conflict with other options that affect the file
                                                             mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
                                                           type: integer
                                                         path:
                                                           description: |-
@@ -8165,6 +8279,7 @@ spec:
                                                             If not specified, the volume defaultMode will be used.
                                                             This might be in conflict with other options that affect the file
                                                             mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
                                                           type: integer
                                                         path:
                                                           description: 'Required:
@@ -8242,6 +8357,7 @@ spec:
                                                             If not specified, the volume defaultMode will be used.
                                                             This might be in conflict with other options that affect the file
                                                             mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
                                                           type: integer
                                                         path:
                                                           description: |-
@@ -8292,6 +8408,7 @@ spec:
                                                       start trying to rotate the token if the token is older than 80 percent of
                                                       its time to live or if the token is older than 24 hours.Defaults to 1 hour
                                                       and must be at least 10 minutes.
+                                                    format: int64
                                                     type: integer
                                                   path:
                                                     description: |-
@@ -8504,6 +8621,7 @@ spec:
                                             Directories within the path are not affected by this setting.
                                             This might be in conflict with other options that affect the file
                                             mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
                                           type: integer
                                         items:
                                           description: |-
@@ -8529,6 +8647,7 @@ spec:
                                                   If not specified, the volume defaultMode will be used.
                                                   This might be in conflict with other options that affect the file
                                                   mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
                                                 type: integer
                                               path:
                                                 description: |-
@@ -8648,6 +8767,7 @@ spec:
                           guarantees (e.g. finalizers) will be honored. If this field is unset,
                           the Job won't be automatically deleted. If this field is set to zero,
                           the Job becomes eligible to be deleted immediately after it finishes.
+                        format: int32
                         type: integer
                     required:
                     - template
@@ -8854,6 +8974,7 @@ spec:
               onlyAllowSettingOnUpdate:
                 description: Test that we can add a field that can only be set to
                   a non-default value on updates using XValidation OptionalOldSelf.
+                format: int32
                 type: integer
                 x-kubernetes-validations:
                 - message: must be set to 0 on creation. can be set to any value on
@@ -8888,6 +9009,7 @@ spec:
                 description: |-
                   Optional deadline in seconds for starting the job if it misses scheduled
                   time for any reason.  Missed jobs executions will be counted as failed ones.
+                format: int64
                 type: integer
               stringAlias:
                 description: This tests that string alias is handled correctly.
@@ -8961,6 +9083,7 @@ spec:
                 description: |-
                   The number of successful finished jobs to retain.
                   This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
                 type: integer
               suspend:
                 description: |-
@@ -9110,6 +9233,7 @@ spec:
                       A Duration represents the elapsed time between two instants
                       as an int64 nanosecond count. The representation limits the
                       largest representable duration to approximately 290 years.
+                    format: int64
                     type: integer
                 required:
                 - value
@@ -9180,6 +9304,7 @@ spec:
             description: CronJobSpec defines the desired state of CronJob
             properties:
               int32WithValidations:
+                format: int32
                 maximum: 2
                 minimum: -2
                 multipleOf: 2

--- a/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_jobs.yaml
@@ -41,6 +41,7 @@ spec:
             properties:
               count:
                 description: Count is the number of times a job may be executed.
+                format: int32
                 maximum: 10
                 minimum: 0
                 type: integer
@@ -48,6 +49,7 @@ spec:
                 description: CronJob is the spec for the related CrongJob.
                 properties:
                   int32WithValidations:
+                    format: int32
                     maximum: 2
                     minimum: -2
                     multipleOf: 2


### PR DESCRIPTION
This reverts commit 02ea9af67be0303d83147446e7386cbe98c10e08.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
The v1.34.0 kube-apiserver returns `"unrecognized format \"int64\""` warnings. We initially thought this was intended and adjusted controller-gen accordingly (https://github.com/kubernetes-sigs/controller-tools/pull/1274)

Turns out it was not (https://github.com/kubernetes/kubernetes/issues/133880), so now reverting the previous change.
