### PR TITLE
📖 docs: Add examples to all marker types.

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -75,6 +75,20 @@ func init() {
 // +controllertools:marker:generateHelp:category=CRD
 
 // SubresourceStatus enables the "/status" subresource on a CRD.
+//
+// The status subresource allows you to update the status field separately from the rest
+// of the resource spec, and prevents updates to the status subresource when updating the root object.
+// This is useful for separating user-provided spec from system-provided status.
+//
+// Example:
+//
+//	// +kubebuilder:subresource:status
+//	type MyCRD struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	    Spec   MyCRDSpec
+//	    Status MyCRDStatus
+//	}
 type SubresourceStatus struct{}
 
 func (s SubresourceStatus) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitionSpec, version string) error {
@@ -100,19 +114,34 @@ func (s SubresourceStatus) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinit
 // +controllertools:marker:generateHelp:category=CRD
 
 // SubresourceScale enables the "/scale" subresource on a CRD.
+//
+// The scale subresource allows you to use `kubectl scale` and the HorizontalPodAutoscaler with your CRD.
+//
+// Example:
+//
+//	// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
+//	type MyCRD struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	    Spec MyCRDSpec
+//	    Status MyCRDStatus
+//	}
 type SubresourceScale struct {
 	// marker names are leftover legacy cruft
 
 	// SpecPath specifies the jsonpath to the replicas field for the scale's spec.
+	// This is where the desired number of replicas is stored (typically .spec.replicas).
 	SpecPath string `marker:"specpath"`
 
 	// StatusPath specifies the jsonpath to the replicas field for the scale's status.
+	// This is where the actual number of replicas is stored (typically .status.replicas).
 	StatusPath string `marker:"statuspath"`
 
 	// SelectorPath specifies the jsonpath to the pod label selector field for the scale's status.
 	//
 	// The selector field must be the *string* form (serialized form) of a selector.
 	// Setting a pod label selector is necessary for your type to work with the HorizontalPodAutoscaler.
+	// This is typically .status.selector.
 	SelectorPath *string `marker:"selectorpath"`
 }
 
@@ -147,6 +176,15 @@ func (s SubresourceScale) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefiniti
 // When conversion is enabled for a CRD (i.e. it's not a trivial-versions/single-version CRD),
 // one version is set as the "storage version" to be stored in etcd.  Attempting to store any
 // other version will result in conversion to the storage version via a conversion webhook.
+//
+// Example:
+//
+//	// +kubebuilder:storageversion
+//	type MyCRDv2 struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	    Spec MyCRDSpec
+//	}
 type StorageVersion struct{}
 
 func (s StorageVersion) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitionSpec, version string) error {
@@ -173,6 +211,13 @@ func (s StorageVersion) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinition
 // This is useful if you need to skip generating and listing version entries
 // for 'internal' resource versions, which typically exist if using the
 // Kubernetes upstream conversion-gen tool.
+//
+// Example:
+//
+//	// +kubebuilder:skipversion
+//	type MyCRDInternal struct {
+//	    // internal version not served by API
+//	}
 type SkipVersion struct{}
 
 func (s SkipVersion) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitionSpec, version string) error {
@@ -197,20 +242,34 @@ func (s SkipVersion) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitionSpe
 // +controllertools:marker:generateHelp:category=CRD
 
 // PrintColumn adds a column to "kubectl get" output for this CRD.
+//
+// This allows you to customize which columns are shown when users run `kubectl get` on your CRD.
+//
+// Example:
+//
+//	// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
+//	// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+//	type MyCRD struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	}
 type PrintColumn struct {
-	// Name specifies the name of the column.
+	// Name specifies the name of the column as it will appear in the header.
 	Name string
 
 	// Type indicates the type of the column.
 	//
 	// It may be any OpenAPI data type listed at
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.
+	// Common values: "string", "integer", "number", "boolean", "date".
 	Type string
 
 	// JSONPath specifies the jsonpath expression used to extract the value of the column.
+	// The path is relative to the resource root. Example: `.status.phase` or `.spec.replicas`.
 	JSONPath string `marker:"JSONPath"` // legacy cruft
 
-	// Description specifies the help/description for this column.
+	// Description specifies optional help text for this column.
+	// Display behavior is client-dependent; see CustomResourceColumnDefinition in the Kubernetes API docs.
 	Description string `marker:",optional"`
 
 	// Format specifies the format of the column.
@@ -222,7 +281,7 @@ type PrintColumn struct {
 	// Priority indicates how important it is that this column be displayed.
 	//
 	// Lower priority (*higher* numbered) columns will be hidden if the terminal
-	// width is too small.
+	// width is too small. Priority 0 columns are always shown.
 	Priority int32 `marker:",optional"`
 }
 
@@ -258,10 +317,19 @@ func (s PrintColumn) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitionSpe
 // +controllertools:marker:generateHelp:category=CRD
 
 // Resource configures naming and scope for a CRD.
+//
+// Example:
+//
+//	// +kubebuilder:resource:path=mycrdplural,singular=mycrdsingular,shortName=mc;mcrd,categories=all,scope=Namespaced
+//	type MyCRD struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	}
 type Resource struct {
 	// Path specifies the plural "resource" for this CRD.
 	//
 	// It generally corresponds to a plural, lower-cased version of the Kind.
+	// For example, if the Kind is "MyCRD", the path might be "mycrds".
 	// See https://book.kubebuilder.io/cronjob-tutorial/gvks.html.
 	Path string `marker:",optional"`
 
@@ -269,7 +337,8 @@ type Resource struct {
 	//
 	// Short names are often used when people have work with your resource
 	// over and over again.  For instance, "rs" for "replicaset" or
-	// "crd" for customresourcedefinition.
+	// "crd" for customresourcedefinition. Multiple short names can be specified
+	// separated by semicolons.
 	ShortName []string `marker:",optional"`
 
 	// Categories specifies which group aliases this resource is part of.
@@ -277,17 +346,19 @@ type Resource struct {
 	// Group aliases are used to work with groups of resources at once.
 	// The most common one is "all" which covers about a third of the base
 	// resources in Kubernetes, and is generally used for "user-facing" resources.
+	// This allows users to run commands like `kubectl get all` to include your CRD.
 	Categories []string `marker:",optional"`
 
 	// Singular overrides the singular form of your resource.
 	//
 	// The singular form is otherwise defaulted off the plural (path).
+	// This is used in API responses and `kubectl` output.
 	Singular string `marker:",optional"`
 
 	// Scope overrides the scope of the CRD (Cluster vs Namespaced).
 	//
 	// Scope defaults to "Namespaced".  Cluster-scoped ("Cluster") resources
-	// don't exist in namespaces.
+	// don't exist in namespaces and are accessible from anywhere in the cluster.
 	Scope string `marker:",optional"`
 }
 
@@ -316,6 +387,15 @@ func (s Resource) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitionSpec, 
 // UnservedVersion does not serve this version.
 //
 // This is useful if you need to drop support for a version in favor of a newer version.
+// The version will still be stored in etcd if it's the storage version, but won't be
+// served via the API.
+//
+// Example:
+//
+//	// +kubebuilder:unservedversion
+//	type MyCRDv1alpha1 struct {
+//	    // This version is no longer served
+//	}
 type UnservedVersion struct{}
 
 func (s UnservedVersion) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitionSpec, version string) error {
@@ -335,8 +415,20 @@ func (s UnservedVersion) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinitio
 // +controllertools:marker:generateHelp:category=CRD
 
 // DeprecatedVersion marks this version as deprecated.
+//
+// Deprecated versions show a warning message when used. This is useful for
+// communicating to users that they should migrate to a newer version.
+//
+// Example:
+//
+//	// +kubebuilder:deprecatedversion:warning="v1alpha1 is deprecated; use v1 instead"
+//	type MyCRDv1alpha1 struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	}
 type DeprecatedVersion struct {
-	// Warning message to be shown on the deprecated version
+	// Warning message to be shown on the deprecated version.
+	// This message is displayed to users when they interact with the deprecated version.
 	Warning *string `marker:",optional"`
 }
 
@@ -363,10 +455,22 @@ func (s DeprecatedVersion) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinit
 // Metadata configures the additional annotations or labels for this CRD.
 // For example adding annotation "api-approved.kubernetes.io" for a CRD with Kubernetes groups,
 // or annotation "cert-manager.io/inject-ca-from-secret" for a CRD that needs CA injection.
+//
+// Example:
+//
+//	// +kubebuilder:metadata:annotations="api-approved.kubernetes.io/v1=https://github.com/myorg/myrepo/pull/123"
+//	// +kubebuilder:metadata:labels="app=myapp"
+//	type MyCRD struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	}
 type Metadata struct {
 	// Annotations will be added into the annotations of this CRD.
+	// Format: "key=value". Multiple annotations can be specified by repeating the marker.
 	Annotations []string `marker:",optional"`
+
 	// Labels will be added into the labels of this CRD.
+	// Format: "key=value". Multiple labels can be specified by repeating the marker.
 	Labels []string `marker:",optional"`
 }
 
@@ -400,8 +504,21 @@ func (s Metadata) ApplyToCRD(crd *apiextensionsv1.CustomResourceDefinition, _ st
 // +controllertools:marker:generateHelp:category=CRD
 
 // SelectableField adds a field that may be used with field selectors.
+//
+// Field selectors allow users to filter resources based on field values when listing.
+// For example, `kubectl get mycrds --field-selector status.phase=Running`.
+//
+// Example:
+//
+//	// +kubebuilder:selectablefield:JSONPath=".status.phase"
+//	type MyCRD struct {
+//	    metav1.TypeMeta
+//	    metav1.ObjectMeta
+//	    Status MyCRDStatus
+//	}
 type SelectableField struct {
 	// JSONPath specifies the jsonpath expression which is used to produce a field selector value.
+	// The path is relative to the resource root. Example: `.status.phase`.
 	JSONPath string `marker:"JSONPath"`
 }
 

--- a/pkg/crd/markers/package.go
+++ b/pkg/crd/markers/package.go
@@ -23,10 +23,10 @@ import (
 func init() {
 	AllDefinitions = append(AllDefinitions,
 		mustOptional(markers.MakeDefinition("groupName", markers.DescribesPackage, "")).
-			WithHelp(markers.SimpleHelp("CRD", "specifies the API group name for this package.")),
+			WithHelp(markers.SimpleHelp("CRD", "specifies the API group name for this package. Example: +groupName=mygroup.example.com")),
 
 		must(markers.MakeDefinition("versionName", markers.DescribesPackage, "")).
-			WithHelp(markers.SimpleHelp("CRD", "overrides the API group version for this package (defaults to the package name).")),
+			WithHelp(markers.SimpleHelp("CRD", "overrides the API group version for this package (defaults to the package name). Example: +versionName=v1beta1")),
 
 		must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesPackage, struct{}{})).
 			WithHelp(markers.SimpleHelp("CRD validation", "specifies that all fields in this package are optional by default.")),
@@ -35,6 +35,6 @@ func init() {
 			WithHelp(markers.SimpleHelp("CRD validation", "specifies that all fields in this package are required by default.")),
 
 		must(markers.MakeDefinition("kubebuilder:skip", markers.DescribesPackage, struct{}{})).
-			WithHelp(markers.SimpleHelp("CRD", "don't consider this package as an API version.")),
+			WithHelp(markers.SimpleHelp("CRD", "don't consider this package as an API version. Use this to exclude internal or helper packages from CRD generation.")),
 	)
 }

--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -53,6 +53,8 @@ func init() {
 // ListType specifies the type of data-structure that the list
 // represents (map, set, atomic).
 //
+// This is important for Server-Side Apply to correctly merge list updates.
+//
 // Possible data-structure types of a list are:
 //
 //   - "map": it needs to have a key field, which will be used to build an
@@ -64,6 +66,21 @@ func init() {
 //
 //   - "atomic": All the fields in the list are treated as a single value,
 //     are typically manipulated together by the same actor.
+//
+// Examples:
+//
+//	// Map list (associative list) - items are merged by key
+//	// +listType=map
+//	// +listMapKey=name
+//	Containers []Container
+//
+//	// Set list - items must be unique scalars
+//	// +listType=set
+//	Tags []string
+//
+//	// Atomic list - entire list is replaced on update
+//	// +listType=atomic
+//	Args []string
 type ListType string
 
 const (
@@ -83,6 +100,19 @@ const (
 // It indicates the index of a map list. They can be repeated if multiple keys
 // must be used. It can only be used when ListType is set to map, and the keys
 // should be scalar types.
+//
+// Examples:
+//
+//	// Single key
+//	// +listType=map
+//	// +listMapKey=name
+//	Containers []Container
+//
+//	// Composite key (multiple keys)
+//	// +listType=map
+//	// +listMapKey=name
+//	// +listMapKey=protocol
+//	Ports []Port
 type ListMapKey string
 
 // +controllertools:marker:generateHelp:category="CRD processing"
@@ -90,6 +120,8 @@ type ListMapKey string
 // MapType specifies the level of atomicity of the map;
 // i.e. whether each item in the map is independent of the others,
 // or all fields are treated as a single unit.
+//
+// This is important for Server-Side Apply to correctly merge map updates.
 //
 // Possible values:
 //
@@ -99,6 +131,16 @@ type ListMapKey string
 //
 //   - "atomic": all fields are treated as one unit.
 //     Any changes have to replace the entire map.
+//
+// Examples:
+//
+//	// Granular map (default) - individual keys can be updated independently
+//	// +mapType=granular
+//	Labels map[string]string
+//
+//	// Atomic map - entire map is replaced on update
+//	// +mapType=atomic
+//	Config map[string]string
 type MapType string
 
 // +controllertools:marker:generateHelp:category="CRD processing"
@@ -106,6 +148,8 @@ type MapType string
 // StructType specifies the level of atomicity of the struct;
 // i.e. whether each field in the struct is independent of the others,
 // or all fields are treated as a single unit.
+//
+// This is important for Server-Side Apply to correctly merge struct updates.
 //
 // Possible values:
 //
@@ -115,6 +159,22 @@ type MapType string
 //
 //   - "atomic": all fields are treated as one unit.
 //     Any changes have to replace the entire struct.
+//
+// Examples:
+//
+//	// Granular struct (default) - individual fields can be updated independently
+//	// +structType=granular
+//	type Config struct {
+//	    Host string
+//	    Port int
+//	}
+//
+//	// Atomic struct - entire struct is replaced on update
+//	// +structType=atomic
+//	type Credentials struct {
+//	    Username string
+//	    Password string
+//	}
 type StructType string
 
 func (l ListType) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -168,6 +168,12 @@ func init() {
 }
 
 // Maximum specifies the maximum numeric value that this field can have.
+//
+// Example:
+//
+//	// +kubebuilder:validation:Maximum=100
+//	Percentage int32
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Maximum float64
 
@@ -176,6 +182,12 @@ func (m Maximum) Value() float64 {
 }
 
 // Minimum specifies the minimum numeric value that this field can have. Negative numbers are supported.
+//
+// Example:
+//
+//	// +kubebuilder:validation:Minimum=0
+//	Replicas int32
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Minimum float64
 
@@ -184,14 +196,34 @@ func (m Minimum) Value() float64 {
 }
 
 // ExclusiveMinimum indicates that the minimum is "up to" but not including that value.
+//
+// Example (value must be greater than 0, not greater than or equal to 0):
+//
+//	// +kubebuilder:validation:Minimum=0
+//	// +kubebuilder:validation:ExclusiveMinimum=true
+//	PositiveNumber float64
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type ExclusiveMinimum bool
 
 // ExclusiveMaximum indicates that the maximum is "up to" but not including that value.
+//
+// Example (value must be less than 100, not less than or equal to 100):
+//
+//	// +kubebuilder:validation:Maximum=100
+//	// +kubebuilder:validation:ExclusiveMaximum=true
+//	Percentage float64
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type ExclusiveMaximum bool
 
 // MultipleOf specifies that this field must have a numeric value that's a multiple of this one.
+//
+// Example (value must be a multiple of 5):
+//
+//	// +kubebuilder:validation:MultipleOf=5
+//	Count int32
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MultipleOf float64
 
@@ -200,38 +232,92 @@ func (m MultipleOf) Value() float64 {
 }
 
 // MaxLength specifies the maximum length for this string.
+//
+// Example:
+//
+//	// +kubebuilder:validation:MaxLength=64
+//	Name string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MaxLength int
 
 // MinLength specifies the minimum length for this string.
+//
+// Example:
+//
+//	// +kubebuilder:validation:MinLength=1
+//	Name string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MinLength int
 
 // Pattern specifies that this string must match the given regular expression.
+//
+// Example (DNS subdomain):
+//
+//	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+//	DNSName string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Pattern string
 
 // MaxItems specifies the maximum length for this list.
+//
+// Example:
+//
+//	// +kubebuilder:validation:MaxItems=10
+//	Items []string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MaxItems int
 
 // MinItems specifies the minimum length for this list.
+//
+// Example:
+//
+//	// +kubebuilder:validation:MinItems=1
+//	Endpoints []string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MinItems int
 
 // UniqueItems specifies that all items in this list must be unique.
+//
+// Example:
+//
+//	// +kubebuilder:validation:UniqueItems=true
+//	Tags []string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type UniqueItems bool
 
 // MaxProperties restricts the number of keys in an object
+//
+// Example:
+//
+//	// +kubebuilder:validation:MaxProperties=10
+//	Labels map[string]string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MaxProperties int
 
 // MinProperties restricts the number of keys in an object
+//
+// Example:
+//
+//	// +kubebuilder:validation:MinProperties=1
+//	Metadata map[string]string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MinProperties int
 
 // Enum specifies that this (scalar) field is restricted to the *exact* values specified here.
+//
+// Example:
+//
+//	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
+//	ServiceType string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Enum []any
 
@@ -239,6 +325,14 @@ type Enum []any
 //
 // For example, a date-time field would be marked as "type: string" and
 // "format: date-time".
+//
+// Common formats include: "int32", "int64", "float", "double", "byte", "date", "date-time", "password".
+//
+// Example:
+//
+//	// +kubebuilder:validation:Format=date-time
+//	CreatedAt string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Format string
 
@@ -246,12 +340,27 @@ type Format string
 //
 // This generally must be paired with custom serialization.  For example, the
 // metav1.Time field would be marked as "type: string" and "format: date-time".
+//
+// Common types include: "string", "number", "integer", "boolean", "array", "object".
+//
+// Example:
+//
+//	// +kubebuilder:validation:Type=string
+//	// +kubebuilder:validation:Format=date-time
+//	Time metav1.Time
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Type string
 
 // Nullable marks this field as allowing the "null" value.
 //
 // This is often not necessary, but may be helpful with custom serialization.
+//
+// Example:
+//
+//	// +nullable
+//	Description *string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Nullable struct{}
 
@@ -263,8 +372,32 @@ type Nullable struct{}
 // "delete"}`). Defaults should be defined in pruned form, and only best-effort
 // validation will be performed. Full validation of a default requires
 // submission of the containing CRD to an apiserver.
+//
+// Examples:
+//
+//	// String default
+//	// +kubebuilder:default="ClusterIP"
+//	ServiceType string
+//
+//	// Integer default
+//	// +kubebuilder:default=3
+//	Replicas int32
+//
+//	// Boolean default
+//	// +kubebuilder:default=true
+//	Enabled bool
+//
+//	// Array default
+//	// +kubebuilder:default={80,443}
+//	Ports []int
+//
+//	// Object default
+//	// +kubebuilder:default={replicas: 1}
+//	Config map[string]interface{}
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Default struct {
+	// Value is the default value. It can be any value valid for the field type.
 	Value any
 }
 
@@ -274,8 +407,20 @@ type Default struct {
 // making the schema more understandable when viewed in documentation tools.
 // It's a metadata field that doesn't affect validation but provides
 // important context about what the schema represents.
+//
+// Examples:
+//
+//	// Simple title
+//	// +kubebuilder:title="Replica Count"
+//	Replicas int32
+//
+//	// Descriptive title
+//	// +kubebuilder:title="Database Connection Configuration"
+//	DatabaseConfig DatabaseConfig
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Title struct {
+	// Value is the title text to be shown in OpenAPI documentation.
 	Value any
 }
 
@@ -288,8 +433,32 @@ type Title struct {
 // "delete"}`). Defaults should be defined in pruned form, and only best-effort
 // validation will be performed. Full validation of a default requires
 // submission of the containing CRD to an apiserver.
+//
+// Examples:
+//
+//	// String default (note the JSON quotes)
+//	// +default="ClusterIP"
+//	ServiceType string
+//
+//	// Integer default
+//	// +default=3
+//	Replicas int32
+//
+//	// Boolean default
+//	// +default=true
+//	Enabled bool
+//
+//	// Array default (JSON format)
+//	// +default=[80,443]
+//	Ports []int
+//
+//	// Object default (JSON format)
+//	// +default={"policy": "delete"}
+//	Config map[string]interface{}
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type KubernetesDefault struct {
+	// Value is the default value in JSON format. It can be any value valid for the field type.
 	Value any
 }
 
@@ -301,8 +470,34 @@ type KubernetesDefault struct {
 // "delete"}`). Examples should be defined in pruned form, and only best-effort
 // validation will be performed. Full validation of an example requires
 // submission of the containing CRD to an apiserver.
+//
+// Examples are shown in API documentation to help users understand the expected format.
+//
+// Usage Examples:
+//
+//	// String example
+//	// +kubebuilder:example="my-service"
+//	ServiceName string
+//
+//	// Integer example
+//	// +kubebuilder:example=5
+//	Replicas int32
+//
+//	// Boolean example
+//	// +kubebuilder:example=false
+//	Debug bool
+//
+//	// Array example
+//	// +kubebuilder:example={8080,8443}
+//	Ports []int
+//
+//	// Object example
+//	// +kubebuilder:example={cpu: "100m", memory: "128Mi"}
+//	Resources map[string]string
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Example struct {
+	// Value is the example value to be shown in API documentation.
 	Value any
 }
 
@@ -318,6 +513,12 @@ type Example struct {
 // NB: The kubebuilder:validation:XPreserveUnknownFields variant is deprecated
 // in favor of the kubebuilder:pruning:PreserveUnknownFields variant.  They function
 // identically.
+//
+// Example:
+//
+//	// +kubebuilder:pruning:PreserveUnknownFields
+//	RawConfig map[string]interface{}
+//
 // +controllertools:marker:generateHelp:category="CRD processing"
 type XPreserveUnknownFields struct{}
 
@@ -327,6 +528,12 @@ type XPreserveUnknownFields struct{}
 // They are validated implicitly according to the semantics of the currently
 // running apiserver. It is not necessary to add any additional schema for these
 // field, yet it is possible. This can be combined with PreserveUnknownFields.
+//
+// Example:
+//
+//	// +kubebuilder:validation:EmbeddedResource
+//	Template runtime.RawExtension
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type XEmbeddedResource struct{}
 
@@ -335,6 +542,13 @@ type XEmbeddedResource struct{}
 // This is required when applying patterns or other validations to an IntOrString
 // field. Known information about the type is applied during the collapse phase
 // and as such is not normally available during marker application.
+//
+// Example:
+//
+//	// +kubebuilder:validation:XIntOrString
+//	// +kubebuilder:validation:Pattern="^(\\d+|\\d+%|)$"
+//	Port intstr.IntOrString
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type XIntOrString struct{}
 
@@ -345,6 +559,12 @@ type XIntOrString struct{}
 // tag is for embedding fields that hold JSONSchema typed objects.
 // Because this field disables all type checking, it is recommended
 // to be used only as a last resort.
+//
+// Example:
+//
+//	// +kubebuilder:validation:Schemaless
+//	JSONSchema apiextensionsv1.JSONSchemaProps
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Schemaless struct{}
 
@@ -365,6 +585,18 @@ func isIntegral(value float64) bool {
 //
 // This marker may be repeated to specify multiple expressions, all of
 // which must evaluate to true.
+//
+// Examples:
+//
+//	// Basic field validation
+//	// +kubebuilder:validation:XValidation:rule="self.minReplicas <= self.replicas && self.replicas <= self.maxReplicas",message="replicas must be between minReplicas and maxReplicas"
+//
+//	// Validation with custom reason
+//	// +kubebuilder:validation:XValidation:rule="self.x <= self.maxX",message="x cannot be greater than maxX",reason="FieldValueInvalid"
+//
+//	// Immutability check
+//	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type XValidation struct {
 	Rule              string
@@ -378,18 +610,47 @@ type XValidation struct {
 // AtMostOneOf adds a validation constraint that allows at most one of the specified fields.
 //
 // This marker may be repeated to specify multiple AtMostOneOf constraints that are mutually exclusive.
+//
+// Example:
+//
+//	// +kubebuilder:validation:AtMostOneOf=configMapRef;secretRef
+//	type MyType struct {
+//	    ConfigMapRef *ConfigMapRef
+//	    SecretRef *SecretRef
+//	}
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type AtMostOneOf []string
 
 // ExactlyOneOf adds a validation constraint that allows at exactly one of the specified fields.
 //
 // This marker may be repeated to specify multiple ExactlyOneOf constraints that are mutually exclusive.
+//
+// Example:
+//
+//	// +kubebuilder:validation:ExactlyOneOf=http;https;grpc
+//	type Protocol struct {
+//	    HTTP *HTTPConfig
+//	    HTTPS *HTTPSConfig
+//	    GRPC *GRPCConfig
+//	}
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type ExactlyOneOf []string
 
 // AtLeastOneOf adds a validation constraint that allows at least one of the specified fields.
 //
 // This marker may be repeated to specify multiple AtLeastOneOf constraints that are mutually exclusive.
+//
+// Example:
+//
+//	// +kubebuilder:validation:AtLeastOneOf=email;phone;address
+//	type Contact struct {
+//	    Email *string
+//	    Phone *string
+//	    Address *string
+//	}
+//
 // +controllertools:marker:generateHelp:category="CRD validation"
 type AtLeastOneOf []string
 

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -29,7 +29,7 @@ func (AtLeastOneOf) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "adds a validation constraint that allows at least one of the specified fields.",
-			Details: "This marker may be repeated to specify multiple AtLeastOneOf constraints that are mutually exclusive.",
+			Details: "This marker may be repeated to specify multiple AtLeastOneOf constraints that are mutually exclusive.\n\nExample:\n\n\t// +kubebuilder:validation:AtLeastOneOf=email;phone;address\n\ttype Contact struct {\n\t    Email *string\n\t    Phone *string\n\t    Address *string\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -40,7 +40,7 @@ func (AtMostOneOf) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "adds a validation constraint that allows at most one of the specified fields.",
-			Details: "This marker may be repeated to specify multiple AtMostOneOf constraints that are mutually exclusive.",
+			Details: "This marker may be repeated to specify multiple AtMostOneOf constraints that are mutually exclusive.\n\nExample:\n\n\t// +kubebuilder:validation:AtMostOneOf=configMapRef;secretRef\n\ttype MyType struct {\n\t    ConfigMapRef *ConfigMapRef\n\t    SecretRef *SecretRef\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -51,11 +51,11 @@ func (Default) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "sets the default value for this field.",
-			Details: "A default value will be accepted as any value valid for the\nfield. Formatting for common types include: boolean: `true`, string:\n`Cluster`, numerical: `1.24`, array: `{1,2}`, object: `{policy:\n\"delete\"}`). Defaults should be defined in pruned form, and only best-effort\nvalidation will be performed. Full validation of a default requires\nsubmission of the containing CRD to an apiserver.",
+			Details: "A default value will be accepted as any value valid for the\nfield. Formatting for common types include: boolean: `true`, string:\n`Cluster`, numerical: `1.24`, array: `{1,2}`, object: `{policy:\n\"delete\"}`). Defaults should be defined in pruned form, and only best-effort\nvalidation will be performed. Full validation of a default requires\nsubmission of the containing CRD to an apiserver.\n\nExamples:\n\n\t// String default\n\t// +kubebuilder:default=\"ClusterIP\"\n\tServiceType string\n\n\t// Integer default\n\t// +kubebuilder:default=3\n\tReplicas int32\n\n\t// Boolean default\n\t// +kubebuilder:default=true\n\tEnabled bool\n\n\t// Array default\n\t// +kubebuilder:default={80,443}\n\tPorts []int\n\n\t// Object default\n\t// +kubebuilder:default={replicas: 1}\n\tConfig map[string]interface{}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Value": {
-				Summary: "",
+				Summary: "is the default value. It can be any value valid for the field type.",
 				Details: "",
 			},
 		},
@@ -67,14 +67,74 @@ func (DeprecatedVersion) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks this version as deprecated.",
-			Details: "",
+			Details: "Deprecated versions show a warning message when used. This is useful for\ncommunicating to users that they should migrate to a newer version.\n\nExample:\n\n\t// +kubebuilder:deprecatedversion:warning=\"v1alpha1 is deprecated; use v1 instead\"\n\ttype MyCRDv1alpha1 struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Warning": {
-				Summary: "message to be shown on the deprecated version",
+				Summary: "message to be shown on the deprecated version.",
+				Details: "This message is displayed to users when they interact with the deprecated version.",
+			},
+		},
+	}
+}
+
+func (Enum) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "specifies that this (scalar) field is restricted to the *exact* values specified here.",
+			Details: "Example:\n\n\t// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer\n\tServiceType string",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
+func (ExactlyOneOf) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "adds a validation constraint that allows at exactly one of the specified fields.",
+			Details: "This marker may be repeated to specify multiple ExactlyOneOf constraints that are mutually exclusive.\n\nExample:\n\n\t// +kubebuilder:validation:ExactlyOneOf=http;https;grpc\n\ttype Protocol struct {\n\t    HTTP *HTTPConfig\n\t    HTTPS *HTTPSConfig\n\t    GRPC *GRPCConfig\n\t}",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
+func (Example) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "sets the example value for this field.",
+			Details: "An example value will be accepted as any value valid for the\nfield. Formatting for common types include: boolean: `true`, string:\n`Cluster`, numerical: `1.24`, array: `{1,2}`, object: `{policy:\n\"delete\"}`). Examples should be defined in pruned form, and only best-effort\nvalidation will be performed. Full validation of an example requires\nsubmission of the containing CRD to an apiserver.\n\nExamples are shown in API documentation to help users understand the expected format.\n\nUsage Examples:\n\n\t// String example\n\t// +kubebuilder:example=\"my-service\"\n\tServiceName string\n\n\t// Integer example\n\t// +kubebuilder:example=5\n\tReplicas int32\n\n\t// Boolean example\n\t// +kubebuilder:example=false\n\tDebug bool\n\n\t// Array example\n\t// +kubebuilder:example={8080,8443}\n\tPorts []int\n\n\t// Object example\n\t// +kubebuilder:example={cpu: \"100m\", memory: \"128Mi\"}\n\tResources map[string]string",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{
+			"Value": {
+				Summary: "is the example value to be shown in API documentation.",
 				Details: "",
 			},
 		},
+	}
+}
+
+func (ExclusiveMaximum) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "indicates that the maximum is \"up to\" but not including that value.",
+			Details: "Example (value must be less than 100, not less than or equal to 100):\n\n\t// +kubebuilder:validation:Maximum=100\n\t// +kubebuilder:validation:ExclusiveMaximum=true\n\tPercentage float64",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
+func (ExclusiveMinimum) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "indicates that the minimum is \"up to\" but not including that value.",
+			Details: "Example (value must be greater than 0, not greater than or equal to 0):\n\n\t// +kubebuilder:validation:Minimum=0\n\t// +kubebuilder:validation:ExclusiveMinimum=true\n\tPositiveNumber float64",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
 	}
 }
 
@@ -98,72 +158,12 @@ func (ExternalDocs) Help() *markers.DefinitionHelp {
 	}
 }
 
-func (Enum) Help() *markers.DefinitionHelp {
-	return &markers.DefinitionHelp{
-		Category: "CRD validation",
-		DetailedHelp: markers.DetailedHelp{
-			Summary: "specifies that this (scalar) field is restricted to the *exact* values specified here.",
-			Details: "",
-		},
-		FieldHelp: map[string]markers.DetailedHelp{},
-	}
-}
-
-func (ExactlyOneOf) Help() *markers.DefinitionHelp {
-	return &markers.DefinitionHelp{
-		Category: "CRD validation",
-		DetailedHelp: markers.DetailedHelp{
-			Summary: "adds a validation constraint that allows at exactly one of the specified fields.",
-			Details: "This marker may be repeated to specify multiple ExactlyOneOf constraints that are mutually exclusive.",
-		},
-		FieldHelp: map[string]markers.DetailedHelp{},
-	}
-}
-
-func (Example) Help() *markers.DefinitionHelp {
-	return &markers.DefinitionHelp{
-		Category: "CRD validation",
-		DetailedHelp: markers.DetailedHelp{
-			Summary: "sets the example value for this field.",
-			Details: "An example value will be accepted as any value valid for the\nfield. Formatting for common types include: boolean: `true`, string:\n`Cluster`, numerical: `1.24`, array: `{1,2}`, object: `{policy:\n\"delete\"}`). Examples should be defined in pruned form, and only best-effort\nvalidation will be performed. Full validation of an example requires\nsubmission of the containing CRD to an apiserver.",
-		},
-		FieldHelp: map[string]markers.DetailedHelp{
-			"Value": {
-				Summary: "",
-				Details: "",
-			},
-		},
-	}
-}
-
-func (ExclusiveMaximum) Help() *markers.DefinitionHelp {
-	return &markers.DefinitionHelp{
-		Category: "CRD validation",
-		DetailedHelp: markers.DetailedHelp{
-			Summary: "indicates that the maximum is \"up to\" but not including that value.",
-			Details: "",
-		},
-		FieldHelp: map[string]markers.DetailedHelp{},
-	}
-}
-
-func (ExclusiveMinimum) Help() *markers.DefinitionHelp {
-	return &markers.DefinitionHelp{
-		Category: "CRD validation",
-		DetailedHelp: markers.DetailedHelp{
-			Summary: "indicates that the minimum is \"up to\" but not including that value.",
-			Details: "",
-		},
-		FieldHelp: map[string]markers.DetailedHelp{},
-	}
-}
-
 func (Format) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies additional \"complex\" formatting for this field.",
-			Details: "For example, a date-time field would be marked as \"type: string\" and\n\"format: date-time\".",
+			Details: "For example, a date-time field would be marked as \"type: string\" and\n\"format: date-time\".\n\nCommon formats include: \"int32\", \"int64\", \"float\", \"double\", \"byte\", \"date\", \"date-time\", \"password\".\n\nExample:\n\n\t// +kubebuilder:validation:Format=date-time\n\tCreatedAt string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -174,11 +174,11 @@ func (KubernetesDefault) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "sets the default value for this field.",
-			Details: "A default value will be accepted as any value valid for the field.\nOnly JSON-formatted values are accepted. `ref(...)` values are ignored.\nFormatting for common types include: boolean: `true`, string:\n`\"Cluster\"`, numerical: `1.24`, array: `[1,2]`, object: `{\"policy\":\n\"delete\"}`). Defaults should be defined in pruned form, and only best-effort\nvalidation will be performed. Full validation of a default requires\nsubmission of the containing CRD to an apiserver.",
+			Details: "A default value will be accepted as any value valid for the field.\nOnly JSON-formatted values are accepted. `ref(...)` values are ignored.\nFormatting for common types include: boolean: `true`, string:\n`\"Cluster\"`, numerical: `1.24`, array: `[1,2]`, object: `{\"policy\":\n\"delete\"}`). Defaults should be defined in pruned form, and only best-effort\nvalidation will be performed. Full validation of a default requires\nsubmission of the containing CRD to an apiserver.\n\nExamples:\n\n\t// String default (note the JSON quotes)\n\t// +default=\"ClusterIP\"\n\tServiceType string\n\n\t// Integer default\n\t// +default=3\n\tReplicas int32\n\n\t// Boolean default\n\t// +default=true\n\tEnabled bool\n\n\t// Array default (JSON format)\n\t// +default=[80,443]\n\tPorts []int\n\n\t// Object default (JSON format)\n\t// +default={\"policy\": \"delete\"}\n\tConfig map[string]interface{}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Value": {
-				Summary: "",
+				Summary: "is the default value in JSON format. It can be any value valid for the field type.",
 				Details: "",
 			},
 		},
@@ -190,7 +190,7 @@ func (ListMapKey) Help() *markers.DefinitionHelp {
 		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the keys to map listTypes.",
-			Details: "It indicates the index of a map list. They can be repeated if multiple keys\nmust be used. It can only be used when ListType is set to map, and the keys\nshould be scalar types.",
+			Details: "It indicates the index of a map list. They can be repeated if multiple keys\nmust be used. It can only be used when ListType is set to map, and the keys\nshould be scalar types.\n\nExamples:\n\n\t// Single key\n\t// +listType=map\n\t// +listMapKey=name\n\tContainers []Container\n\n\t// Composite key (multiple keys)\n\t// +listType=map\n\t// +listMapKey=name\n\t// +listMapKey=protocol\n\tPorts []Port",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -201,7 +201,7 @@ func (ListType) Help() *markers.DefinitionHelp {
 		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the type of data-structure that the list",
-			Details: "represents (map, set, atomic).\n\nPossible data-structure types of a list are:\n\n  - \"map\": it needs to have a key field, which will be used to build an\n    associative list. A typical example is a the pod container list,\n    which is indexed by the container name.\n\n  - \"set\": Fields need to be \"scalar\", and there can be only one\n    occurrence of each.\n\n  - \"atomic\": All the fields in the list are treated as a single value,\n    are typically manipulated together by the same actor.",
+			Details: "represents (map, set, atomic).\n\nThis is important for Server-Side Apply to correctly merge list updates.\n\nPossible data-structure types of a list are:\n\n  - \"map\": it needs to have a key field, which will be used to build an\n    associative list. A typical example is a the pod container list,\n    which is indexed by the container name.\n\n  - \"set\": Fields need to be \"scalar\", and there can be only one\n    occurrence of each.\n\n  - \"atomic\": All the fields in the list are treated as a single value,\n    are typically manipulated together by the same actor.\n\nExamples:\n\n\t// Map list (associative list) - items are merged by key\n\t// +listType=map\n\t// +listMapKey=name\n\tContainers []Container\n\n\t// Set list - items must be unique scalars\n\t// +listType=set\n\tTags []string\n\n\t// Atomic list - entire list is replaced on update\n\t// +listType=atomic\n\tArgs []string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -212,7 +212,7 @@ func (MapType) Help() *markers.DefinitionHelp {
 		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the level of atomicity of the map;",
-			Details: "i.e. whether each item in the map is independent of the others,\nor all fields are treated as a single unit.\n\nPossible values:\n\n  - \"granular\": items in the map are independent of each other,\n    and can be manipulated by different actors.\n    This is the default behavior.\n\n  - \"atomic\": all fields are treated as one unit.\n    Any changes have to replace the entire map.",
+			Details: "i.e. whether each item in the map is independent of the others,\nor all fields are treated as a single unit.\n\nThis is important for Server-Side Apply to correctly merge map updates.\n\nPossible values:\n\n  - \"granular\": items in the map are independent of each other,\n    and can be manipulated by different actors.\n    This is the default behavior.\n\n  - \"atomic\": all fields are treated as one unit.\n    Any changes have to replace the entire map.\n\nExamples:\n\n\t// Granular map (default) - individual keys can be updated independently\n\t// +mapType=granular\n\tLabels map[string]string\n\n\t// Atomic map - entire map is replaced on update\n\t// +mapType=atomic\n\tConfig map[string]string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -223,7 +223,7 @@ func (MaxItems) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the maximum length for this list.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:MaxItems=10\n\tItems []string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -234,7 +234,7 @@ func (MaxLength) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the maximum length for this string.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:MaxLength=64\n\tName string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -245,7 +245,7 @@ func (MaxProperties) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "restricts the number of keys in an object",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:MaxProperties=10\n\tLabels map[string]string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -256,7 +256,7 @@ func (Maximum) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the maximum numeric value that this field can have.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:Maximum=100\n\tPercentage int32",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -267,16 +267,16 @@ func (Metadata) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "configures the additional annotations or labels for this CRD.",
-			Details: "For example adding annotation \"api-approved.kubernetes.io\" for a CRD with Kubernetes groups,\nor annotation \"cert-manager.io/inject-ca-from-secret\" for a CRD that needs CA injection.",
+			Details: "For example adding annotation \"api-approved.kubernetes.io\" for a CRD with Kubernetes groups,\nor annotation \"cert-manager.io/inject-ca-from-secret\" for a CRD that needs CA injection.\n\nExample:\n\n\t// +kubebuilder:metadata:annotations=\"api-approved.kubernetes.io/v1=https://github.com/myorg/myrepo/pull/123\"\n\t// +kubebuilder:metadata:labels=\"app=myapp\"\n\ttype MyCRD struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Annotations": {
 				Summary: "will be added into the annotations of this CRD.",
-				Details: "",
+				Details: "Format: \"key=value\". Multiple annotations can be specified by repeating the marker.",
 			},
 			"Labels": {
 				Summary: "will be added into the labels of this CRD.",
-				Details: "",
+				Details: "Format: \"key=value\". Multiple labels can be specified by repeating the marker.",
 			},
 		},
 	}
@@ -287,7 +287,7 @@ func (MinItems) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the minimum length for this list.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:MinItems=1\n\tEndpoints []string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -298,7 +298,7 @@ func (MinLength) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the minimum length for this string.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:MinLength=1\n\tName string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -309,7 +309,7 @@ func (MinProperties) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "restricts the number of keys in an object",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:MinProperties=1\n\tMetadata map[string]string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -320,7 +320,7 @@ func (Minimum) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the minimum numeric value that this field can have. Negative numbers are supported.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:Minimum=0\n\tReplicas int32",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -331,7 +331,7 @@ func (MultipleOf) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies that this field must have a numeric value that's a multiple of this one.",
-			Details: "",
+			Details: "Example (value must be a multiple of 5):\n\n\t// +kubebuilder:validation:MultipleOf=5\n\tCount int32",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -342,7 +342,7 @@ func (Nullable) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks this field as allowing the \"null\" value.",
-			Details: "This is often not necessary, but may be helpful with custom serialization.",
+			Details: "This is often not necessary, but may be helpful with custom serialization.\n\nExample:\n\n\t// +nullable\n\tDescription *string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -353,7 +353,7 @@ func (Pattern) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies that this string must match the given regular expression.",
-			Details: "",
+			Details: "Example (DNS subdomain):\n\n\t// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`\n\tDNSName string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -364,24 +364,24 @@ func (PrintColumn) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "adds a column to \"kubectl get\" output for this CRD.",
-			Details: "",
+			Details: "This allows you to customize which columns are shown when users run `kubectl get` on your CRD.\n\nExample:\n\n\t// +kubebuilder:printcolumn:name=\"Status\",type=string,JSONPath=`.status.phase`\n\t// +kubebuilder:printcolumn:name=\"Age\",type=date,JSONPath=`.metadata.creationTimestamp`\n\ttype MyCRD struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Name": {
-				Summary: "specifies the name of the column.",
+				Summary: "specifies the name of the column as it will appear in the header.",
 				Details: "",
 			},
 			"Type": {
 				Summary: "indicates the type of the column.",
-				Details: "It may be any OpenAPI data type listed at\nhttps://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.",
+				Details: "It may be any OpenAPI data type listed at\nhttps://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types.\nCommon values: \"string\", \"integer\", \"number\", \"boolean\", \"date\".",
 			},
 			"JSONPath": {
 				Summary: "specifies the jsonpath expression used to extract the value of the column.",
-				Details: "",
+				Details: "The path is relative to the resource root. Example: `.status.phase` or `.spec.replicas`.",
 			},
 			"Description": {
-				Summary: "specifies the help/description for this column.",
-				Details: "",
+				Summary: "specifies optional help text for this column.",
+				Details: "Display behavior is client-dependent; see CustomResourceColumnDefinition in the Kubernetes API docs.",
 			},
 			"Format": {
 				Summary: "specifies the format of the column.",
@@ -389,7 +389,7 @@ func (PrintColumn) Help() *markers.DefinitionHelp {
 			},
 			"Priority": {
 				Summary: "indicates how important it is that this column be displayed.",
-				Details: "Lower priority (*higher* numbered) columns will be hidden if the terminal\nwidth is too small.",
+				Details: "Lower priority (*higher* numbered) columns will be hidden if the terminal\nwidth is too small. Priority 0 columns are always shown.",
 			},
 		},
 	}
@@ -400,28 +400,28 @@ func (Resource) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "configures naming and scope for a CRD.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:resource:path=mycrdplural,singular=mycrdsingular,shortName=mc;mcrd,categories=all,scope=Namespaced\n\ttype MyCRD struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Path": {
 				Summary: "specifies the plural \"resource\" for this CRD.",
-				Details: "It generally corresponds to a plural, lower-cased version of the Kind.\nSee https://book.kubebuilder.io/cronjob-tutorial/gvks.html.",
+				Details: "It generally corresponds to a plural, lower-cased version of the Kind.\nFor example, if the Kind is \"MyCRD\", the path might be \"mycrds\".\nSee https://book.kubebuilder.io/cronjob-tutorial/gvks.html.",
 			},
 			"ShortName": {
 				Summary: "specifies aliases for this CRD.",
-				Details: "Short names are often used when people have work with your resource\nover and over again.  For instance, \"rs\" for \"replicaset\" or\n\"crd\" for customresourcedefinition.",
+				Details: "Short names are often used when people have work with your resource\nover and over again.  For instance, \"rs\" for \"replicaset\" or\n\"crd\" for customresourcedefinition. Multiple short names can be specified\nseparated by semicolons.",
 			},
 			"Categories": {
 				Summary: "specifies which group aliases this resource is part of.",
-				Details: "Group aliases are used to work with groups of resources at once.\nThe most common one is \"all\" which covers about a third of the base\nresources in Kubernetes, and is generally used for \"user-facing\" resources.",
+				Details: "Group aliases are used to work with groups of resources at once.\nThe most common one is \"all\" which covers about a third of the base\nresources in Kubernetes, and is generally used for \"user-facing\" resources.\nThis allows users to run commands like `kubectl get all` to include your CRD.",
 			},
 			"Singular": {
 				Summary: "overrides the singular form of your resource.",
-				Details: "The singular form is otherwise defaulted off the plural (path).",
+				Details: "The singular form is otherwise defaulted off the plural (path).\nThis is used in API responses and `kubectl` output.",
 			},
 			"Scope": {
 				Summary: "overrides the scope of the CRD (Cluster vs Namespaced).",
-				Details: "Scope defaults to \"Namespaced\".  Cluster-scoped (\"Cluster\") resources\ndon't exist in namespaces.",
+				Details: "Scope defaults to \"Namespaced\".  Cluster-scoped (\"Cluster\") resources\ndon't exist in namespaces and are accessible from anywhere in the cluster.",
 			},
 		},
 	}
@@ -432,7 +432,7 @@ func (Schemaless) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks a field as being a schemaless object.",
-			Details: "Schemaless objects are not introspected, so you must provide\nany type and validation information yourself. One use for this\ntag is for embedding fields that hold JSONSchema typed objects.\nBecause this field disables all type checking, it is recommended\nto be used only as a last resort.",
+			Details: "Schemaless objects are not introspected, so you must provide\nany type and validation information yourself. One use for this\ntag is for embedding fields that hold JSONSchema typed objects.\nBecause this field disables all type checking, it is recommended\nto be used only as a last resort.\n\nExample:\n\n\t// +kubebuilder:validation:Schemaless\n\tJSONSchema apiextensionsv1.JSONSchemaProps",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -443,12 +443,12 @@ func (SelectableField) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "adds a field that may be used with field selectors.",
-			Details: "",
+			Details: "Field selectors allow users to filter resources based on field values when listing.\nFor example, `kubectl get mycrds --field-selector status.phase=Running`.\n\nExample:\n\n\t// +kubebuilder:selectablefield:JSONPath=\".status.phase\"\n\ttype MyCRD struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t    Status MyCRDStatus\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"JSONPath": {
 				Summary: "specifies the jsonpath expression which is used to produce a field selector value.",
-				Details: "",
+				Details: "The path is relative to the resource root. Example: `.status.phase`.",
 			},
 		},
 	}
@@ -459,7 +459,7 @@ func (SkipVersion) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "removes the particular version of the CRD from the CRDs spec.",
-			Details: "This is useful if you need to skip generating and listing version entries\nfor 'internal' resource versions, which typically exist if using the\nKubernetes upstream conversion-gen tool.",
+			Details: "This is useful if you need to skip generating and listing version entries\nfor 'internal' resource versions, which typically exist if using the\nKubernetes upstream conversion-gen tool.\n\nExample:\n\n\t// +kubebuilder:skipversion\n\ttype MyCRDInternal struct {\n\t    // internal version not served by API\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -470,7 +470,7 @@ func (StorageVersion) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks this version as the \"storage version\" for the CRD for conversion.",
-			Details: "When conversion is enabled for a CRD (i.e. it's not a trivial-versions/single-version CRD),\none version is set as the \"storage version\" to be stored in etcd.  Attempting to store any\nother version will result in conversion to the storage version via a conversion webhook.",
+			Details: "When conversion is enabled for a CRD (i.e. it's not a trivial-versions/single-version CRD),\none version is set as the \"storage version\" to be stored in etcd.  Attempting to store any\nother version will result in conversion to the storage version via a conversion webhook.\n\nExample:\n\n\t// +kubebuilder:storageversion\n\ttype MyCRDv2 struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t    Spec MyCRDSpec\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -481,7 +481,7 @@ func (StructType) Help() *markers.DefinitionHelp {
 		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies the level of atomicity of the struct;",
-			Details: "i.e. whether each field in the struct is independent of the others,\nor all fields are treated as a single unit.\n\nPossible values:\n\n  - \"granular\": fields in the struct are independent of each other,\n    and can be manipulated by different actors.\n    This is the default behavior.\n\n  - \"atomic\": all fields are treated as one unit.\n    Any changes have to replace the entire struct.",
+			Details: "i.e. whether each field in the struct is independent of the others,\nor all fields are treated as a single unit.\n\nThis is important for Server-Side Apply to correctly merge struct updates.\n\nPossible values:\n\n  - \"granular\": fields in the struct are independent of each other,\n    and can be manipulated by different actors.\n    This is the default behavior.\n\n  - \"atomic\": all fields are treated as one unit.\n    Any changes have to replace the entire struct.\n\nExamples:\n\n\t// Granular struct (default) - individual fields can be updated independently\n\t// +structType=granular\n\ttype Config struct {\n\t    Host string\n\t    Port int\n\t}\n\n\t// Atomic struct - entire struct is replaced on update\n\t// +structType=atomic\n\ttype Credentials struct {\n\t    Username string\n\t    Password string\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -492,20 +492,20 @@ func (SubresourceScale) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "enables the \"/scale\" subresource on a CRD.",
-			Details: "",
+			Details: "The scale subresource allows you to use `kubectl scale` and the HorizontalPodAutoscaler with your CRD.\n\nExample:\n\n\t// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector\n\ttype MyCRD struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t    Spec MyCRDSpec\n\t    Status MyCRDStatus\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"SpecPath": {
 				Summary: "specifies the jsonpath to the replicas field for the scale's spec.",
-				Details: "",
+				Details: "This is where the desired number of replicas is stored (typically .spec.replicas).",
 			},
 			"StatusPath": {
 				Summary: "specifies the jsonpath to the replicas field for the scale's status.",
-				Details: "",
+				Details: "This is where the actual number of replicas is stored (typically .status.replicas).",
 			},
 			"SelectorPath": {
 				Summary: "specifies the jsonpath to the pod label selector field for the scale's status.",
-				Details: "The selector field must be the *string* form (serialized form) of a selector.\nSetting a pod label selector is necessary for your type to work with the HorizontalPodAutoscaler.",
+				Details: "The selector field must be the *string* form (serialized form) of a selector.\nSetting a pod label selector is necessary for your type to work with the HorizontalPodAutoscaler.\nThis is typically .status.selector.",
 			},
 		},
 	}
@@ -516,7 +516,7 @@ func (SubresourceStatus) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "enables the \"/status\" subresource on a CRD.",
-			Details: "",
+			Details: "The status subresource allows you to update the status field separately from the rest\nof the resource spec, and prevents updates to the status subresource when updating the root object.\nThis is useful for separating user-provided spec from system-provided status.\n\nExample:\n\n\t// +kubebuilder:subresource:status\n\ttype MyCRD struct {\n\t    metav1.TypeMeta\n\t    metav1.ObjectMeta\n\t    Spec   MyCRDSpec\n\t    Status MyCRDStatus\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -527,11 +527,11 @@ func (Title) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "sets the title for this field.",
-			Details: "The title is metadata that makes the OpenAPI documentation more user-friendly,\nmaking the schema more understandable when viewed in documentation tools.\nIt's a metadata field that doesn't affect validation but provides\nimportant context about what the schema represents.",
+			Details: "The title is metadata that makes the OpenAPI documentation more user-friendly,\nmaking the schema more understandable when viewed in documentation tools.\nIt's a metadata field that doesn't affect validation but provides\nimportant context about what the schema represents.\n\nExamples:\n\n\t// Simple title\n\t// +kubebuilder:title=\"Replica Count\"\n\tReplicas int32\n\n\t// Descriptive title\n\t// +kubebuilder:title=\"Database Connection Configuration\"\n\tDatabaseConfig DatabaseConfig",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Value": {
-				Summary: "",
+				Summary: "is the title text to be shown in OpenAPI documentation.",
 				Details: "",
 			},
 		},
@@ -543,7 +543,7 @@ func (Type) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "overrides the type for this field (which defaults to the equivalent of the Go type).",
-			Details: "This generally must be paired with custom serialization.  For example, the\nmetav1.Time field would be marked as \"type: string\" and \"format: date-time\".",
+			Details: "This generally must be paired with custom serialization.  For example, the\nmetav1.Time field would be marked as \"type: string\" and \"format: date-time\".\n\nCommon types include: \"string\", \"number\", \"integer\", \"boolean\", \"array\", \"object\".\n\nExample:\n\n\t// +kubebuilder:validation:Type=string\n\t// +kubebuilder:validation:Format=date-time\n\tTime metav1.Time",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -554,7 +554,7 @@ func (UniqueItems) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies that all items in this list must be unique.",
-			Details: "",
+			Details: "Example:\n\n\t// +kubebuilder:validation:UniqueItems=true\n\tTags []string",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -565,7 +565,7 @@ func (UnservedVersion) Help() *markers.DefinitionHelp {
 		Category: "CRD",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "does not serve this version.",
-			Details: "This is useful if you need to drop support for a version in favor of a newer version.",
+			Details: "This is useful if you need to drop support for a version in favor of a newer version.\nThe version will still be stored in etcd if it's the storage version, but won't be\nserved via the API.\n\nExample:\n\n\t// +kubebuilder:unservedversion\n\ttype MyCRDv1alpha1 struct {\n\t    // This version is no longer served\n\t}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -576,7 +576,7 @@ func (XEmbeddedResource) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks a fields as an embedded resource with apiVersion, kind and metadata fields.",
-			Details: "An embedded resource is a value that has apiVersion, kind and metadata fields.\nThey are validated implicitly according to the semantics of the currently\nrunning apiserver. It is not necessary to add any additional schema for these\nfield, yet it is possible. This can be combined with PreserveUnknownFields.",
+			Details: "An embedded resource is a value that has apiVersion, kind and metadata fields.\nThey are validated implicitly according to the semantics of the currently\nrunning apiserver. It is not necessary to add any additional schema for these\nfield, yet it is possible. This can be combined with PreserveUnknownFields.\n\nExample:\n\n\t// +kubebuilder:validation:EmbeddedResource\n\tTemplate runtime.RawExtension",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -587,7 +587,7 @@ func (XIntOrString) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks a fields as an IntOrString.",
-			Details: "This is required when applying patterns or other validations to an IntOrString\nfield. Known information about the type is applied during the collapse phase\nand as such is not normally available during marker application.",
+			Details: "This is required when applying patterns or other validations to an IntOrString\nfield. Known information about the type is applied during the collapse phase\nand as such is not normally available during marker application.\n\nExample:\n\n\t// +kubebuilder:validation:XIntOrString\n\t// +kubebuilder:validation:Pattern=\"^(\\\\d+|\\\\d+%|)$\"\n\tPort intstr.IntOrString",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -598,7 +598,7 @@ func (XPreserveUnknownFields) Help() *markers.DefinitionHelp {
 		Category: "CRD processing",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "stops the apiserver from pruning fields which are not specified.",
-			Details: "By default the apiserver drops unknown fields from the request payload\nduring the decoding step. This marker stops the API server from doing so.\nIt affects fields recursively, but switches back to normal pruning behaviour\nif nested  properties or additionalProperties are specified in the schema.\nThis can either be true or undefined. False\nis forbidden.\n\nNB: The kubebuilder:validation:XPreserveUnknownFields variant is deprecated\nin favor of the kubebuilder:pruning:PreserveUnknownFields variant.  They function\nidentically.",
+			Details: "By default the apiserver drops unknown fields from the request payload\nduring the decoding step. This marker stops the API server from doing so.\nIt affects fields recursively, but switches back to normal pruning behaviour\nif nested  properties or additionalProperties are specified in the schema.\nThis can either be true or undefined. False\nis forbidden.\n\nNB: The kubebuilder:validation:XPreserveUnknownFields variant is deprecated\nin favor of the kubebuilder:pruning:PreserveUnknownFields variant.  They function\nidentically.\n\nExample:\n\n\t// +kubebuilder:pruning:PreserveUnknownFields\n\tRawConfig map[string]interface{}",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}
@@ -609,7 +609,7 @@ func (XValidation) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks a field as requiring a value for which a given",
-			Details: "expression evaluates to true.\n\nThis marker may be repeated to specify multiple expressions, all of\nwhich must evaluate to true.",
+			Details: "expression evaluates to true.\n\nThis marker may be repeated to specify multiple expressions, all of\nwhich must evaluate to true.\n\nExamples:\n\n\t// Basic field validation\n\t// +kubebuilder:validation:XValidation:rule=\"self.minReplicas <= self.replicas && self.replicas <= self.maxReplicas\",message=\"replicas must be between minReplicas and maxReplicas\"\n\n\t// Validation with custom reason\n\t// +kubebuilder:validation:XValidation:rule=\"self.x <= self.maxX\",message=\"x cannot be greater than maxX\",reason=\"FieldValueInvalid\"\n\n\t// Immutability check\n\t// +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"field is immutable\"",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Rule": {

--- a/pkg/rbac/parser.go
+++ b/pkg/rbac/parser.go
@@ -42,24 +42,76 @@ var (
 // +controllertools:marker:generateHelp:category=RBAC
 
 // Rule specifies an RBAC rule to all access to some resources or non-resource URLs.
+//
+// RBAC markers are used to generate ClusterRole or Role manifests.
+// Multiple markers can be combined to build comprehensive RBAC policies.
+//
+// Examples:
+//
+//	// Basic resource access
+//	// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+//
+//	// Core API group (use empty string)
+//	// +kubebuilder:rbac:groups="",resources=pods;services,verbs=get;list;watch
+//
+//	// Multiple API groups and resources
+//	// +kubebuilder:rbac:groups=apps;batch,resources=deployments;jobs,verbs=get;list;watch;create;update;patch;delete
+//
+//	// Access to resource status or scale subresources
+//	// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+//	// +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=get;update
+//
+//	// Access to specific resource instances by name
+//	// +kubebuilder:rbac:groups="",resources=configmaps,resourceNames=my-config,verbs=get
+//
+//	// Non-resource URLs (for metrics, healthz, etc.)
+//	// +kubebuilder:rbac:urls=/metrics;/healthz,verbs=get
+//
+//	// Namespace-scoped Role instead of ClusterRole
+//	// +kubebuilder:rbac:groups="",namespace=my-namespace,resources=secrets,verbs=get;list;watch
+//
+//	// Custom role name
+//	// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list,roleName=deployment-reader
 type Rule struct {
 	// Groups specifies the API groups that this rule encompasses.
+	// Use empty string ("") for the core API group.
+	// Multiple groups can be specified separated by semicolons.
+	// Example: "apps;batch" or "" (for core group).
 	Groups []string `marker:",optional"`
+
 	// Resources specifies the API resources that this rule encompasses.
+	// Multiple resources can be specified separated by semicolons.
+	// Subresources can be specified with a slash (e.g., "deployments/status").
+	// Example: "deployments;pods" or "deployments/status".
 	Resources []string `marker:",optional"`
+
 	// ResourceNames specifies the names of the API resources that this rule encompasses.
 	//
 	// Create requests cannot be restricted by resourcename, as the object's name
 	// is not known at authorization time.
+	// Multiple names can be specified separated by semicolons.
+	// Example: "my-config;my-secret".
 	ResourceNames []string `marker:",optional"`
+
 	// Verbs specifies the (lowercase) kubernetes API verbs that this rule encompasses.
+	// Common verbs: "get", "list", "watch", "create", "update", "patch", "delete".
+	// Use "*" for all verbs.
+	// Multiple verbs must be specified separated by semicolons.
+	// Example: "get;list;watch".
 	Verbs []string
+
 	// URL specifies the non-resource URLs that this rule encompasses.
+	// Non-resource URLs are paths that don't represent resources, like "/metrics" or "/healthz".
+	// Multiple URLs can be specified separated by semicolons.
+	// Example: "/metrics;/healthz".
 	URLs []string `marker:"urls,optional"`
+
 	// Namespace specifies the scope of the Rule.
 	// If not set, the Rule belongs to the generated ClusterRole.
 	// If set, the Rule belongs to a Role, whose namespace is specified by this field.
+	// Example: "my-namespace".
 	Namespace string `marker:",optional"`
+
 	// RoleName specifies a custom name for the Role or ClusterRole.
 	// If not set, uses the default roleName from the generator.
 	// Useful for avoiding name conflicts when the same roleName is used across multiple namespaces.

--- a/pkg/rbac/zz_generated.markerhelp.go
+++ b/pkg/rbac/zz_generated.markerhelp.go
@@ -57,32 +57,36 @@ func (Rule) Help() *markers.DefinitionHelp {
 		Category: "RBAC",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies an RBAC rule to all access to some resources or non-resource URLs.",
-			Details: "",
+			Details: "RBAC markers are used to generate ClusterRole or Role manifests.\nMultiple markers can be combined to build comprehensive RBAC policies.\n\nExamples:\n\n\t// Basic resource access\n\t// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch\n\n\t// Core API group (use empty string)\n\t// +kubebuilder:rbac:groups=\"\",resources=pods;services,verbs=get;list;watch\n\n\t// Multiple API groups and resources\n\t// +kubebuilder:rbac:groups=apps;batch,resources=deployments;jobs,verbs=get;list;watch;create;update;patch;delete\n\n\t// Access to resource status or scale subresources\n\t// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch\n\t// +kubebuilder:rbac:groups=apps,resources=deployments/scale,verbs=get;update\n\n\t// Access to specific resource instances by name\n\t// +kubebuilder:rbac:groups=\"\",resources=configmaps,resourceNames=my-config,verbs=get\n\n\t// Non-resource URLs (for metrics, healthz, etc.)\n\t// +kubebuilder:rbac:urls=/metrics;/healthz,verbs=get\n\n\t// Namespace-scoped Role instead of ClusterRole\n\t// +kubebuilder:rbac:groups=\"\",namespace=my-namespace,resources=secrets,verbs=get;list;watch\n\n\t// Custom role name\n\t// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list,roleName=deployment-reader",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Groups": {
 				Summary: "specifies the API groups that this rule encompasses.",
-				Details: "",
+				Details: "Use empty string (\"\") for the core API group.\nMultiple groups can be specified separated by semicolons.\nExample: \"apps;batch\" or \"\" (for core group).",
 			},
 			"Resources": {
 				Summary: "specifies the API resources that this rule encompasses.",
-				Details: "",
+				Details: "Multiple resources can be specified separated by semicolons.\nSubresources can be specified with a slash (e.g., \"deployments/status\").\nExample: \"deployments;pods\" or \"deployments/status\".",
 			},
 			"ResourceNames": {
 				Summary: "specifies the names of the API resources that this rule encompasses.",
-				Details: "Create requests cannot be restricted by resourcename, as the object's name\nis not known at authorization time.",
+				Details: "Create requests cannot be restricted by resourcename, as the object's name\nis not known at authorization time.\nMultiple names can be specified separated by semicolons.\nExample: \"my-config;my-secret\".",
 			},
 			"Verbs": {
 				Summary: "specifies the (lowercase) kubernetes API verbs that this rule encompasses.",
-				Details: "",
+				Details: "Common verbs: \"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\", \"delete\".\nUse \"*\" for all verbs.\nMultiple verbs must be specified separated by semicolons.\nExample: \"get;list;watch\".",
 			},
 			"URLs": {
 				Summary: "URL specifies the non-resource URLs that this rule encompasses.",
-				Details: "",
+				Details: "Non-resource URLs are paths that don't represent resources, like \"/metrics\" or \"/healthz\".\nMultiple URLs can be specified separated by semicolons.\nExample: \"/metrics;/healthz\".",
 			},
 			"Namespace": {
 				Summary: "specifies the scope of the Rule.",
-				Details: "If not set, the Rule belongs to the generated ClusterRole.\nIf set, the Rule belongs to a Role, whose namespace is specified by this field.",
+				Details: "If not set, the Rule belongs to the generated ClusterRole.\nIf set, the Rule belongs to a Role, whose namespace is specified by this field.\nExample: \"my-namespace\".",
+			},
+			"RoleName": {
+				Summary: "specifies a custom name for the Role or ClusterRole.",
+				Details: "If not set, uses the default roleName from the generator.\nUseful for avoiding name conflicts when the same roleName is used across multiple namespaces.\n\nExample: When using namespace-scoped RBAC markers with kustomize's global namespace transformation,\nmultiple Roles might end up in the same namespace with identical names, causing an \"ID conflict\" error.\nUse roleName to ensure each Role has a unique name:\n\n  // +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-manager,resources=deployments,verbs=get;list\n  // +kubebuilder:rbac:groups=\"\",namespace=users,roleName=user-secrets,resources=secrets,verbs=get\n\nThis generates Roles named \"infra-manager\" and \"user-secrets\" instead of both being \"manager-role\".",
 			},
 		},
 	}

--- a/pkg/webhook/zz_generated.markerhelp.go
+++ b/pkg/webhook/zz_generated.markerhelp.go
@@ -29,7 +29,7 @@ func (Config) Help() *markers.DefinitionHelp {
 		Category: "Webhook",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies how a webhook should be served.",
-			Details: "It specifies only the details that are intrinsic to the application serving\nit (e.g. the resources it can handle, or the path it serves on).",
+			Details: "It specifies only the details that are intrinsic to the application serving\nit (e.g. the resources it can handle, or the path it serves on).\n\nExample (Validating Webhook):\n\n\t// +kubebuilder:webhook:path=/validate-mygroup-v1-myresource,mutating=false,failurePolicy=fail,sideEffects=None,groups=mygroup.example.com,resources=myresources,verbs=create;update,versions=v1,name=myresource.kb.io,admissionReviewVersions=v1\n\nExample (Mutating Webhook):\n\n\t// +kubebuilder:webhook:path=/mutate-mygroup-v1-myresource,mutating=true,failurePolicy=fail,sideEffects=None,groups=mygroup.example.com,resources=myresources,verbs=create;update,versions=v1,name=myresource.kb.io,admissionReviewVersions=v1",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Mutating": {
@@ -38,15 +38,15 @@ func (Config) Help() *markers.DefinitionHelp {
 			},
 			"FailurePolicy": {
 				Summary: "specifies what should happen if the API server cannot reach the webhook.",
-				Details: "It may be either \"ignore\" (to skip the webhook and continue on) or \"fail\" (to reject\nthe object in question).",
+				Details: "It may be either \"ignore\" (to skip the webhook and continue on) or \"fail\" (to reject\nthe object in question). Most webhooks should use \"fail\" to ensure the webhook logic\nis always executed.",
 			},
 			"MatchPolicy": {
 				Summary: "defines how the \"rules\" list is used to match incoming requests.",
-				Details: "Allowed values are \"Exact\" (match only if it exactly matches the specified rule)\nor \"Equivalent\" (match a request if it modifies a resource listed in rules, even via another API group or version).",
+				Details: "Allowed values are \"Exact\" (match only if it exactly matches the specified rule)\nor \"Equivalent\" (match a request if it modifies a resource listed in rules, even via another API group or version).\nDefaults to \"Equivalent\" if not specified.",
 			},
 			"SideEffects": {
 				Summary: "specify whether calling the webhook will have side effects.",
-				Details: "This has an impact on dry runs and `kubectl diff`: if the sideEffect is \"Unknown\" (the default) or \"Some\", then\nthe API server will not call the webhook on a dry-run request and fails instead.\nIf the value is \"None\", then the webhook has no side effects and the API server will call it on dry-run.\nIf the value is \"NoneOnDryRun\", then the webhook is responsible for inspecting the \"dryRun\" property of the\nAdmissionReview sent in the request, and avoiding side effects if that value is \"true.\"",
+				Details: "This has an impact on dry runs and `kubectl diff`: if the sideEffect is \"Unknown\" (the default) or \"Some\", then\nthe API server will not call the webhook on a dry-run request and fails instead.\nIf the value is \"None\", then the webhook has no side effects and the API server will call it on dry-run.\nIf the value is \"NoneOnDryRun\", then the webhook is responsible for inspecting the \"dryRun\" property of the\nAdmissionReview sent in the request, and avoiding side effects if that value is \"true.\"\nMost webhooks should use \"None\".",
 			},
 			"TimeoutSeconds": {
 				Summary: "allows configuring how long the API server should wait for a webhook to respond before treating the call as a failure.",
@@ -54,39 +54,39 @@ func (Config) Help() *markers.DefinitionHelp {
 			},
 			"Groups": {
 				Summary: "specifies the API groups that this webhook receives requests for.",
-				Details: "",
+				Details: "Use \"*\" to match all groups. Multiple groups are separated by semicolons.\nExample: \"apps;batch\" or \"*\".",
 			},
 			"Resources": {
 				Summary: "specifies the API resources that this webhook receives requests for.",
-				Details: "",
+				Details: "Use \"*\" to match all resources. Multiple resources are separated by semicolons.\nExample: \"deployments;pods\" or \"*\".",
 			},
 			"Verbs": {
 				Summary: "specifies the Kubernetes API verbs that this webhook receives requests for.",
-				Details: "Only modification-like verbs may be specified.\nMay be \"create\", \"update\", \"delete\", \"connect\", or \"*\" (for all).",
+				Details: "Only modification-like verbs may be specified.\nMay be \"create\", \"update\", \"delete\", \"connect\", or \"*\" (for all).\nMultiple verbs are separated by semicolons. Example: \"create;update\".",
 			},
 			"Versions": {
 				Summary: "specifies the API versions that this webhook receives requests for.",
-				Details: "",
+				Details: "Use \"*\" to match all versions. Multiple versions are separated by semicolons.\nExample: \"v1;v1beta1\" or \"*\".",
 			},
 			"Name": {
 				Summary: "indicates the name of this webhook configuration. Should be a domain with at least three segments separated by dots",
-				Details: "",
+				Details: "Example: \"myresource.mygroup.example.com\".",
 			},
 			"ServiceName": {
 				Summary: "indicates the name of the K8s Service the webhook uses.",
-				Details: "",
+				Details: "Defaults to \"webhook-service\" if not specified.",
 			},
 			"ServiceNamespace": {
 				Summary: "indicates the namespace of the K8s Service the webhook uses.",
-				Details: "",
+				Details: "Defaults to \"system\" if not specified.",
 			},
 			"Path": {
 				Summary: "specifies that path that the API server should connect to this webhook on. Must be",
 				Details: "prefixed with a '/validate-' or '/mutate-' depending on the type, and followed by\n$GROUP-$VERSION-$KIND where all values are lower-cased and the periods in the group\nare substituted for hyphens. For example, a validating webhook path for type\nbatch.tutorial.kubebuilder.io/v1,Kind=CronJob would be\n/validate-batch-tutorial-kubebuilder-io-v1-cronjob",
 			},
 			"ServicePort": {
-				Summary: "indicates the port of the K8s Service the webhook uses",
-				Details: "",
+				Summary: "indicates the port of the K8s Service the webhook uses.",
+				Details: "Defaults to 443 if not specified.",
 			},
 			"WebhookVersions": {
 				Summary: "specifies the target API versions of the {Mutating,Validating}WebhookConfiguration objects",
@@ -94,11 +94,11 @@ func (Config) Help() *markers.DefinitionHelp {
 			},
 			"AdmissionReviewVersions": {
 				Summary: "is an ordered list of preferred `AdmissionReview`",
-				Details: "versions the Webhook expects.",
+				Details: "versions the Webhook expects. The API server will try to use the first version\nin the list which it supports. If none of the versions specified are supported,\nthe API call will fail. Common values: \"v1\" or \"v1;v1beta1\".",
 			},
 			"ReinvocationPolicy": {
-				Summary: "allows mutating webhooks to request reinvocation after other mutations",
-				Details: "To allow mutating admission plugins to observe changes made by other plugins,\nbuilt-in mutating admission plugins are re-run if a mutating webhook modifies\nan object, and mutating webhooks can specify a reinvocationPolicy to control\nwhether they are reinvoked as well.",
+				Summary: "allows mutating webhooks to request reinvocation after other mutations.",
+				Details: "To allow mutating admission plugins to observe changes made by other plugins,\nbuilt-in mutating admission plugins are re-run if a mutating webhook modifies\nan object, and mutating webhooks can specify a reinvocationPolicy to control\nwhether they are reinvoked as well. May be \"Never\" or \"IfNeeded\". Defaults to \"Never\".",
 			},
 			"URL": {
 				Summary: "allows mutating webhooks configuration to specify an external URL when generating",
@@ -132,8 +132,8 @@ func (WebhookConfig) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "",
 		DetailedHelp: markers.DetailedHelp{
-			Summary: "",
-			Details: "",
+			Summary: "specifies the configuration for a MutatingWebhookConfiguration or ValidatingWebhookConfiguration.",
+			Details: "This marker configures the webhook configuration object itself, not the individual webhooks.\n\nExample:\n\n\t// +kubebuilder:webhookconfiguration:mutating=true,name=my-mutating-webhook-configuration\n\tpackage v1",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Mutating": {
@@ -142,7 +142,7 @@ func (WebhookConfig) Help() *markers.DefinitionHelp {
 			},
 			"Name": {
 				Summary: "indicates the name of the K8s MutatingWebhookConfiguration or ValidatingWebhookConfiguration object.",
-				Details: "",
+				Details: "If not specified, the name will be auto-generated based on the webhook names.",
 			},
 		},
 	}


### PR DESCRIPTION
Add comprehensive usage examples and improved field documentation to all marker types (validation, CRD, webhook, RBAC, topology).

Generated-by: Cursor/Claude

Closes: https://github.com/kubernetes-sigs/controller-tools/issues/1054

