### PR TITLE
🐛  Prevent XValidation duplication by verifying if the rule already exists

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -666,14 +666,6 @@ func (m XValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 		}
 	}
 
-	// Check if this validation rule already exists to prevent duplication
-	for _, existingRule := range schema.XValidations {
-		if existingRule.Rule == m.Rule {
-			// Rule already exists, don't add it again
-			return nil
-		}
-	}
-
 	schema.XValidations = append(schema.XValidations, apiext.ValidationRule{
 		Rule:              m.Rule,
 		Message:           m.Message,

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -231,7 +231,7 @@ func typeToSchema(ctx *schemaContext, rawType ast.Expr) *apiext.JSONSchemaProps 
 	case *ast.MapType:
 		props = mapToSchema(ctx, expr)
 	case *ast.StarExpr:
-		props = typeToSchema(ctx, expr.X)
+		props = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), expr.X)
 	case *ast.StructType:
 		props = structToSchema(ctx, expr)
 	default:

--- a/pkg/crd/testdata/oneof/types.go
+++ b/pkg/crd/testdata/oneof/types.go
@@ -37,8 +37,10 @@ type OneofSpec struct {
 
 	TypeWithAllOneOf *TypeWithAllOneofs `json:"typeWithAllOneOf,omitempty"`
 
-	// The validation rule on TypeWithOneofs should not be duplicated.
-	SameTypeWithOneof *TypeWithOneofs `json:"sameTypeWithOneof,omitempty"`
+	FirstCustomTypeAlias CustomTypeAlias `json:"firstCustomTypeAlias,omitempty"`
+
+	// This verifies if the custom type alias XValidation is not duplicated.
+	SecondCustomTypeAlias CustomTypeAlias `json:"secondCustomTypeAlias,omitempty"`
 }
 
 // +kubebuilder:validation:XValidation:message="only one of foo|bar may be set",rule="!(has(self.foo) && has(self.bar))"
@@ -97,6 +99,10 @@ type TypeWithAllOneofs struct {
 	E *string `json:"e,omitempty"`
 	F *string `json:"f,omitempty"`
 }
+
+// CustomTypeAlias is a custom alias
+// +kubebuilder:validation:XValidation:rule="self >= 100 && self <= 1000",message="invalid CustomTypeAlias value"
+type CustomTypeAlias *int32
 
 // Oneof is the Schema for the Oneof API
 type Oneof struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
@@ -36,6 +36,13 @@ spec:
           spec:
             description: OneofSpec is the spec for the oneofs API.
             properties:
+              firstCustomTypeAlias:
+                description: CustomTypeAlias is a custom alias
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: invalid CustomTypeAlias value
+                  rule: self >= 100 && self <= 1000
               firstTypeWithExactOneof:
                 properties:
                   bar:
@@ -60,20 +67,14 @@ spec:
                 - message: at most one of the fields in [foo bar] may be set
                   rule: '[has(self.foo),has(self.bar)].filter(x,x==true).size() <=
                     1'
-              sameTypeWithOneof:
-                description: The validation rule on TypeWithOneofs should not be duplicated.
-                properties:
-                  bar:
-                    type: string
-                  foo:
-                    type: string
-                type: object
+              secondCustomTypeAlias:
+                description: This verifies if the custom type alias XValidation is
+                  not duplicated.
+                format: int32
+                type: integer
                 x-kubernetes-validations:
-                - message: only one of foo|bar may be set
-                  rule: '!(has(self.foo) && has(self.bar))'
-                - message: at most one of the fields in [foo bar] may be set
-                  rule: '[has(self.foo),has(self.bar)].filter(x,x==true).size() <=
-                    1'
+                - message: invalid CustomTypeAlias value
+                  rule: self >= 100 && self <= 1000
               secondTypeWithExactOneof:
                 properties:
                   a:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->

#### Analyse:

When defining a custom type and applying a cel expression on the type level,  and if you reuse the same type twice or more in the spec, the XValidation will be duplicated, which causes errors in patching the CRDs:

```
x-kubernetes-validations: duplicate entries for key [rule=
```

XValidation is always appended to the schema, without checking if the validation.rule already exists.


This PR adds:
 
* Verifies if `XValidation.Rule` already exists in the schema before appending it.
* Simple test case, Add another field with the same type that defines a cel expression.


Closes #1294 