### PR TITLE
✨ Allow title to be set on a type

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -52,6 +52,9 @@ var ValidationMarkers = mustMakeAllWithPrefix(validationPrefix, markers.Describe
 	ExclusiveMaximum(false),
 	ExclusiveMinimum(false),
 	MultipleOf(0),
+
+	// object markers
+
 	MinProperties(0),
 	MaxProperties(0),
 
@@ -61,7 +64,7 @@ var ValidationMarkers = mustMakeAllWithPrefix(validationPrefix, markers.Describe
 	MinLength(0),
 	Pattern(""),
 
-	// slice markers
+	// array markers
 
 	MaxItems(0),
 	MinItems(0),
@@ -114,9 +117,6 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition(SchemalessName, markers.DescribesField, Schemaless{})).
 		WithHelp(Schemaless{}.Help()),
-
-	must(markers.MakeAnyTypeDefinition("kubebuilder:title", markers.DescribesField, Title{})).
-		WithHelp(Title{}.Help()),
 }
 
 // ValidationIshMarkers are field-and-type markers that don't fall under the
@@ -127,6 +127,11 @@ var ValidationIshMarkers = []*definitionWithHelp{
 		WithHelp(XPreserveUnknownFields{}.Help()),
 	must(markers.MakeDefinition("kubebuilder:pruning:PreserveUnknownFields", markers.DescribesType, XPreserveUnknownFields{})).
 		WithHelp(XPreserveUnknownFields{}.Help()),
+
+	must(markers.MakeAnyTypeDefinition("kubebuilder:title", markers.DescribesField, Title{})).
+		WithHelp(Title{}.Help()),
+	must(markers.MakeAnyTypeDefinition("kubebuilder:title", markers.DescribesType, Title{})).
+		WithHelp(Title{}.Help()),
 }
 
 func init() {

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -352,8 +352,13 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:MaxLength=255
 	StringAliasAddedValidation StringAlias `json:"stringAliasAddedValidation,omitempty"`
 
-	// This tests that validation on a the string alias type itself is handled correctly.
+	// This tests that validation on a string alias type itself is handled correctly.
 	StringAliasAlreadyValidated StringAliasWithValidation `json:"stringAliasAlreadyValidated,omitempty"`
+
+	// These test that title works on both a type and field, with field taking precedence.
+	// +kubebuilder:title="title on field"
+	StringAliasWithAddedTitle StringAliasWithTitle `json:"stringAliasWithAddedTitle,omitempty"`
+	StringAliasWithTitle      StringAliasWithTitle `json:"stringAliasWithTitle,omitempty"`
 
 	// This tests string slice validation.
 	// +kubebuilder:validation:MinItems=2
@@ -400,6 +405,9 @@ type EmbeddedStruct struct {
 }
 
 type StringAlias = string
+
+// +kubebuilder:title="title on type"
+type StringAliasWithTitle = string
 
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=255

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9021,12 +9021,20 @@ spec:
                 minLength: 1
                 type: string
               stringAliasAlreadyValidated:
-                description: This tests that validation on a the string alias type
-                  itself is handled correctly.
+                description: This tests that validation on a string alias type itself
+                  is handled correctly.
                 maxLength: 255
                 minLength: 1
                 type: string
               stringAliasPtr:
+                type: string
+              stringAliasWithAddedTitle:
+                description: These test that title works on both a type and field,
+                  with field taking precedence.
+                title: title on field
+                type: string
+              stringAliasWithTitle:
+                title: title on type
                 type: string
               stringPair:
                 description: This tests string slice validation.


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

We use types to reduce duplication and increase the consistency of our CRDs. This allows the `+kubebuilder:title` marker to be set on a type as well as a field.

```go
// +kubebuilder:title="Secret Name"
// +kubebuilder:validation:MinLength=1
// +kubebuilder:validation:MaxLength=253
type SecretName = string
```

Fixes: #883
See: #1175