### PR TITLE
🌱chore: Update golangci-lint version to v2.10.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,6 +33,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # tag=v9.2.0
         with:
-          version: v2.8.0
+          version: v2.10.1
           args: --output.text.print-linter-name=true --output.text.colors=true --timeout 10m
           working-directory: ${{matrix.working-directory}}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package version //nolint:revive
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->

Fix
```
pkg/version/version_test.go:17:9: var-naming: avoid package names that conflict with Go standard library package names (revive)
package version
```
