### PR TITLE
🐛 Fix normalize {} to [] for slice defaults in CRDs

### DIFF
--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -122,6 +122,14 @@ type CronJobSpec struct {
 	// +kubebuilder:title=DefaultedSlice
 	DefaultedSlice []string `json:"defaultedSlice"`
 
+	// +kubebuilder:default:={"md0":{"gpus":{}}}
+	// Expect: default.md0.gpus == []
+	DefaultedNestedProfiles Profiles `json:"defaultedNestedProfiles,omitempty"`
+
+	// +kubebuilder:default:={"md0":{}}
+	// Expect: default.md0 == []
+	DefaultedNestedSliceMap map[string][]string `json:"defaultedNestedSliceMap,omitempty"`
+
 	// This tests that slice and object defaulting can be performed.
 	// +kubebuilder:default={{nested: {foo: "baz", bar: true}},{nested: {foo: "qux", bar: false}}}
 	// +kubebuilder:example={{nested: {foo: "baz", bar: true}},{nested: {foo: "qux", bar: false}}}
@@ -419,6 +427,15 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:MaxLength=10
 	FieldLevelLocalDeclarationOverride LongerString `json:"fieldLevelLocalDeclarationOverride,omitempty"`
 }
+
+// NodeProfile is used to verify nested array defaulting inside an object.
+// gpus is a slice; when default supplies {}, it must become [].
+type NodeProfile struct {
+	Gpus []string `json:"gpus,omitempty"`
+}
+
+// Profiles map verifies nested coercion under properties.
+type Profiles map[string]NodeProfile
 
 type InlineAlias = EmbeddedStruct
 

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -133,6 +133,31 @@ spec:
                   type: string
                 title: '{}'
                 type: array
+              defaultedNestedProfiles:
+                additionalProperties:
+                  description: |-
+                    NodeProfile is used to verify nested array defaulting inside an object.
+                    gpus is a slice; when default supplies {}, it must become [].
+                  properties:
+                    gpus:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                default:
+                  md0:
+                    gpus: []
+                description: 'Expect: default.md0.gpus == []'
+                type: object
+              defaultedNestedSliceMap:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                default:
+                  md0: []
+                description: 'Expect: default.md0 == []'
+                type: object
               defaultedObject:
                 default:
                 - nested:


### PR DESCRIPTION
**What this fixes**

Right now if you set a default with an inline object that contains a slice, and use {} as the value, the generator ends up treating it as an object instead of an empty list.

For example, if I use:

```go
// +kubebuilder:default:={"md0":{"ephemeralStorage":"20Gi","gpus":{},"instanceType":"u1.medium","maxReplicas":10,"minReplicas":0,"resources":{},"roles":{"ingress-nginx"}}}
```

the generated CRD gives me:

```yaml
default:
  md0:
    ephemeralStorage: 20Gi
    gpus: {}
    instanceType: u1.medium
    maxReplicas: 10
    minReplicas: 0
    resources: {}
    roles:
    - ingress-nginx
```

but since gpus is a slice, what I actually want (and what users would expect) is:

```yaml
default:
  md0:
    ephemeralStorage: 20Gi
    gpus: []
    instanceType: u1.medium
    maxReplicas: 10
    minReplicas: 0
    resources: {}
    roles:
    - ingress-nginx
```


**What changed**
- Added a normalization step in ApplyToSchema that looks at the target schema type and coerces {} → [] when the field is an array (and vice versa for objects).
- This runs recursively, so nested defaults inside maps/objects are also fixed.
- Extended the testdata with cases for nested slices inside maps/objects to make sure the behavior is covered.

**Why**

It’s a small thing, but it avoids confusion when writing defaults for slices. Before this patch, the CRD schema would show gpus: {}, which is wrong and makes clients unhappy. Now it consistently produces [].