### PR TITLE
 ✨ feat(crd):add k8s:listType and k8s:listMapKey markers

### DIFF
--- a/pkg/crd/markers/topology.go
+++ b/pkg/crd/markers/topology.go
@@ -42,6 +42,14 @@ var TopologyMarkers = []*definitionWithHelp{
 		WithHelp(StructType("").Help()),
 	must(markers.MakeDefinition("structType", markers.DescribesType, StructType(""))).
 		WithHelp(StructType("").Help()),
+	must(markers.MakeDefinition("k8s:listType", markers.DescribesField, ListType(""))).
+		WithHelp(ListType("").Help()),
+	must(markers.MakeDefinition("k8s:listType", markers.DescribesType, ListType(""))).
+		WithHelp(ListType("").Help()),
+	must(markers.MakeDefinition("k8s:listMapKey", markers.DescribesField, ListMapKey(""))).
+		WithHelp(ListMapKey("").Help()),
+	must(markers.MakeDefinition("k8s:listMapKey", markers.DescribesType, ListMapKey(""))).
+		WithHelp(ListMapKey("").Help()),
 }
 
 func init() {

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -212,8 +212,24 @@ type CronJobSpec struct {
 	// +listMapKey=secondary
 	AssociativeList []AssociativeType `json:"associativeList"`
 
+	// This tests that associative lists work using the +k8s:listType alias.
+	// +k8s:listType=map
+	// +k8s:listMapKey=name
+	K8sAssociativeList []AssociativeType `json:"k8sAssociativeList"`
+
+	// This tests that +k8s:listType=set works.
+	// +k8s:listType=set
+	K8sSetList []string `json:"k8sSetList,omitempty"`
+
+	// This tests that +k8s:listType=atomic works.
+	// +k8s:listType=atomic
+	K8sAtomicList []string `json:"k8sAtomicList,omitempty"`
+
 	// This tests that associative lists work via a nested type.
 	NestedAssociativeList NestedAssociativeList `json:"nestedassociativeList"`
+
+	// This tests that associative lists work via a nested type using the +k8s:listType alias.
+	K8sNestedAssociativeList K8sNestedAssociativeList `json:"k8sNestedAssociativeList"`
 
 	// A map that allows different actors to manage different fields
 	// +mapType=granular
@@ -554,6 +570,11 @@ type AssociativeType struct {
 // +listMapKey=name
 // +listMapKey=secondary
 type NestedAssociativeList []AssociativeType
+
+// +k8s:listType=map
+// +k8s:listMapKey=name
+// +k8s:listMapKey=secondary
+type K8sNestedAssociativeList []AssociativeType
 
 // +mapType=granular
 type NestedMapOfInfo map[string][]byte

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9353,18 +9353,6 @@ spec:
                 - bar
                 - foo
                 type: object
-              k8sConcurrencyPolicy:
-                description: |-
-                  Specifies how to treat concurrent executions of a Job.
-                  Valid values are:
-                  - "Allow" (default): allows CronJobs to run concurrently;
-                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
-                  - "Replace": cancels currently running job and replaces it with a new one
-                enum:
-                - Allow
-                - Forbid
-                - Replace
-                type: string
               k8sAssociativeList:
                 description: This tests that associative lists work using the +k8s:listType
                   alias.
@@ -9391,6 +9379,18 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
+              k8sConcurrencyPolicy:
+                description: |-
+                  Specifies how to treat concurrent executions of a Job.
+                  Valid values are:
+                  - "Allow" (default): allows CronJobs to run concurrently;
+                  - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
+                  - "Replace": cancels currently running job and replaces it with a new one
+                enum:
+                - Allow
+                - Forbid
+                - Replace
+                type: string
               k8sNestedAssociativeList:
                 description: This tests that associative lists work via a nested type
                   using the +k8s:listType alias.

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9365,6 +9365,59 @@ spec:
                 - Forbid
                 - Replace
                 type: string
+              k8sAssociativeList:
+                description: This tests that associative lists work using the +k8s:listType
+                  alias.
+                items:
+                  properties:
+                    foo:
+                      type: string
+                    name:
+                      type: string
+                    secondary:
+                      type: integer
+                  required:
+                  - foo
+                  - name
+                  - secondary
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              k8sAtomicList:
+                description: This tests that +k8s:listType=atomic works.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              k8sNestedAssociativeList:
+                description: This tests that associative lists work via a nested type
+                  using the +k8s:listType alias.
+                items:
+                  properties:
+                    foo:
+                      type: string
+                    name:
+                      type: string
+                    secondary:
+                      type: integer
+                  required:
+                  - foo
+                  - name
+                  - secondary
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - secondary
+                x-kubernetes-list-type: map
+              k8sSetList:
+                description: This tests that +k8s:listType=set works.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               kubernetesDefaultedEmptyMap:
                 additionalProperties:
                   type: string
@@ -9752,6 +9805,8 @@ spec:
             - int32WithValidations
             - intWithValidations
             - jobTemplate
+            - k8sAssociativeList
+            - k8sNestedAssociativeList
             - kubernetesDefaultedEmptyMap
             - kubernetesDefaultedEmptyObject
             - kubernetesDefaultedEmptySlice


### PR DESCRIPTION
### What does this do, and why do we need it? 

This PR adds +k8s:listType and +k8s:listMapKey as declarative validation tag aliases in the crd marker system. These tags allow authors to annotate list fields using the stable k8s: prefix convention.

These IDL tags are introduced as part of the KEP for declarative validation: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/5073-declarative-validation-with-validation-gen/README.md