### PR TITLE
🌱 crd: add integration test for indirect type alias resolution

### DIFF
--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -233,6 +233,58 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 				assertCRDForGroupKind(pkgs[0], schema.GroupKind{Kind: "CronJob"}, "testdata._cronjobs.yaml")
 			})
 		})
+	})
+
+	It("should resolve type aliases to packages not directly imported", func() {
+		By("switching into testdata to appease go modules")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Chdir("./testdata")).To(Succeed())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		By("loading the roots")
+		pkgs, err := loader.LoadRoots("./typealiasindirect/rootpkg")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+		pkg := pkgs[0]
+
+		By("setting up the parser")
+		reg := &markers.Registry{}
+		Expect(crdmarkers.Register(reg)).To(Succeed())
+		parser := &crd.Parser{
+			Collector: &markers.Collector{Registry: reg},
+			Checker:   &loader.TypeChecker{},
+		}
+		crd.AddKnownTypes(parser)
+
+		By("requesting that the package be parsed")
+		parser.NeedPackage(pkg)
+
+		By("checking that no non-type errors occurred along the way")
+		Expect(packageErrors(pkg, packages.TypeError)).NotTo(HaveOccurred())
+
+		By("requesting that the CRD be generated")
+		groupKind := schema.GroupKind{Kind: "Repro", Group: "repro.io"}
+		parser.NeedCRDFor(groupKind, nil)
+
+		By("fixing top level ObjectMeta on the CRD")
+		crd.FixTopLevelMetadata(parser.CustomResourceDefinitions[groupKind])
+
+		By("checking that the CRD is present")
+		generated, found := parser.CustomResourceDefinitions[groupKind]
+		Expect(found).To(BeTrue())
+
+		By("verifying schema includes the field from the aliased package")
+		versions := generated.Spec.Versions
+		Expect(versions).NotTo(BeEmpty())
+		schemaProps := versions[0].Schema.OpenAPIV3Schema.Properties
+		specSchema, ok := schemaProps["spec"]
+		Expect(ok).To(BeTrue())
+		reproducerSchema, ok := specSchema.Properties["reproducer"]
+		Expect(ok).To(BeTrue())
+		Expect(reproducerSchema.Type).To(Equal("object"))
+		_, ok = reproducerSchema.Properties["repro"]
+		Expect(ok).To(BeTrue())
 	})
 
 	It("should generate plural words for Kind correctly", func() {

--- a/pkg/crd/testdata/typealiasindirect/aliaspkg/alias.go
+++ b/pkg/crd/testdata/typealiasindirect/aliaspkg/alias.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aliaspkg
+
+import "testdata.kubebuilder.io/cronjob/typealiasindirect/targetpkg"
+
+type MyAlias = targetpkg.TargetStruct

--- a/pkg/crd/testdata/typealiasindirect/rootpkg/doc.go
+++ b/pkg/crd/testdata/typealiasindirect/rootpkg/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +kubebuilder:object:generate=true
+// +groupName=repro.io
+
+package rootpkg

--- a/pkg/crd/testdata/typealiasindirect/rootpkg/types.go
+++ b/pkg/crd/testdata/typealiasindirect/rootpkg/types.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rootpkg
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"testdata.kubebuilder.io/cronjob/typealiasindirect/aliaspkg"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Namespaced,path=repros
+type Repro struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ReproSpec `json:"spec,omitempty"`
+}
+
+type ReproSpec struct {
+	Reproducer aliaspkg.MyAlias `json:"reproducer"`
+}
+
+// +kubebuilder:object:root=true
+type ReproList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Repro `json:"items"`
+}

--- a/pkg/crd/testdata/typealiasindirect/targetpkg/types.go
+++ b/pkg/crd/testdata/typealiasindirect/targetpkg/types.go
@@ -1,0 +1,21 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package targetpkg
+
+type TargetStruct struct {
+	Repro string `json:"repro"`
+}


### PR DESCRIPTION
Adds regression coverage for the scenario reported in #1063.

In controller-tools v0.16.x, CRD generation could panic when a root API type
contained a field defined via a type alias whose target type lived in a package
not directly imported by the root package.

This PR adds integration-level coverage using the existing Ginkgo/Gomega test
pattern in parser_integration_test.go:
- runs from the pkg/crd/testdata module
- uses loader.LoadRoots and parser APIs
- avoids subprocess execution

The test uses a descriptive fixture layout to model the alias chain:
rootpkg → aliaspkg → targetpkg

Also removes the previous subprocess-based test approach and replaces it with
the standard integration test structure used in this package.

The issue no longer reproduces on main (and v0.20.1), likely fixed as a side
effect of #1122. This test ensures the behavior remains covered and prevents
future regressions.