### PR TITLE
:sparkles: Add support for k8s:immutable

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -134,6 +134,9 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition(SchemalessName, markers.DescribesField, Schemaless{})).
 		WithHelp(Schemaless{}.Help()),
+
+	must(markers.MakeDefinition("k8s:immutable", markers.DescribesField, Immutable{})).
+		WithHelp(Immutable{}.Help()),
 }
 
 // ValidationIshMarkers are field-and-type markers that don't fall under the
@@ -578,6 +581,33 @@ type XIntOrString struct{}
 //
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Schemaless struct{}
+
+// Immutable marks a field as immutable. Once set, the value cannot be changed.
+// For optional fields, a single transition from unset to set is allowed.
+//
+// Note that immutable fields that are nested below optional fields can still be
+// updated by unsetting the optional parent field and re-setting it again.
+//
+// Examples:
+//
+//	// +k8s:immutable
+//	// +required
+//	Port intstr.IntOrString
+//
+//	// +k8s:immutable
+//	// +optional
+//	TargetPort intstr.IntOrString
+//
+// +controllertools:marker:generateHelp:category="CRD validation"
+type Immutable struct{}
+
+func (m Immutable) ApplyToSchema(_ *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
+	schema.XValidations = append(schema.XValidations, apiextensionsv1.ValidationRule{
+		Rule:    "self == oldSelf",
+		Message: "field is immutable",
+	})
+	return nil
+}
 
 func hasNumericType(schema *apiextensionsv1.JSONSchemaProps) bool {
 	return schema.Type == string(Integer) || schema.Type == string(Number)

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -169,6 +169,17 @@ func (Format) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (Immutable) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "marks a field as immutable. Once set, the value cannot be changed.",
+			Details: "For optional fields, a single transition from unset to set is allowed.\n\nNote that immutable fields that are nested below optional fields can still be\nupdated by unsetting the optional parent field and re-setting it again.\n\nExamples:\n\n\t// +k8s:immutable\n\t// +required\n\tPort intstr.IntOrString\n\n\t// +k8s:immutable\n\t// +optional\n\tTargetPort intstr.IntOrString",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (KubernetesDefault) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -464,6 +464,8 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 		return props
 	}
 
+	var immutableFields []string
+
 	for _, field := range ctx.info.Fields {
 		// Skip if the field is not an inline field, ignoreUnexportedFields is true, and the field is not exported
 		if field.Name != "" && ctx.ignoreUnexportedFields && !ast.IsExported(field.Name) {
@@ -552,11 +554,28 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 			continue
 		}
 
+		if field.Markers.Get("k8s:immutable") != nil {
+			immutableFields = append(immutableFields, fieldName)
+		}
+
 		props.Properties[fieldName] = *propSchema
 	}
 
 	// Ensure the required fields are always listed alphabetically.
 	slices.Sort(props.Required)
+
+	// For optional immutable fields, add a parent-level validation rule to prevent
+	// clearing the field once set. The field-level rule prevents value changes, but
+	// when an optional field is removed, the field-level rule doesn't execute.
+	for _, fieldName := range immutableFields {
+		if slices.Contains(props.Required, fieldName) {
+			continue
+		}
+		props.XValidations = append(props.XValidations, apiextensionsv1.ValidationRule{
+			Rule:    fmt.Sprintf("!has(oldSelf.%s) || has(self.%s)", fieldName, fieldName),
+			Message: fmt.Sprintf("field %s is immutable once set", fieldName),
+		})
+	}
 
 	return props
 }

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 // TODO(directxman12): test this across both versions (right now we're just
 // trusting k/k conversion, which is probably fine though)
 
-//go:generate ../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true,allowDangerousTypes=true paths=./;./deprecated;./unserved;./job/... output:dir=.
+//go:generate ../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true,allowDangerousTypes=true paths=./;./deprecated;./unserved;./job/...;./immutable output:dir=.
 
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1

--- a/pkg/crd/testdata/immutable/types.go
+++ b/pkg/crd/testdata/immutable/types.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package immutable
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+type ImmutableType struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ImmutableSpec `json:"spec"`
+}
+
+// +kubebuilder:object:root=true
+type ImmutableTypeList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ImmutableType `json:"items"`
+}
+
+type ImmutableSpec struct {
+	// +k8s:immutable
+	RequiredString string `json:"requiredString"`
+
+	// +k8s:immutable
+	// +optional
+	OptionalString *string `json:"optionalString,omitempty"`
+
+	// +k8s:immutable
+	// +optional
+	OptionalLiteralString string `json:"optionalLiteralString,omitempty"`
+
+	// +k8s:immutable
+	RequiredStruct NestedStruct `json:"requiredStruct"`
+
+	// +k8s:immutable
+	// +optional
+	OptionalStruct *NestedStruct `json:"optionalStruct,omitempty"`
+
+	// +k8s:immutable
+	// +optional
+	OptionalOmitZeroStruct NestedStruct `json:"optionalOmitZeroStruct,omitzero"`
+
+	// +k8s:immutable
+	RequiredSlice []string `json:"requiredSlice"`
+
+	// +k8s:immutable
+	// +optional
+	OptionalSlice []string `json:"optionalSlice,omitempty"`
+
+	// +k8s:immutable
+	RequiredMap map[string]string `json:"requiredMap"`
+
+	// +k8s:immutable
+	// +optional
+	OptionalMap map[string]string `json:"optionalMap,omitempty"`
+
+	MutableString string `json:"mutableString"`
+}
+
+type NestedStruct struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}

--- a/pkg/crd/testdata/immutable_test.go
+++ b/pkg/crd/testdata/immutable_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cronjob
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Immutable CRD", func() {
+	newObj := func(name string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "testdata.kubebuilder.io/v1",
+				"kind":       "ImmutableType",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": "default",
+				},
+				"spec": map[string]any{
+					"requiredString": "original",
+					"requiredStruct": map[string]any{
+						"key":   "k",
+						"value": "v",
+					},
+					"requiredSlice": []any{"a", "b"},
+					"requiredMap":   map[string]any{"k1": "v1"},
+					"mutableString": "can-change",
+				},
+			},
+		}
+	}
+
+	It("should allow creation", func(ctx SpecContext) {
+		obj := newObj("test-create")
+		Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+	})
+
+	It("should allow update with identical immutable values", func(ctx SpecContext) {
+		obj := newObj("test-noop")
+		Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+
+		got := obj.DeepCopy()
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+
+		Expect(unstructured.SetNestedField(got.Object, "updated", "spec", "mutableString")).To(Succeed())
+		Expect(k8sClient.Update(ctx, got)).To(Succeed())
+	})
+
+	DescribeTable("should reject changing an immutable required field",
+		func(ctx SpecContext, name string, mutate, clear func(*unstructured.Unstructured)) {
+			obj := newObj(name)
+			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+
+			got := obj.DeepCopy()
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+
+			mutate(got)
+			Expect(k8sClient.Update(ctx, got)).To(MatchError(ContainSubstring("field is immutable")))
+
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+			clear(got)
+			Expect(k8sClient.Update(ctx, got)).To(MatchError(ContainSubstring("Required value")))
+		},
+		Entry("string", "test-req-str",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, "changed", "spec", "requiredString")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "requiredString")
+			},
+		),
+		Entry("struct", "test-req-struct",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, map[string]any{
+					"key":   "k",
+					"value": "changed",
+				}, "spec", "requiredStruct")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "requiredStruct")
+			},
+		),
+		Entry("slice", "test-req-slice",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedSlice(obj.Object, []any{"a", "c"}, "spec", "requiredSlice")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "requiredSlice")
+			},
+		),
+		Entry("map", "test-req-map",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedStringMap(obj.Object, map[string]string{"k1": "changed"}, "spec", "requiredMap")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "requiredMap")
+			},
+		),
+	)
+
+	DescribeTable("should allow setting an optional field for the first time but reject further changes",
+		func(ctx SpecContext, name string, setInitial, setChanged, clear func(*unstructured.Unstructured)) {
+			obj := newObj(name)
+			Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+
+			got := obj.DeepCopy()
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+
+			Expect(unstructured.SetNestedField(got.Object, "changed", "spec", "requiredString")).To(Succeed())
+			Expect(k8sClient.Update(ctx, got)).To(MatchError(ContainSubstring("field is immutable")))
+
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+
+			setInitial(got)
+			Expect(k8sClient.Update(ctx, got)).To(Succeed())
+
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+			setChanged(got)
+			Expect(k8sClient.Update(ctx, got)).To(MatchError(ContainSubstring("field is immutable")))
+
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(got), got)).To(Succeed())
+			clear(got)
+			Expect(k8sClient.Update(ctx, got)).To(MatchError(ContainSubstring("is immutable once set")))
+		},
+		Entry("string", "test-opt-str",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, "first-value", "spec", "optionalString")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, "second-value", "spec", "optionalString")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "optionalString")
+			},
+		),
+		Entry("literal string", "test-opt-literal-str",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, "first-value", "spec", "optionalLiteralString")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, "second-value", "spec", "optionalLiteralString")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "optionalLiteralString")
+			},
+		),
+		Entry("struct", "test-opt-struct",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, map[string]any{
+					"key":   "k",
+					"value": "v",
+				}, "spec", "optionalStruct")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, map[string]any{
+					"key":   "k",
+					"value": "changed",
+				}, "spec", "optionalStruct")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "optionalStruct")
+			},
+		),
+		Entry("omitZeroStruct", "test-opt-zero-struct",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, map[string]any{
+					"key":   "k",
+					"value": "v",
+				}, "spec", "optionalOmitZeroStruct")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedField(obj.Object, map[string]any{
+					"key":   "k",
+					"value": "changed",
+				}, "spec", "optionalOmitZeroStruct")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "optionalOmitZeroStruct")
+			},
+		),
+		Entry("slice", "test-opt-slice",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedSlice(obj.Object, []any{"x", "y"}, "spec", "optionalSlice")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedSlice(obj.Object, []any{"x", "z"}, "spec", "optionalSlice")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "optionalSlice")
+			},
+		),
+		Entry("map", "test-opt-map",
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedStringMap(obj.Object, map[string]string{"a": "1"}, "spec", "optionalMap")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				Expect(unstructured.SetNestedStringMap(obj.Object, map[string]string{"a": "2"}, "spec", "optionalMap")).To(Succeed())
+			},
+			func(obj *unstructured.Unstructured) {
+				unstructured.RemoveNestedField(obj.Object, "spec", "optionalMap")
+			},
+		),
+	)
+})

--- a/pkg/crd/testdata/suite_test.go
+++ b/pkg/crd/testdata/suite_test.go
@@ -37,11 +37,10 @@ func TestCRD(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	testEnv = &envtest.Environment{
-		CRDInstallOptions: envtest.CRDInstallOptions{
-			Paths: []string{"testdata.kubebuilder.io_enums.yaml"},
-		},
-	}
+	testEnv = &envtest.Environment{CRDInstallOptions: envtest.CRDInstallOptions{Paths: []string{
+		"testdata.kubebuilder.io_enums.yaml",
+		"testdata.kubebuilder.io_immutabletypes.yaml",
+	}}}
 
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/crd/testdata/testdata.kubebuilder.io_immutabletypes.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_immutabletypes.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  name: immutabletypes.testdata.kubebuilder.io
+spec:
+  group: testdata.kubebuilder.io
+  names:
+    kind: ImmutableType
+    listKind: ImmutableTypeList
+    plural: immutabletypes
+    singular: immutabletype
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              mutableString:
+                type: string
+              optionalLiteralString:
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              optionalMap:
+                additionalProperties:
+                  type: string
+                type: object
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              optionalOmitZeroStruct:
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+                - value
+                type: object
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              optionalSlice:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              optionalString:
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              optionalStruct:
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+                - value
+                type: object
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              requiredMap:
+                additionalProperties:
+                  type: string
+                type: object
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              requiredSlice:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              requiredString:
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              requiredStruct:
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+                required:
+                - key
+                - value
+                type: object
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+            required:
+            - mutableString
+            - requiredMap
+            - requiredSlice
+            - requiredString
+            - requiredStruct
+            type: object
+            x-kubernetes-validations:
+            - message: field optionalString is immutable once set
+              rule: '!has(oldSelf.optionalString) || has(self.optionalString)'
+            - message: field optionalLiteralString is immutable once set
+              rule: '!has(oldSelf.optionalLiteralString) || has(self.optionalLiteralString)'
+            - message: field optionalStruct is immutable once set
+              rule: '!has(oldSelf.optionalStruct) || has(self.optionalStruct)'
+            - message: field optionalOmitZeroStruct is immutable once set
+              rule: '!has(oldSelf.optionalOmitZeroStruct) || has(self.optionalOmitZeroStruct)'
+            - message: field optionalSlice is immutable once set
+              rule: '!has(oldSelf.optionalSlice) || has(self.optionalSlice)'
+            - message: field optionalMap is immutable once set
+              rule: '!has(oldSelf.optionalMap) || has(self.optionalMap)'
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
This change adds support for `k8s:immutable` as described in the [KEP][0].

It replaces https://github.com/kubernetes-sigs/controller-tools/pull/1216 and follows @jpbetz [suggestion](https://github.com/kubernetes-sigs/controller-tools/pull/1216#issuecomment-3001177470) for the CEL expression. It also adds integration tests.

Closes #1216

[0]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
