### PR TITLE
✨ feat: Add optional roleName parameter to RBAC marker

### DIFF
--- a/pkg/rbac/testdata/controller.go
+++ b/pkg/rbac/testdata/controller.go
@@ -37,3 +37,10 @@ package controller
 // +kubebuilder:rbac:groups=core;"";some-other-to-deduplicate-with-core,resources=me,verbs=list;get
 // +kubebuilder:rbac:groups=deduplicate-groups5,resources=abc,verbs=get;update;patch;create,namespace=here
 // +kubebuilder:rbac:groups=deduplicate-groups5,resources=abc,verbs=*,namespace=here
+// Test custom roleName to avoid conflicts
+// +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-deployment-manager,resources=deployments,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",namespace=users,roleName=user-secrets-reader,resources=secrets,verbs=get;list;watch
+// Test multiple markers with same custom roleName in same namespace (should merge)
+// +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-deployment-manager,resources=statefulsets,verbs=get;list
+// Test backward compatibility - no roleName specified (uses default)
+// +kubebuilder:rbac:groups=monitoring,namespace=observability,resources=prometheuses,verbs=get;list

--- a/pkg/rbac/testdata/role.yaml
+++ b/pkg/rbac/testdata/role.yaml
@@ -145,6 +145,44 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: infra-deployment-manager
+  namespace: infrastructure
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-role
+  namespace: observability
+rules:
+- apiGroups:
+  - monitoring
+  resources:
+  - prometheuses
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: manager-role
   namespace: park
 rules:
@@ -154,6 +192,21 @@ rules:
   - jobs
   verbs:
   - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: user-secrets-reader
+  namespace: users
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -168,4 +221,3 @@ rules:
   - jobs
   verbs:
   - get
-


### PR DESCRIPTION
## Problem

When using namespace-scoped RBAC markers with different namespaces, controller-gen generates multiple Roles with identical names in different namespaces:

```yaml
# Generated from markers
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: manager-role  # ← Same name
  namespace: infrastructure
rules: [...]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: manager-role  # ← Same name
  namespace: users
rules: [...]
```

While this is valid Kubernetes, it causes **kustomize to fail** when applying a global namespace transformation:

```bash
Error: namespace transformation produces ID conflict: 
[{"kind":"Role","metadata":{"name":"manager-role","namespace":"myproject-system"}...}
 {"kind":"Role","metadata":{"name":"manager-role","namespace":"myproject-system"}...}]
```

Both Roles end up in the same namespace with identical names → conflict!

Reported in: kubernetes-sigs/kubebuilder#5148
Follow up from: #1329

## Solution

This PR adds an **optional `roleName` parameter** to the RBAC marker, allowing users to specify custom role names per marker:

```go
// +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-manager,resources=deployments,verbs=get;list
// +kubebuilder:rbac:groups="",namespace=users,roleName=user-secrets,resources=secrets,verbs=get
```

**Generated output:**

```yaml
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: infra-manager  # ← Unique name
  namespace: infrastructure
rules: [...]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: user-secrets  # ← Unique name
  namespace: users
rules: [...]
```

Now kustomize's namespace transformation succeeds:

```yaml
# After: namespace: myproject-system transform
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: infra-manager  # ← Different names
  namespace: myproject-system
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: user-secrets  # ← Different names
  namespace: myproject-system
```

✅ No conflicts!

## Key Features

### 1. **Non-breaking (100% backward compatible)**

If `roleName` is not specified, behavior is **identical** to current implementation:

```go
// Existing marker (no roleName specified)
// +kubebuilder:rbac:groups=apps,namespace=prod,resources=deployments,verbs=get

// Generated Role uses default from --roleName flag (same as before)
---
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: manager-role  # ← Uses default
  namespace: prod
```

### 2. **Opt-in when needed**

Only specify `roleName` when you need unique names:

```go
// Use custom name only where you need it
// +kubebuilder:rbac:groups=apps,namespace=infra,roleName=infra-mgr,resources=deployments,verbs=get
// +kubebuilder:rbac:groups=apps,namespace=prod,resources=deployments,verbs=get  // ← Uses default
```

### 3. **Marker merging still works**

Multiple markers with the same `roleName` in the same namespace are merged (as expected):

```go
// These merge into one Role named "infra-manager"
// +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-manager,resources=deployments,verbs=get;list
// +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-manager,resources=statefulsets,verbs=get;list
```

This PR addresses all the concerns while still solving the original problem.

## Testing

Added comprehensive tests in `pkg/rbac/testdata/`:

1. **Custom roleName**: Roles get specified names
2. **No roleName (backward compat)**: Roles use default name
3. **Marker merging**: Multiple markers with same roleName merge correctly
4. **Multiple namespaces**: Each namespace:roleName combination creates separate Role

All existing tests pass unchanged, confirming backward compatibility.

## Implementation Details

- Modified `Rule` struct to include optional `RoleName string` field
- Updated `GenerateRoles()` to group by `(namespace, roleName)` instead of just `namespace`
- Added helper documentation explaining the use case and conflict scenario
- Zero changes to CLI or default behavior

## Migration Path for Affected Users

Users currently hitting the kustomize conflict can add `roleName` to their markers:

**Before (conflicts):**
```go
// +kubebuilder:rbac:groups=apps,namespace=infrastructure,resources=deployments,verbs=get
// +kubebuilder:rbac:groups="",namespace=users,resources=secrets,verbs=get
```

**After (no conflicts):**
```go
// +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-mgr,resources=deployments,verbs=get
// +kubebuilder:rbac:groups="",namespace=users,roleName=user-secrets,resources=secrets,verbs=get
```

Run `make manifests`, commit the updated RBAC YAML, and deploy. No other changes needed.
