### PR TITLE
✨ feat(webhook): Add patch field for webhook customization

### DIFF
--- a/pkg/webhook/parser.go
+++ b/pkg/webhook/parser.go
@@ -23,6 +23,7 @@ limitations under the License.
 package webhook
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -200,6 +202,37 @@ type Config struct {
 	// The URL configuration should be between quotes.
 	// `url` cannot be specified when `path` is specified.
 	URL string `marker:"url,optional"`
+
+	// Patch applies a strategic merge patch to customize the generated webhook configuration.
+	//
+	// This allows you to set any webhook field that isn't directly exposed as a marker parameter,
+	// such as namespaceSelector, objectSelector, or matchConditions. The patch is a JSON object
+	// that follows Kubernetes strategic merge patch semantics and is applied to the webhook
+	// configuration after all other marker parameters are processed.
+	//
+	// Use backticks to avoid escaping quotes in the JSON.
+	//
+	// Common use cases:
+	// - Limit webhook scope to specific namespaces using namespaceSelector
+	// - Filter webhook invocations by object labels using objectSelector
+	// - Combine multiple customizations in a single patch
+	//
+	// Example (limit to labeled namespaces):
+	//
+	//	// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,...,patch=`{"namespaceSelector":{"matchLabels":{"webhook-enabled":"true"}}}`
+	//
+	// Example (filter by object labels with matchExpressions):
+	//
+	//	// +kubebuilder:webhook:path=/validate-v1-deployment,...,patch=`{"objectSelector":{"matchExpressions":[{"key":"tier","operator":"In","values":["frontend","backend"]}]}}`
+	//
+	// Example (combine namespace and object selectors):
+	//
+	//	// +kubebuilder:webhook:...,patch=`{"namespaceSelector":{"matchLabels":{"env":"production"}},"objectSelector":{"matchLabels":{"managed-by":"my-operator"}}}`
+	//
+	// Example (override timeout):
+	//
+	//	// +kubebuilder:webhook:...,patch=`{"timeoutSeconds":25}`
+	Patch string `marker:"patch,optional"`
 }
 
 // verbToAPIVariant converts a marker's verb to the proper value for the API.
@@ -219,6 +252,34 @@ func verbToAPIVariant(verbRaw string) admissionregv1.OperationType {
 	default:
 		return admissionregv1.OperationType(verbRaw)
 	}
+}
+
+// applyPatch applies a strategic merge patch to a webhook object.
+// The patch is provided as a JSON string and is applied using Kubernetes strategic merge patch logic.
+func applyPatch(webhook any, patchStr string) error {
+	patchStr = strings.TrimSpace(patchStr)
+	if patchStr == "" {
+		return nil
+	}
+
+	// Marshal the webhook to JSON
+	webhookJSON, err := json.Marshal(webhook)
+	if err != nil {
+		return fmt.Errorf("failed to marshal webhook: %w", err)
+	}
+
+	// Apply the strategic merge patch
+	patchedJSON, err := strategicpatch.StrategicMergePatch(webhookJSON, []byte(patchStr), webhook)
+	if err != nil {
+		return fmt.Errorf("failed to apply strategic merge patch: %w", err)
+	}
+
+	// Unmarshal back into the webhook
+	if err := json.Unmarshal(patchedJSON, webhook); err != nil {
+		return fmt.Errorf("failed to unmarshal patched webhook: %w", err)
+	}
+
+	return nil
 }
 
 // ToMutatingWebhookConfiguration converts this WebhookConfig to its Kubernetes API form.
@@ -263,7 +324,7 @@ func (c Config) ToMutatingWebhook() (admissionregv1.MutatingWebhook, error) {
 		return admissionregv1.MutatingWebhook{}, err
 	}
 
-	return admissionregv1.MutatingWebhook{
+	webhook := admissionregv1.MutatingWebhook{
 		Name:                    c.Name,
 		Rules:                   c.rules(),
 		FailurePolicy:           c.failurePolicy(),
@@ -273,7 +334,14 @@ func (c Config) ToMutatingWebhook() (admissionregv1.MutatingWebhook, error) {
 		TimeoutSeconds:          c.timeoutSeconds(),
 		AdmissionReviewVersions: c.AdmissionReviewVersions,
 		ReinvocationPolicy:      c.reinvocationPolicy(),
-	}, nil
+	}
+
+	// Apply strategic merge patch if provided
+	if err := applyPatch(&webhook, c.Patch); err != nil {
+		return admissionregv1.MutatingWebhook{}, fmt.Errorf("failed to apply patch: %w", err)
+	}
+
+	return webhook, nil
 }
 
 // ToValidatingWebhook converts this rule to its Kubernetes API form.
@@ -292,7 +360,7 @@ func (c Config) ToValidatingWebhook() (admissionregv1.ValidatingWebhook, error) 
 		return admissionregv1.ValidatingWebhook{}, err
 	}
 
-	return admissionregv1.ValidatingWebhook{
+	webhook := admissionregv1.ValidatingWebhook{
 		Name:                    c.Name,
 		Rules:                   c.rules(),
 		FailurePolicy:           c.failurePolicy(),
@@ -301,7 +369,14 @@ func (c Config) ToValidatingWebhook() (admissionregv1.ValidatingWebhook, error) 
 		SideEffects:             c.sideEffects(),
 		TimeoutSeconds:          c.timeoutSeconds(),
 		AdmissionReviewVersions: c.AdmissionReviewVersions,
-	}, nil
+	}
+
+	// Apply strategic merge patch if provided
+	if err := applyPatch(&webhook, c.Patch); err != nil {
+		return admissionregv1.ValidatingWebhook{}, fmt.Errorf("failed to apply patch: %w", err)
+	}
+
+	return webhook, nil
 }
 
 // rules returns the configuration of what operations on what

--- a/pkg/webhook/parser_integration_test.go
+++ b/pkg/webhook/parser_integration_test.go
@@ -526,6 +526,140 @@ var _ = Describe("Webhook Generation From Parsing to CustomResourceDefinition", 
 		Expect(err).To(HaveOccurred())
 	})
 
+	It("should properly generate webhook definition with namespaceSelector", func() {
+		By("switching into testdata to appease go modules")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Chdir("./testdata/valid-namespaceselector")).To(Succeed())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		By("loading the roots")
+		pkgs, err := loader.LoadRoots(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		By("setting up the parser")
+		reg := &markers.Registry{}
+		Expect(reg.Register(webhook.ConfigDefinition)).To(Succeed())
+		Expect(reg.Register(webhook.WebhookConfigDefinition)).To(Succeed())
+
+		By("requesting that the manifest be generated")
+		outputDir := GinkgoT().TempDir()
+		genCtx := &genall.GenerationContext{
+			Collector:  &markers.Collector{Registry: reg},
+			Roots:      pkgs,
+			OutputRule: genall.OutputToDirectory(outputDir),
+		}
+		Expect(webhook.Generator{}.Generate(genCtx)).To(Succeed())
+		for _, r := range genCtx.Roots {
+			Expect(r.Errors).To(HaveLen(0))
+		}
+
+		By("loading the generated v1 YAML")
+		actualFile, err := os.ReadFile(path.Join(outputDir, "manifests.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		actualManifest := &admissionregv1.ValidatingWebhookConfiguration{}
+		Expect(yaml.UnmarshalStrict(actualFile, actualManifest)).To(Succeed())
+
+		By("loading the desired v1 YAML")
+		expectedFile, err := os.ReadFile("manifests.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		expectedManifest := &admissionregv1.ValidatingWebhookConfiguration{}
+		Expect(yaml.UnmarshalStrict(expectedFile, expectedManifest)).To(Succeed())
+
+		By("comparing the two")
+		assertSame(actualManifest, expectedManifest)
+	})
+
+	It("should properly generate webhook definition with objectSelector", func() {
+		By("switching into testdata to appease go modules")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Chdir("./testdata/valid-objectselector")).To(Succeed())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		By("loading the roots")
+		pkgs, err := loader.LoadRoots(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		By("setting up the parser")
+		reg := &markers.Registry{}
+		Expect(reg.Register(webhook.ConfigDefinition)).To(Succeed())
+		Expect(reg.Register(webhook.WebhookConfigDefinition)).To(Succeed())
+
+		By("requesting that the manifest be generated")
+		outputDir := GinkgoT().TempDir()
+		genCtx := &genall.GenerationContext{
+			Collector:  &markers.Collector{Registry: reg},
+			Roots:      pkgs,
+			OutputRule: genall.OutputToDirectory(outputDir),
+		}
+		Expect(webhook.Generator{}.Generate(genCtx)).To(Succeed())
+		for _, r := range genCtx.Roots {
+			Expect(r.Errors).To(HaveLen(0))
+		}
+
+		By("loading the generated v1 YAML")
+		actualFile, err := os.ReadFile(path.Join(outputDir, "manifests.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		actualManifest := &admissionregv1.MutatingWebhookConfiguration{}
+		Expect(yaml.UnmarshalStrict(actualFile, actualManifest)).To(Succeed())
+
+		By("loading the desired v1 YAML")
+		expectedFile, err := os.ReadFile("manifests.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		expectedManifest := &admissionregv1.MutatingWebhookConfiguration{}
+		Expect(yaml.UnmarshalStrict(expectedFile, expectedManifest)).To(Succeed())
+
+		By("comparing the two")
+		assertSame(actualManifest, expectedManifest)
+	})
+
+	It("should properly generate webhook definition with matchExpressions in selectors", func() {
+		By("switching into testdata to appease go modules")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Chdir("./testdata/valid-selectors-matchexpressions")).To(Succeed())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		By("loading the roots")
+		pkgs, err := loader.LoadRoots(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		By("setting up the parser")
+		reg := &markers.Registry{}
+		Expect(reg.Register(webhook.ConfigDefinition)).To(Succeed())
+		Expect(reg.Register(webhook.WebhookConfigDefinition)).To(Succeed())
+
+		By("requesting that the manifest be generated")
+		outputDir := GinkgoT().TempDir()
+		genCtx := &genall.GenerationContext{
+			Collector:  &markers.Collector{Registry: reg},
+			Roots:      pkgs,
+			OutputRule: genall.OutputToDirectory(outputDir),
+		}
+		Expect(webhook.Generator{}.Generate(genCtx)).To(Succeed())
+		for _, r := range genCtx.Roots {
+			Expect(r.Errors).To(HaveLen(0))
+		}
+
+		By("loading the generated v1 YAML")
+		actualFile, err := os.ReadFile(path.Join(outputDir, "manifests.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		actualMutating, actualValidating := unmarshalBothV1(actualFile)
+
+		By("loading the desired v1 YAML")
+		expectedFile, err := os.ReadFile("manifests.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		expectedMutating, expectedValidating := unmarshalBothV1(expectedFile)
+
+		By("comparing the two")
+		assertSame(actualMutating, expectedMutating)
+		assertSame(actualValidating, expectedValidating)
+	})
+
 })
 
 func unmarshalBothV1(in []byte) (mutating admissionregv1.MutatingWebhookConfiguration, validating admissionregv1.ValidatingWebhookConfiguration) {

--- a/pkg/webhook/parser_test.go
+++ b/pkg/webhook/parser_test.go
@@ -1,0 +1,306 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestApplyPatch verifies that strategic merge patches are correctly applied to webhook configurations.
+func TestApplyPatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		patch       string
+		expectError bool
+		validate    func(*testing.T, *admissionregv1.MutatingWebhook)
+	}{
+		{
+			name:  "empty patch",
+			patch: "",
+			validate: func(t *testing.T, wh *admissionregv1.MutatingWebhook) {
+				if wh.NamespaceSelector != nil {
+					t.Error("expected nil namespaceSelector")
+				}
+			},
+		},
+		{
+			name:  "namespaceSelector with matchLabels",
+			patch: `{"namespaceSelector":{"matchLabels":{"webhook-enabled":"true"}}}`,
+			validate: func(t *testing.T, wh *admissionregv1.MutatingWebhook) {
+				if wh.NamespaceSelector == nil {
+					t.Fatal("expected namespaceSelector to be set")
+				}
+				if len(wh.NamespaceSelector.MatchLabels) != 1 {
+					t.Errorf("expected 1 matchLabel, got %d", len(wh.NamespaceSelector.MatchLabels))
+				}
+				if wh.NamespaceSelector.MatchLabels["webhook-enabled"] != "true" {
+					t.Errorf("expected webhook-enabled=true, got %q", wh.NamespaceSelector.MatchLabels["webhook-enabled"])
+				}
+			},
+		},
+		{
+			name:  "objectSelector with matchExpressions",
+			patch: `{"objectSelector":{"matchExpressions":[{"key":"tier","operator":"In","values":["frontend","backend"]}]}}`,
+			validate: func(t *testing.T, wh *admissionregv1.MutatingWebhook) {
+				if wh.ObjectSelector == nil {
+					t.Fatal("expected objectSelector to be set")
+				}
+				if len(wh.ObjectSelector.MatchExpressions) != 1 {
+					t.Fatalf("expected 1 matchExpression, got %d", len(wh.ObjectSelector.MatchExpressions))
+				}
+				expr := wh.ObjectSelector.MatchExpressions[0]
+				if expr.Key != "tier" {
+					t.Errorf("expected key=tier, got %q", expr.Key)
+				}
+				if expr.Operator != metav1.LabelSelectorOpIn {
+					t.Errorf("expected operator=In, got %q", expr.Operator)
+				}
+				if len(expr.Values) != 2 {
+					t.Errorf("expected 2 values, got %d", len(expr.Values))
+				}
+			},
+		},
+		{
+			name:  "multiple fields including timeoutSeconds",
+			patch: `{"namespaceSelector":{"matchLabels":{"env":"prod"}},"timeoutSeconds":15}`,
+			validate: func(t *testing.T, wh *admissionregv1.MutatingWebhook) {
+				if wh.NamespaceSelector == nil {
+					t.Fatal("expected namespaceSelector to be set")
+				}
+				if wh.NamespaceSelector.MatchLabels["env"] != "prod" {
+					t.Error("expected env=prod")
+				}
+				if wh.TimeoutSeconds == nil || *wh.TimeoutSeconds != 15 {
+					t.Errorf("expected timeoutSeconds=15, got %v", wh.TimeoutSeconds)
+				}
+			},
+		},
+		{
+			name:  "both selectors with matchLabels and matchExpressions",
+			patch: `{"namespaceSelector":{"matchLabels":{"ns-label":"value"}},"objectSelector":{"matchLabels":{"obj-label":"value"},"matchExpressions":[{"key":"app","operator":"NotIn","values":["excluded"]}]}}`,
+			validate: func(t *testing.T, wh *admissionregv1.MutatingWebhook) {
+				if wh.NamespaceSelector == nil {
+					t.Fatal("expected namespaceSelector to be set")
+				}
+				if wh.ObjectSelector == nil {
+					t.Fatal("expected objectSelector to be set")
+				}
+				if wh.NamespaceSelector.MatchLabels["ns-label"] != "value" {
+					t.Error("expected ns-label=value")
+				}
+				if wh.ObjectSelector.MatchLabels["obj-label"] != "value" {
+					t.Error("expected obj-label=value")
+				}
+				if len(wh.ObjectSelector.MatchExpressions) != 1 {
+					t.Errorf("expected 1 matchExpression, got %d", len(wh.ObjectSelector.MatchExpressions))
+				}
+			},
+		},
+		{
+			name:        "invalid JSON",
+			patch:       `{invalid`,
+			expectError: true,
+		},
+		{
+			name:  "patch with special characters in keys",
+			patch: `{"namespaceSelector":{"matchLabels":{"app.kubernetes.io/name":"myapp"}}}`,
+			validate: func(t *testing.T, wh *admissionregv1.MutatingWebhook) {
+				if wh.NamespaceSelector == nil {
+					t.Fatal("expected namespaceSelector to be set")
+				}
+				if wh.NamespaceSelector.MatchLabels["app.kubernetes.io/name"] != "myapp" {
+					t.Error("expected app.kubernetes.io/name=myapp")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a basic webhook
+			webhook := &admissionregv1.MutatingWebhook{
+				Name: "test-webhook",
+			}
+
+			err := applyPatch(webhook, tt.patch)
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, webhook)
+			}
+		})
+	}
+}
+
+// TestConfigToMutatingWebhookWithPatch verifies that the Config.ToMutatingWebhook method
+// correctly applies patches to the generated webhook.
+func TestConfigToMutatingWebhookWithPatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      Config
+		expectError bool
+		validate    func(*testing.T, admissionregv1.MutatingWebhook)
+	}{
+		{
+			name: "mutating webhook with namespaceSelector patch",
+			config: Config{
+				Mutating:                true,
+				Name:                    "test.webhook.io",
+				FailurePolicy:           "fail",
+				SideEffects:             "None",
+				Path:                    "/mutate",
+				Groups:                  []string{"apps"},
+				Resources:               []string{"deployments"},
+				Versions:                []string{"v1"},
+				Verbs:                   []string{"create", "update"},
+				AdmissionReviewVersions: []string{"v1"},
+				Patch:                   `{"namespaceSelector":{"matchLabels":{"webhook":"enabled"}}}`,
+			},
+			validate: func(t *testing.T, wh admissionregv1.MutatingWebhook) {
+				if wh.NamespaceSelector == nil {
+					t.Fatal("expected namespaceSelector to be set")
+				}
+				if wh.NamespaceSelector.MatchLabels["webhook"] != "enabled" {
+					t.Error("expected webhook=enabled")
+				}
+			},
+		},
+		{
+			name: "mutating webhook with objectSelector patch",
+			config: Config{
+				Mutating:                true,
+				Name:                    "test.webhook.io",
+				FailurePolicy:           "fail",
+				SideEffects:             "None",
+				Path:                    "/mutate",
+				Groups:                  []string{"apps"},
+				Resources:               []string{"deployments"},
+				Versions:                []string{"v1"},
+				Verbs:                   []string{"create"},
+				AdmissionReviewVersions: []string{"v1"},
+				Patch:                   `{"objectSelector":{"matchExpressions":[{"key":"managed-by","operator":"In","values":["controller"]}]}}`,
+			},
+			validate: func(t *testing.T, wh admissionregv1.MutatingWebhook) {
+				if wh.ObjectSelector == nil {
+					t.Fatal("expected objectSelector to be set")
+				}
+				if len(wh.ObjectSelector.MatchExpressions) != 1 {
+					t.Fatalf("expected 1 matchExpression, got %d", len(wh.ObjectSelector.MatchExpressions))
+				}
+			},
+		},
+		{
+			name: "mutating webhook with timeout override",
+			config: Config{
+				Mutating:                true,
+				Name:                    "test.webhook.io",
+				FailurePolicy:           "fail",
+				SideEffects:             "None",
+				Path:                    "/mutate",
+				Groups:                  []string{"apps"},
+				Resources:               []string{"deployments"},
+				Versions:                []string{"v1"},
+				Verbs:                   []string{"create"},
+				AdmissionReviewVersions: []string{"v1"},
+				TimeoutSeconds:          10,
+				Patch:                   `{"timeoutSeconds":25}`,
+			},
+			validate: func(t *testing.T, wh admissionregv1.MutatingWebhook) {
+				if wh.TimeoutSeconds == nil || *wh.TimeoutSeconds != 25 {
+					t.Errorf("expected timeoutSeconds to be overridden to 25, got %v", wh.TimeoutSeconds)
+				}
+			},
+		},
+		{
+			name: "invalid patch JSON",
+			config: Config{
+				Mutating:                true,
+				Name:                    "test.webhook.io",
+				FailurePolicy:           "fail",
+				SideEffects:             "None",
+				Path:                    "/mutate",
+				Groups:                  []string{"apps"},
+				Resources:               []string{"deployments"},
+				Versions:                []string{"v1"},
+				Verbs:                   []string{"create"},
+				AdmissionReviewVersions: []string{"v1"},
+				Patch:                   `{invalid json`,
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			webhook, err := tt.config.ToMutatingWebhook()
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, webhook)
+			}
+		})
+	}
+}
+
+// TestConfigToValidatingWebhookWithPatch verifies that the Config.ToValidatingWebhook method
+// correctly applies patches to the generated webhook.
+func TestConfigToValidatingWebhookWithPatch(t *testing.T) {
+	config := Config{
+		Mutating:                false,
+		Name:                    "test.webhook.io",
+		FailurePolicy:           "fail",
+		SideEffects:             "None",
+		Path:                    "/validate",
+		Groups:                  []string{"apps"},
+		Resources:               []string{"deployments"},
+		Versions:                []string{"v1"},
+		Verbs:                   []string{"create", "update"},
+		AdmissionReviewVersions: []string{"v1"},
+		Patch:                   `{"namespaceSelector":{"matchLabels":{"env":"production"}}}`,
+	}
+
+	webhook, err := config.ToValidatingWebhook()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if webhook.NamespaceSelector == nil {
+		t.Fatal("expected namespaceSelector to be set")
+	}
+	if webhook.NamespaceSelector.MatchLabels["env"] != "production" {
+		t.Errorf("expected env=production, got %q", webhook.NamespaceSelector.MatchLabels["env"])
+	}
+}

--- a/pkg/webhook/testdata/valid-namespaceselector/manifests.yaml
+++ b/pkg/webhook/testdata/valid-namespaceselector/manifests.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-testdata-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: validation.cronjob.testdata.kubebuilder.io
+  namespaceSelector:
+    matchLabels:
+      webhook-enabled: "true"
+  rules:
+  - apiGroups:
+    - testdata.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None

--- a/pkg/webhook/testdata/valid-namespaceselector/webhook.go
+++ b/pkg/webhook/testdata/valid-namespaceselector/webhook.go
@@ -1,0 +1,19 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cronjob
+
+// Validating webhook with namespaceSelector via patch marker. Uses backticks so no escapes are needed.
+// +kubebuilder:webhook:verbs=create;update,path=/validate-testdata-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=testdata.kubebuilder.io,resources=cronjobs,versions=v1,name=validation.cronjob.testdata.kubebuilder.io,sideEffects=None,admissionReviewVersions=v1,patch=`{"namespaceSelector":{"matchLabels":{"webhook-enabled":"true"}}}`

--- a/pkg/webhook/testdata/valid-objectselector/manifests.yaml
+++ b/pkg/webhook/testdata/valid-objectselector/manifests.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-testdata-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: default.cronjob.testdata.kubebuilder.io
+  objectSelector:
+    matchLabels:
+      managed-by: myoperator
+  rules:
+  - apiGroups:
+    - testdata.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None

--- a/pkg/webhook/testdata/valid-objectselector/webhook.go
+++ b/pkg/webhook/testdata/valid-objectselector/webhook.go
@@ -1,0 +1,19 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cronjob
+
+// Mutating webhook with objectSelector via patch marker. Uses backticks so no escapes are needed.
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-testdata-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=testdata.kubebuilder.io,resources=cronjobs,versions=v1,name=default.cronjob.testdata.kubebuilder.io,sideEffects=None,admissionReviewVersions=v1,patch=`{"objectSelector":{"matchLabels":{"managed-by":"myoperator"}}}`

--- a/pkg/webhook/testdata/valid-selectors-matchexpressions/manifests.yaml
+++ b/pkg/webhook/testdata/valid-selectors-matchexpressions/manifests.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-testdata-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: default.cronjob.testdata.kubebuilder.io
+  objectSelector:
+    matchExpressions:
+    - key: tier
+      operator: In
+      values:
+      - frontend
+      - backend
+    matchLabels:
+      managed-by: controller
+  rules:
+  - apiGroups:
+    - testdata.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-testdata-kubebuilder-io-v1-cronjob
+  failurePolicy: Fail
+  name: validation.cronjob.testdata.kubebuilder.io
+  namespaceSelector:
+    matchExpressions:
+    - key: environment
+      operator: In
+      values:
+      - dev
+      - staging
+      - prod
+  rules:
+  - apiGroups:
+    - testdata.kubebuilder.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - cronjobs
+  sideEffects: None

--- a/pkg/webhook/testdata/valid-selectors-matchexpressions/webhook.go
+++ b/pkg/webhook/testdata/valid-selectors-matchexpressions/webhook.go
@@ -1,0 +1,21 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cronjob
+
+// Validating webhook with namespaceSelector via patch marker (matchExpressions). Uses backticks so no escapes are needed.
+// +kubebuilder:webhook:verbs=create;update,path=/validate-testdata-kubebuilder-io-v1-cronjob,mutating=false,failurePolicy=fail,groups=testdata.kubebuilder.io,resources=cronjobs,versions=v1,name=validation.cronjob.testdata.kubebuilder.io,sideEffects=None,admissionReviewVersions=v1,patch=`{"namespaceSelector":{"matchExpressions":[{"key":"environment","operator":"In","values":["dev","staging","prod"]}]}}`
+// Mutating webhook with objectSelector via patch marker (matchLabels and matchExpressions). Uses backticks so no escapes are needed.
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-testdata-kubebuilder-io-v1-cronjob,mutating=true,failurePolicy=fail,groups=testdata.kubebuilder.io,resources=cronjobs,versions=v1,name=default.cronjob.testdata.kubebuilder.io,sideEffects=None,admissionReviewVersions=v1,patch=`{"objectSelector":{"matchLabels":{"managed-by":"controller"},"matchExpressions":[{"key":"tier","operator":"In","values":["frontend","backend"]}]}}`

--- a/pkg/webhook/zz_generated.markerhelp.go
+++ b/pkg/webhook/zz_generated.markerhelp.go
@@ -104,6 +104,10 @@ func (Config) Help() *markers.DefinitionHelp {
 				Summary: "allows mutating webhooks configuration to specify an external URL when generating",
 				Details: "the manifests, instead of using the internal service communication. Should be in format of\nhttps://address:port/path\nWhen this option is specified, the serviceConfig.Service is removed from webhook the manifest.\nThe URL configuration should be between quotes.\n`url` cannot be specified when `path` is specified.",
 			},
+			"Patch": {
+				Summary: "applies a strategic merge patch to customize the generated webhook configuration.",
+				Details: "This allows you to set any webhook field that isn't directly exposed as a marker parameter,\nsuch as namespaceSelector, objectSelector, or matchConditions. The patch is a JSON object\nthat follows Kubernetes strategic merge patch semantics and is applied to the webhook\nconfiguration after all other marker parameters are processed.\n\nUse backticks to avoid escaping quotes in the JSON.\n\nCommon use cases:\n- Limit webhook scope to specific namespaces using namespaceSelector\n- Filter webhook invocations by object labels using objectSelector\n- Combine multiple customizations in a single patch\n\nExample (limit to labeled namespaces):\n\n\t// +kubebuilder:webhook:path=/mutate-v1-pod,mutating=true,...,patch=`{\"namespaceSelector\":{\"matchLabels\":{\"webhook-enabled\":\"true\"}}}`\n\nExample (filter by object labels with matchExpressions):\n\n\t// +kubebuilder:webhook:path=/validate-v1-deployment,...,patch=`{\"objectSelector\":{\"matchExpressions\":[{\"key\":\"tier\",\"operator\":\"In\",\"values\":[\"frontend\",\"backend\"]}]}}`\n\nExample (combine namespace and object selectors):\n\n\t// +kubebuilder:webhook:...,patch=`{\"namespaceSelector\":{\"matchLabels\":{\"env\":\"production\"}},\"objectSelector\":{\"matchLabels\":{\"managed-by\":\"my-operator\"}}}`\n\nExample (override timeout):\n\n\t// +kubebuilder:webhook:...,patch=`{\"timeoutSeconds\":25}`",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Enables filtering webhooks by namespace and object labels to solve the webhook bootstrap problem and support namespace-scoped operators. This markers will allow Kubebuilder abstracts the complexities. 

Closes:  https://github.com/kubernetes-sigs/controller-tools/issues/553 and https://github.com/kubernetes-sigs/controller-tools/issues/1338 and https://github.com/kubernetes-sigs/kubebuilder/issues/5758