### PR TITLE
:sparkles: Add support for k8s:enum markers

### DIFF
--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -557,7 +557,7 @@ type ExternalDocs struct {
 	Description string `marker:",optional"`
 }
 
-func (m ExternalDocs) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m ExternalDocs) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if _, err := url.ParseRequestURI(m.URL); err != nil {
 		return fmt.Errorf("invalid url %q in kubebuilder:externalDocs marker: %w", m.URL, err)
 	}

--- a/pkg/crd/markers/doc.go
+++ b/pkg/crd/markers/doc.go
@@ -37,7 +37,7 @@ limitations under the License.
 //		return ApplyPriorityFirst
 //	}
 //
-//	func (m MyCustomMarker) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+//	func (m MyCustomMarker) ApplyToSchema(ctx *SchemaContext, schema *apiext.JSONSchemaProps) error {
 //	  ...
 //	}
 //

--- a/pkg/crd/markers/schema_context.go
+++ b/pkg/crd/markers/schema_context.go
@@ -1,0 +1,30 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package markers
+
+import (
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+// SchemaContext carries contextual information passed to
+// SchemaMarker.ApplyToSchema implementations that need more than the
+// schema itself (for example, to inspect package AST or type info).
+type SchemaContext struct {
+	Package  *loader.Package
+	TypeInfo *markers.TypeInfo
+}

--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -177,7 +177,7 @@ type MapType string
 //	}
 type StructType string
 
-func (l ListType) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (l ListType) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply listType to an array, found %s", schema.Type)
 	}
@@ -193,7 +193,7 @@ func (l ListType) ApplyPriority() ApplyPriority {
 	return ApplyPriorityDefault - 1
 }
 
-func (l ListMapKey) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (l ListMapKey) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply listMapKey to an array, found %s", schema.Type)
 	}
@@ -204,7 +204,7 @@ func (l ListMapKey) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error
 	return nil
 }
 
-func (m MapType) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MapType) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != string(Object) {
 		return fmt.Errorf("must apply mapType to an object")
 	}
@@ -219,7 +219,7 @@ func (m MapType) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (s StructType) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (s StructType) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != string(Object) && schema.Type != "" {
 		return fmt.Errorf("must apply structType to an object; either explicitly set or defaulted through an empty schema type")
 	}

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -19,7 +19,11 @@ package markers
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
 	"math"
+	"slices"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -93,7 +97,7 @@ var TypeOnlyMarkers = []*definitionWithHelp{
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies a list of field names that must conform to the ExactlyOneOf constraint.")),
 	must(markers.MakeDefinition(ValidationAtLeastOneOfPrefix, markers.DescribesType, AtLeastOneOf(nil))).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies a list of field names that must conform to the AtLeastOneOf constraint.")),
-	must(markers.MakeDefinition(K8sEnumTag, markers.DescribesType, struct{}{})).
+	must(markers.MakeDefinition(K8sEnumTag, markers.DescribesType, K8sEnum{})).
 		WithHelp(markers.SimpleHelp("CRD", "indicates that the given type is an enum; all const values of this type are considered values in the enum")),
 }
 
@@ -659,7 +663,7 @@ type ExactlyOneOf []string
 // +controllertools:marker:generateHelp:category="CRD validation"
 type AtLeastOneOf []string
 
-func (m Maximum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Maximum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasNumericType(schema) {
 		return fmt.Errorf("must apply maximum to a numeric value, found %s", schema.Type)
 	}
@@ -673,7 +677,7 @@ func (m Maximum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (m Minimum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Minimum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasNumericType(schema) {
 		return fmt.Errorf("must apply minimum to a numeric value, found %s", schema.Type)
 	}
@@ -687,7 +691,7 @@ func (m Minimum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (m ExclusiveMaximum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m ExclusiveMaximum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasNumericType(schema) {
 		return fmt.Errorf("must apply exclusivemaximum to a numeric value, found %s", schema.Type)
 	}
@@ -695,7 +699,7 @@ func (m ExclusiveMaximum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps)
 	return nil
 }
 
-func (m ExclusiveMinimum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m ExclusiveMinimum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasNumericType(schema) {
 		return fmt.Errorf("must apply exclusiveminimum to a numeric value, found %s", schema.Type)
 	}
@@ -704,7 +708,7 @@ func (m ExclusiveMinimum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps)
 	return nil
 }
 
-func (m MultipleOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MultipleOf) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasNumericType(schema) {
 		return fmt.Errorf("must apply multipleof to a numeric value, found %s", schema.Type)
 	}
@@ -718,7 +722,7 @@ func (m MultipleOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error
 	return nil
 }
 
-func (m MaxLength) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MaxLength) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasTextualType(schema) {
 		return fmt.Errorf("must apply maxlength to a textual value, found type %q", schema.Type)
 	}
@@ -727,7 +731,7 @@ func (m MaxLength) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error 
 	return nil
 }
 
-func (m MinLength) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MinLength) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasTextualType(schema) {
 		return fmt.Errorf("must apply minlength to a textual value, found type %q", schema.Type)
 	}
@@ -736,7 +740,7 @@ func (m MinLength) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error 
 	return nil
 }
 
-func (m Pattern) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Pattern) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if !hasTextualType(schema) {
 		return fmt.Errorf("must apply pattern to a textual value, found type %q", schema.Type)
 	}
@@ -744,7 +748,7 @@ func (m Pattern) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (m MaxItems) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MaxItems) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply maxitem to an array")
 	}
@@ -753,7 +757,7 @@ func (m MaxItems) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (m MinItems) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MinItems) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != string(Array) {
 		return fmt.Errorf("must apply minitems to an array")
 	}
@@ -762,7 +766,7 @@ func (m MinItems) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (m UniqueItems) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m UniqueItems) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != "array" {
 		return fmt.Errorf("must apply uniqueitems to an array")
 	}
@@ -770,7 +774,7 @@ func (m UniqueItems) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) erro
 	return nil
 }
 
-func (m MinProperties) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MinProperties) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != "object" {
 		return fmt.Errorf("must apply minproperties to an object")
 	}
@@ -779,7 +783,7 @@ func (m MinProperties) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) er
 	return nil
 }
 
-func (m MaxProperties) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m MaxProperties) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if schema.Type != "object" {
 		return fmt.Errorf("must apply maxproperties to an object")
 	}
@@ -788,7 +792,7 @@ func (m MaxProperties) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) er
 	return nil
 }
 
-func (m Enum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Enum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	// TODO(directxman12): this is a bit hacky -- we should
 	// probably support AnyType better + using the schema structure
 	vals := make([]apiextensionsv1.JSON, len(m))
@@ -806,7 +810,7 @@ func (m Enum) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (m Format) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Format) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	schema.Format = string(m)
 	return nil
 }
@@ -816,7 +820,7 @@ func (m Format) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 // TODO(directxman12): find a less hacky way to do this
 // (we could preserve ordering of markers, but that feels bad in its own right).
 
-func (m Type) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Type) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	schema.Type = string(m)
 	return nil
 }
@@ -825,13 +829,13 @@ func (m Type) ApplyPriority() ApplyPriority {
 	return ApplyPriorityDefault - 1
 }
 
-func (m Nullable) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Nullable) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	schema.Nullable = true
 	return nil
 }
 
 // ApplyToSchema defaults are only valid CRDs created with the v1 API
-func (m Default) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Default) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	marshalledDefault, err := json.Marshal(m.Value)
 	if err != nil {
 		return err
@@ -848,7 +852,7 @@ func (m Default) ApplyPriority() ApplyPriority {
 	return 10
 }
 
-func (m Title) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Title) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if m.Value == nil {
 		// only apply to the schema if we have a non-nil title
 		return nil
@@ -871,7 +875,7 @@ func (m *KubernetesDefault) ParseMarker(_ string, _ string, restFields string) e
 }
 
 // ApplyToSchema defaults are only valid CRDs created with the v1 API
-func (m KubernetesDefault) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m KubernetesDefault) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if m.Value == nil {
 		// only apply to the schema if we have a non-nil default value
 		return nil
@@ -889,7 +893,7 @@ func (m KubernetesDefault) ApplyPriority() ApplyPriority {
 	return 9
 }
 
-func (m Example) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m Example) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	marshalledExample, err := json.Marshal(m.Value)
 	if err != nil {
 		return err
@@ -898,13 +902,13 @@ func (m Example) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
 	return nil
 }
 
-func (m XPreserveUnknownFields) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m XPreserveUnknownFields) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	defTrue := true
 	schema.XPreserveUnknownFields = &defTrue
 	return nil
 }
 
-func (m XEmbeddedResource) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m XEmbeddedResource) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	schema.XEmbeddedResource = true
 	return nil
 }
@@ -912,7 +916,7 @@ func (m XEmbeddedResource) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps
 // NB(JoelSpeed): we use this property in other markers here,
 // which means the "XIntOrString" marker *must* be applied first.
 
-func (m XIntOrString) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m XIntOrString) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	schema.XIntOrString = true
 	return nil
 }
@@ -921,7 +925,7 @@ func (m XIntOrString) ApplyPriority() ApplyPriority {
 	return ApplyPriorityDefault - 1
 }
 
-func (m XValidation) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (m XValidation) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	var reason *apiextensionsv1.FieldValueErrorReason
 	if m.Reason != "" {
 		switch m.Reason {
@@ -947,7 +951,7 @@ func (XValidation) ApplyPriority() ApplyPriority {
 	return ApplyPriorityDefault
 }
 
-func (fields AtMostOneOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (fields AtMostOneOf) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if len(fields) == 0 {
 		return nil
 	}
@@ -956,7 +960,7 @@ func (fields AtMostOneOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps)
 		Rule:    fmt.Sprintf("%s <= 1", rule),
 		Message: fmt.Sprintf("at most one of the fields in %v may be set", fields),
 	}
-	return xvalidation.ApplyToSchema(schema)
+	return xvalidation.ApplyToSchema(ctx, schema)
 }
 
 func (AtMostOneOf) ApplyPriority() ApplyPriority {
@@ -964,7 +968,7 @@ func (AtMostOneOf) ApplyPriority() ApplyPriority {
 	return XValidation{}.ApplyPriority() + 1
 }
 
-func (fields ExactlyOneOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (fields ExactlyOneOf) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if len(fields) == 0 {
 		return nil
 	}
@@ -973,7 +977,7 @@ func (fields ExactlyOneOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps
 		Rule:    fmt.Sprintf("%s == 1", rule),
 		Message: fmt.Sprintf("exactly one of the fields in %v must be set", fields),
 	}
-	return xvalidation.ApplyToSchema(schema)
+	return xvalidation.ApplyToSchema(ctx, schema)
 }
 
 func (ExactlyOneOf) ApplyPriority() ApplyPriority {
@@ -981,7 +985,7 @@ func (ExactlyOneOf) ApplyPriority() ApplyPriority {
 	return AtMostOneOf{}.ApplyPriority() + 1
 }
 
-func (fields AtLeastOneOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+func (fields AtLeastOneOf) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
 	if len(fields) == 0 {
 		return nil
 	}
@@ -990,7 +994,7 @@ func (fields AtLeastOneOf) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps
 		Rule:    fmt.Sprintf("%s >= 1", rule),
 		Message: fmt.Sprintf("at least one of the fields in %v must be set", fields),
 	}
-	return xvalidation.ApplyToSchema(schema)
+	return xvalidation.ApplyToSchema(ctx, schema)
 }
 
 func (AtLeastOneOf) ApplyPriority() ApplyPriority {
@@ -1013,4 +1017,63 @@ func fieldsToOneOfCelRuleStr(fields []string) string {
 	}
 	list.WriteString("].filter(x,x==true).size()")
 	return list.String()
+}
+
+// K8sEnum marks a type as an enum; the schema's Enum values are populated
+// from the string const declarations of this type in the same package.
+type K8sEnum struct{}
+
+func (K8sEnum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
+	if ctx == nil || ctx.Package == nil || ctx.TypeInfo == nil {
+		return fmt.Errorf("k8s:enum requires type context")
+	}
+	pkg := ctx.Package
+	info := ctx.TypeInfo
+	typeDef := pkg.TypesInfo.Defs[info.RawSpec.Name]
+	if typeDef == nil {
+		return fmt.Errorf("unknown enum type %s", info.Name)
+	}
+	typeInfo := typeDef.Type()
+	basicInfo, isBasic := typeInfo.Underlying().(*types.Basic)
+	if !isBasic || basicInfo.Info()&types.IsString == 0 {
+		return fmt.Errorf("enum type must be a string, not %s", typeInfo.String())
+	}
+
+	var enumValues []apiextensionsv1.JSON
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range valueSpec.Names {
+					obj := pkg.TypesInfo.Defs[name]
+					if obj == nil || obj.Type() != typeInfo {
+						continue
+					}
+					val := valueSpec.Values[i]
+					basicLit, ok := val.(*ast.BasicLit)
+					if !ok || basicLit.Kind != token.STRING {
+						continue
+					}
+					// trim quotes
+					value := basicLit.Value[1 : len(basicLit.Value)-1]
+					enumValues = append(enumValues, apiextensionsv1.JSON{Raw: []byte(`"` + value + `"`)})
+				}
+			}
+		}
+	}
+
+	slices.SortFunc(enumValues, func(a, b apiextensionsv1.JSON) int {
+		return strings.Compare(string(a.Raw), string(b.Raw))
+	})
+
+	schema.Type = "string"
+	schema.Enum = enumValues
+	return nil
 }

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -99,6 +99,7 @@ var TypeOnlyMarkers = []*definitionWithHelp{
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies a list of field names that must conform to the AtLeastOneOf constraint.")),
 	must(markers.MakeDefinition(K8sEnumTag, markers.DescribesType, K8sEnum{})).
 		WithHelp(markers.SimpleHelp("CRD", "indicates that the given type is an enum; all const values of this type are considered values in the enum")),
+	must(markers.MakeDefinition(K8sEnumTag, markers.DescribesField, K8sEnumField{})),
 }
 
 // FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make
@@ -1017,6 +1018,15 @@ func fieldsToOneOfCelRuleStr(fields []string) string {
 	}
 	list.WriteString("].filter(x,x==true).size()")
 	return list.String()
+}
+
+// K8sEnumField exists solely to reject the k8s:enum marker when placed on a
+// field. The marker is only meaningful on a type declaration; without this
+// registration a field-level use would be silently ignored.
+type K8sEnumField struct{}
+
+func (K8sEnumField) ApplyToSchema(*SchemaContext, *apiextensionsv1.JSONSchemaProps) error {
+	return fmt.Errorf("k8s:enum must be set on a type, not a field")
 }
 
 // K8sEnum marks a type as an enum; the schema's Enum values are populated

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -35,6 +35,9 @@ const (
 	ValidationExactlyOneOfPrefix = validationPrefix + "ExactlyOneOf"
 	ValidationAtMostOneOfPrefix  = validationPrefix + "AtMostOneOf"
 	ValidationAtLeastOneOfPrefix = validationPrefix + "AtLeastOneOf"
+
+	// K8sEnumTag indicates that the given type is an enum; all const values of this type are considered values in the enum
+	K8sEnumTag = "k8s:enum"
 )
 
 // ValidationMarkers lists all available markers that affect CRD schema generation,
@@ -90,6 +93,8 @@ var TypeOnlyMarkers = []*definitionWithHelp{
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies a list of field names that must conform to the ExactlyOneOf constraint.")),
 	must(markers.MakeDefinition(ValidationAtLeastOneOfPrefix, markers.DescribesType, AtLeastOneOf(nil))).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies a list of field names that must conform to the AtLeastOneOf constraint.")),
+	must(markers.MakeDefinition(K8sEnumTag, markers.DescribesType, struct{}{})).
+		WithHelp(markers.SimpleHelp("CRD", "indicates that the given type is an enum; all const values of this type are considered values in the enum")),
 }
 
 // FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -24,6 +24,7 @@ import (
 	"go/types"
 	"math"
 	"slices"
+	"strconv"
 	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -1071,9 +1072,15 @@ func (K8sEnum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSch
 					if !ok || basicLit.Kind != token.STRING {
 						continue
 					}
-					// trim quotes
-					value := basicLit.Value[1 : len(basicLit.Value)-1]
-					enumValues = append(enumValues, apiextensionsv1.JSON{Raw: []byte(`"` + value + `"`)})
+					unquoted, err := strconv.Unquote(basicLit.Value)
+					if err != nil {
+						return fmt.Errorf("failed to unquote enum value %q: %w", basicLit.Value, err)
+					}
+					raw, err := json.Marshal(unquoted)
+					if err != nil {
+						return fmt.Errorf("failed to json marshal enum value %q: %w", unquoted, err)
+					}
+					enumValues = append(enumValues, apiextensionsv1.JSON{Raw: raw})
 				}
 			}
 		}
@@ -1082,6 +1089,10 @@ func (K8sEnum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSch
 	slices.SortFunc(enumValues, func(a, b apiextensionsv1.JSON) int {
 		return strings.Compare(string(a.Raw), string(b.Raw))
 	})
+
+	if len(enumValues) == 0 {
+		return fmt.Errorf("no enum values found for type %s", info.Name)
+	}
 
 	schema.Type = "string"
 	schema.Enum = enumValues

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -186,6 +186,16 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 			})
 		})
 
+		Context("Enum API", func() {
+			BeforeEach(func() {
+				pkgPaths = []string{"./enum/..."}
+				expPkgLen = 1
+			})
+			It("should successfully generate the CRD with enum validation constraints", func() {
+				assertCRD(pkgs[0], "Enum", "testdata.kubebuilder.io_enums.yaml")
+			})
+		})
+
 		Context("OneOf API with invalid marker", func() {
 			BeforeEach(func() {
 				pkgPaths = []string{"./oneof_error/..."}

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -196,6 +196,20 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 			})
 		})
 
+		Context("Enum API with marker on field", func() {
+			BeforeEach(func() {
+				pkgPaths = []string{"./enum_error/..."}
+				expPkgLen = 1
+			})
+			It("should generate an error when k8s:enum is set on a field", func() {
+				groupKind := schema.GroupKind{Kind: "EnumError", Group: "testdata.kubebuilder.io"}
+				parser.NeedCRDFor(groupKind, nil)
+
+				expectedErr := "k8s:enum must be set on a type, not a field"
+				Expect(packageErrors(pkgs[0])).To(MatchError(ContainSubstring(expectedErr)))
+			})
+		})
+
 		Context("OneOf API with invalid marker", func() {
 			BeforeEach(func() {
 				pkgPaths = []string{"./oneof_error/..."}

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -49,7 +49,7 @@ var byteType = types.Universe.Lookup("byte").Type()
 type SchemaMarker interface {
 	// ApplyToSchema is called after the rest of the schema for a given type
 	// or field is generated, to modify the schema appropriately.
-	ApplyToSchema(*apiextensionsv1.JSONSchemaProps) error
+	ApplyToSchema(ctx *crdmarkers.SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error
 }
 
 // applyFirstMarker is applied before any other markers.  It's a bit of a hack.
@@ -114,9 +114,6 @@ func (c *schemaContext) requestSchema(pkgPath, typeName string) {
 
 // infoToSchema creates a schema for the type in the given set of type information.
 func infoToSchema(ctx *schemaContext) *apiextensionsv1.JSONSchemaProps {
-	if ctx.info.Markers.Get(crdmarkers.K8sEnumTag) != nil {
-		return enumToSchema(ctx)
-	}
 	if obj := ctx.pkg.Types.Scope().Lookup(ctx.info.Name); obj != nil {
 		switch {
 		// If the obj implements a JSON marshaler and has a marker, use the
@@ -141,61 +138,6 @@ func infoToSchema(ctx *schemaContext) *apiextensionsv1.JSONSchemaProps {
 		}
 	}
 	return typeToSchema(ctx, ctx.info.RawSpec.Type)
-}
-
-func enumToSchema(ctx *schemaContext) *apiextensionsv1.JSONSchemaProps {
-	rawType := ctx.info.RawSpec.Type
-	typeDef := ctx.pkg.TypesInfo.Defs[ctx.info.RawSpec.Name]
-	if typeDef == nil {
-		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unknown enum type %s", ctx.info.Name), rawType))
-		return &apiextensionsv1.JSONSchemaProps{}
-	}
-	typeInfo := typeDef.Type()
-	if basicInfo, isBasic := typeInfo.Underlying().(*types.Basic); !isBasic || basicInfo.Info()&types.IsString == 0 {
-		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("enum type must be a string, not %s", typeInfo.String()), rawType))
-		return &apiextensionsv1.JSONSchemaProps{}
-	}
-
-	var enumValues []apiextensionsv1.JSON
-	for _, file := range ctx.pkg.Syntax {
-		for _, decl := range file.Decls {
-			genDecl, ok := decl.(*ast.GenDecl)
-			if !ok || genDecl.Tok != token.CONST {
-				continue
-			}
-			for _, spec := range genDecl.Specs {
-				valueSpec, ok := spec.(*ast.ValueSpec)
-				if !ok {
-					continue
-				}
-				for i, name := range valueSpec.Names {
-					obj := ctx.pkg.TypesInfo.Defs[name]
-					if obj == nil || obj.Type() != typeInfo {
-						continue
-					}
-					val := valueSpec.Values[i]
-					basicLit, ok := val.(*ast.BasicLit)
-					if !ok || basicLit.Kind != token.STRING {
-						continue
-					}
-					// trim quotes
-					value := basicLit.Value[1 : len(basicLit.Value)-1]
-					enumValues = append(enumValues, apiextensionsv1.JSON{Raw: []byte(`"` + value + `"`)})
-				}
-			}
-		}
-	}
-
-	slices.SortFunc(enumValues, func(a, b apiextensionsv1.JSON) int {
-		return strings.Compare(string(a.Raw), string(b.Raw))
-	})
-
-	schema := &apiextensionsv1.JSONSchemaProps{
-		Type: "string",
-		Enum: enumValues,
-	}
-	applyMarkers(ctx, ctx.info.Markers, schema, rawType)
-	return schema
 }
 
 type schemaMarkerWithName struct {
@@ -252,8 +194,9 @@ func applyMarkers(ctx *schemaContext, markerSet markers.MarkerValues, props *api
 	slices.SortStableFunc(markers, func(i, j schemaMarkerWithName) int { return cmpPriority(i, j) })
 	slices.SortStableFunc(itemsMarkers, func(i, j schemaMarkerWithName) int { return cmpPriority(i, j) })
 
+	schemaCtx := &crdmarkers.SchemaContext{Package: ctx.pkg, TypeInfo: ctx.info}
 	for _, schemaMarker := range markers {
-		if err := schemaMarker.SchemaMarker.ApplyToSchema(props); err != nil {
+		if err := schemaMarker.SchemaMarker.ApplyToSchema(schemaCtx, props); err != nil {
 			ctx.pkg.AddError(loader.ErrFromNode(err /* an okay guess */, node))
 		}
 	}
@@ -264,7 +207,7 @@ func applyMarkers(ctx *schemaContext, markerSet markers.MarkerValues, props *api
 			ctx.pkg.AddError(loader.ErrFromNode(err, node))
 		} else {
 			itemsSchema := props.Items.Schema
-			if err := schemaMarker.SchemaMarker.ApplyToSchema(itemsSchema); err != nil {
+			if err := schemaMarker.SchemaMarker.ApplyToSchema(schemaCtx, itemsSchema); err != nil {
 				ctx.pkg.AddError(loader.ErrFromNode(err /* an okay guess */, node))
 			}
 		}

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -114,6 +114,9 @@ func (c *schemaContext) requestSchema(pkgPath, typeName string) {
 
 // infoToSchema creates a schema for the type in the given set of type information.
 func infoToSchema(ctx *schemaContext) *apiextensionsv1.JSONSchemaProps {
+	if ctx.info.Markers.Get(crdmarkers.K8sEnumTag) != nil {
+		return enumToSchema(ctx)
+	}
 	if obj := ctx.pkg.Types.Scope().Lookup(ctx.info.Name); obj != nil {
 		switch {
 		// If the obj implements a JSON marshaler and has a marker, use the
@@ -138,6 +141,61 @@ func infoToSchema(ctx *schemaContext) *apiextensionsv1.JSONSchemaProps {
 		}
 	}
 	return typeToSchema(ctx, ctx.info.RawSpec.Type)
+}
+
+func enumToSchema(ctx *schemaContext) *apiextensionsv1.JSONSchemaProps {
+	rawType := ctx.info.RawSpec.Type
+	typeDef := ctx.pkg.TypesInfo.Defs[ctx.info.RawSpec.Name]
+	if typeDef == nil {
+		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unknown enum type %s", ctx.info.Name), rawType))
+		return &apiextensionsv1.JSONSchemaProps{}
+	}
+	typeInfo := typeDef.Type()
+	if basicInfo, isBasic := typeInfo.Underlying().(*types.Basic); !isBasic || basicInfo.Info()&types.IsString == 0 {
+		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("enum type must be a string, not %s", typeInfo.String()), rawType))
+		return &apiextensionsv1.JSONSchemaProps{}
+	}
+
+	var enumValues []apiextensionsv1.JSON
+	for _, file := range ctx.pkg.Syntax {
+		for _, decl := range file.Decls {
+			genDecl, ok := decl.(*ast.GenDecl)
+			if !ok || genDecl.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				valueSpec, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range valueSpec.Names {
+					obj := ctx.pkg.TypesInfo.Defs[name]
+					if obj == nil || obj.Type() != typeInfo {
+						continue
+					}
+					val := valueSpec.Values[i]
+					basicLit, ok := val.(*ast.BasicLit)
+					if !ok || basicLit.Kind != token.STRING {
+						continue
+					}
+					// trim quotes
+					value := basicLit.Value[1 : len(basicLit.Value)-1]
+					enumValues = append(enumValues, apiextensionsv1.JSON{Raw: []byte(`"` + value + `"`)})
+				}
+			}
+		}
+	}
+
+	slices.SortFunc(enumValues, func(a, b apiextensionsv1.JSON) int {
+		return strings.Compare(string(a.Raw), string(b.Raw))
+	})
+
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "string",
+		Enum: enumValues,
+	}
+	applyMarkers(ctx, ctx.info.Markers, schema, rawType)
+	return schema
 }
 
 type schemaMarkerWithName struct {

--- a/pkg/crd/schema_test.go
+++ b/pkg/crd/schema_test.go
@@ -148,7 +148,7 @@ type defaultPriorityMarker struct {
 	callback func()
 }
 
-func (m *defaultPriorityMarker) ApplyToSchema(*apiextensionsv1.JSONSchemaProps) error {
+func (m *defaultPriorityMarker) ApplyToSchema(*crdmarkers.SchemaContext, *apiextensionsv1.JSONSchemaProps) error {
 	m.callback()
 	return nil
 }
@@ -162,7 +162,7 @@ func (m *testPriorityMarker) ApplyPriority() crdmarkers.ApplyPriority {
 	return m.priority
 }
 
-func (m *testPriorityMarker) ApplyToSchema(*apiextensionsv1.JSONSchemaProps) error {
+func (m *testPriorityMarker) ApplyToSchema(*crdmarkers.SchemaContext, *apiextensionsv1.JSONSchemaProps) error {
 	m.callback()
 	return nil
 }
@@ -172,7 +172,7 @@ type testapplyFirstMarker struct {
 }
 
 func (m *testapplyFirstMarker) ApplyFirst() {}
-func (m *testapplyFirstMarker) ApplyToSchema(*apiextensionsv1.JSONSchemaProps) error {
+func (m *testapplyFirstMarker) ApplyToSchema(*crdmarkers.SchemaContext, *apiextensionsv1.JSONSchemaProps) error {
 	m.callback()
 	return nil
 }

--- a/pkg/crd/testdata/crd_test.go
+++ b/pkg/crd/testdata/crd_test.go
@@ -21,6 +21,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
 
@@ -37,3 +39,39 @@ var _ = Describe("CronJob CRD", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
+
+var _ = Describe("Enum CRD", func() {
+	It("should accept Value1", func(ctx SpecContext) {
+		obj := enumObject("valid-value1", "Value1")
+		err := k8sClient.Create(ctx, obj)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should accept Value2", func(ctx SpecContext) {
+		obj := enumObject("valid-value2", "Value2")
+		err := k8sClient.Create(ctx, obj)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should reject an invalid enum value", func(ctx SpecContext) {
+		obj := enumObject("invalid-value", "Invalid")
+		err := k8sClient.Create(ctx, obj)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+func enumObject(name, fieldValue string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "testdata.kubebuilder.io/v1",
+			"kind":       "Enum",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": metav1.NamespaceDefault,
+			},
+			"spec": map[string]interface{}{
+				"field": fieldValue,
+			},
+		},
+	}
+}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -61,6 +61,14 @@ type CronJobSpec struct {
 	// +optional
 	ConcurrencyPolicy ConcurrencyPolicy `json:"concurrencyPolicy,omitempty"`
 
+	// Specifies how to treat concurrent executions of a Job.
+	// Valid values are:
+	// - "Allow" (default): allows CronJobs to run concurrently;
+	// - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+	// - "Replace": cancels currently running job and replaces it with a new one
+	// +optional
+	K8sConcurrencyPolicy K8sConcurrencyPolicy `json:"k8sConcurrencyPolicy,omitempty"`
+
 	// This flag tells the controller to suspend subsequent executions, it does
 	// not apply to already started executions.  Defaults to false.
 	// +optional
@@ -752,6 +760,21 @@ const (
 
 	// ReplaceConcurrent cancels currently running job and replaces it with a new one.
 	ReplaceConcurrent ConcurrencyPolicy = "Replace"
+)
+
+// +k8s:enum
+type K8sConcurrencyPolicy string
+
+const (
+	// AllowK8sConcurrencyPolicy allows CronJobs to run concurrently.
+	AllowK8sConcurrencyPolicy K8sConcurrencyPolicy = "Allow"
+
+	// ForbidK8sConcurrencyPolicy forbids concurrent runs, skipping next run if previous
+	// hasn't finished yet.
+	ForbidK8sConcurrencyPolicy K8sConcurrencyPolicy = "Forbid"
+
+	// ReplaceK8sConcurrencyPolicy cancels currently running job and replaces it with a new one.
+	ReplaceK8sConcurrencyPolicy K8sConcurrencyPolicy = "Replace"
 )
 
 // StringEvenType is a type that includes an expression-based validation.

--- a/pkg/crd/testdata/enum/api.go
+++ b/pkg/crd/testdata/enum/api.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/crd/testdata/enum/api.go
+++ b/pkg/crd/testdata/enum/api.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package enum
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +k8s:enum
+type EnumType string
+
+const (
+	Value1 EnumType = "Value1"
+	Value2 EnumType = "Value2"
+)
+
+// +kubebuilder:object:root=true
+
+// Enum is a test CRD that contains an enum.
+type Enum struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec EnumSpec `json:"spec,omitempty"`
+}
+
+// EnumSpec defines the desired state of Enum
+type EnumSpec struct {
+	Field EnumType `json:"field,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// EnumList contains a list of Enum
+type EnumList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Enum `json:"items"`
+}

--- a/pkg/crd/testdata/enum_error/api.go
+++ b/pkg/crd/testdata/enum_error/api.go
@@ -1,0 +1,41 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package enum_error
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+type EnumError struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec EnumErrorSpec `json:"spec,omitempty"`
+}
+
+type EnumErrorSpec struct {
+	// +k8s:enum
+	Field string `json:"field,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+type EnumErrorList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []EnumError `json:"items"`
+}

--- a/pkg/crd/testdata/suite_test.go
+++ b/pkg/crd/testdata/suite_test.go
@@ -37,7 +37,11 @@ func TestCRD(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testEnv = &envtest.Environment{}
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{"testdata.kubebuilder.io_enums.yaml"},
+		},
+	}
 
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -108,6 +108,18 @@ spec:
                 - Forbid
                 - Replace
                 type: string
+              k8sConcurrencyPolicy:
+                description: |-
+                  Specifies how to treat concurrent executions of a Job.
+                  Valid values are:
+                  - "Allow" (default): allows CronJobs to run concurrently;
+                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+                  - "Replace": cancels currently running job and replaces it with a new one
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
               defaultedEmptyMap:
                 additionalProperties:
                   type: string

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -108,18 +108,6 @@ spec:
                 - Forbid
                 - Replace
                 type: string
-              k8sConcurrencyPolicy:
-                description: |-
-                  Specifies how to treat concurrent executions of a Job.
-                  Valid values are:
-                  - "Allow" (default): allows CronJobs to run concurrently;
-                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
-                  - "Replace": cancels currently running job and replaces it with a new one
-                enum:
-                - Allow
-                - Forbid
-                - Replace
-                type: string
               defaultedEmptyMap:
                 additionalProperties:
                   type: string
@@ -9365,6 +9353,18 @@ spec:
                 - bar
                 - foo
                 type: object
+              k8sConcurrencyPolicy:
+                description: |-
+                  Specifies how to treat concurrent executions of a Job.
+                  Valid values are:
+                  - "Allow" (default): allows CronJobs to run concurrently;
+                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+                  - "Replace": cancels currently running job and replaces it with a new one
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
               kubernetesDefaultedEmptyMap:
                 additionalProperties:
                   type: string

--- a/pkg/crd/testdata/testdata.kubebuilder.io_enums.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_enums.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: enums.testdata.kubebuilder.io
+spec:
+  group: testdata.kubebuilder.io
+  names:
+    kind: Enum
+    listKind: EnumList
+    plural: enums
+    singular: enum
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Enum is a test CRD that contains an enum.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnumSpec defines the desired state of Enum
+            properties:
+              field:
+                enum:
+                - Value1
+                - Value2
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
This change adds support for the k8s:enum marker as described [in the kep](https://github.com/kubernetes/enhancements/tree/c68dfb941894fc8859a951fe47a60b2161300b88/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen).

It is a rebase of https://github.com/kubernetes-sigs/controller-tools/pull/1250 plus a test

Closes https://github.com/kubernetes-sigs/controller-tools/pull/1250

/assign @JoelSpeed @lalitc375 
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
