### PR TITLE
🐛  fix +listType marker not working on type alias fields

### DIFF
--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -112,7 +112,7 @@ func resolveFieldConflict(fieldName string, srcField, dstField reflect.Value, sr
 	case "XPreserveUnknownFields":
 		dstField.Set(srcField)
 		return false
-	case "XMapType":
+	case "XMapType", "XListType", "XListMapKeys":
 		dstField.Set(srcField)
 		return false
 	case "XValidations":

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -38,6 +38,9 @@ import (
 const (
 	// defPrefix is the prefix used to link to definitions in the OpenAPI schema.
 	defPrefix = "#/definitions/"
+
+	// arrayType is the JSON schema type for arrays.
+	arrayType = "array"
 )
 
 // byteType is the types.Type for byte (see the types documention
@@ -237,7 +240,7 @@ func applyMarkers(ctx *schemaContext, markerSet markers.MarkerValues, props *api
 	}
 
 	for _, schemaMarker := range itemsMarkers {
-		if props.Type != "array" || props.Items == nil || props.Items.Schema == nil {
+		if props.Type != arrayType || props.Items == nil || props.Items.Schema == nil {
 			err := fmt.Errorf("must apply %s to an array value, found %s", schemaMarker.Name, props.Type)
 			ctx.pkg.AddError(loader.ErrFromNode(err, node))
 		} else {
@@ -348,26 +351,30 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		ctx.requestSchemaWithPkg(pkgPath, typeNameInfo.Name(), pkg)
 		link := TypeRefLink(pkgPath, typeNameInfo.Name())
 
-		// In cases where we have a named type, apply the type and format from the named schema
-		// to allow markers that need this information to apply correctly.
-		var typ, fmt string
-		if namedInfo, isNamed := typeInfo.(*types.Named); isNamed {
+		props := &apiextensionsv1.JSONSchemaProps{
+			Ref: &link,
+		}
+
+		// Set the type for slice and map aliases so field-level markers like +listType
+		// and +mapType can work. Structs are skipped — they use a $ref only.
+		// Go 1.23+ (gotypesalias=1) represents `type Foo = []T` as *types.Alias, so
+		// unalias first to reach the real underlying type.
+		switch types.Unalias(typeInfo.(types.Type)).Underlying().(type) {
+		case *types.Slice:
+			props.Type = arrayType
+		case *types.Map:
+			//nolint:goconst
+			props.Type = "object"
+		case *types.Basic:
 			// We don't want/need to do this for structs, maps, or arrays.
 			// These are already handled in infoToSchema if they have custom marshalling.
-			if _, isBasic := namedInfo.Underlying().(*types.Basic); isBasic {
-				namedTypeInfo := ctx.schemaRequester.LookupType(ctx.pkg, namedInfo.Obj().Name())
-
-				namedSchema := infoToSchema(ctx.ForInfo(namedTypeInfo))
-				typ = namedSchema.Type
-				fmt = namedSchema.Format
-			}
+			namedTypeInfo := ctx.schemaRequester.LookupType(ctx.pkg, typeNameInfo.Name())
+			namedSchema := infoToSchema(ctx.ForInfo(namedTypeInfo))
+			props.Type = namedSchema.Type
+			props.Format = namedSchema.Format
 		}
 
-		return &apiextensionsv1.JSONSchemaProps{
-			Type:   typ,
-			Format: fmt,
-			Ref:    &link,
-		}
+		return props
 	default:
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unsupported type %T for identifier %s", typeInfo, ident.Name), ident))
 		return &apiextensionsv1.JSONSchemaProps{}
@@ -391,10 +398,19 @@ func namedToSchema(ctx *schemaContext, named *ast.SelectorExpr) *apiextensionsv1
 	nonVendorPath := loader.NonVendorPath(typesPkg.Path())
 	ctx.requestSchemaWithPkg(nonVendorPath, typeNameInfo.Name(), typesPkg)
 	link := TypeRefLink(nonVendorPath, typeNameInfo.Name())
-	return &apiextensionsv1.JSONSchemaProps{
+	// Set the type for slice and map aliases so field-level markers like +listType
+	// and +mapType can work. Structs are skipped — they use a $ref only.
+	props := &apiextensionsv1.JSONSchemaProps{
 		Ref: &link,
 	}
+	switch typeInfoRaw.Underlying().(type) {
+	case *types.Slice:
+		props.Type = arrayType
+	case *types.Map:
+		props.Type = "object"
+	}
 	// NB(directxman12): we special-case things like resource.Quantity during the "collapse" phase.
+	return props
 }
 
 // arrayToSchema creates a schema for the items of the given array, dealing appropriately
@@ -413,7 +429,7 @@ func arrayToSchema(ctx *schemaContext, array *ast.ArrayType) *apiextensionsv1.JS
 	items := typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), array.Elt)
 
 	return &apiextensionsv1.JSONSchemaProps{
-		Type:  "array",
+		Type:  arrayType,
 		Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: items},
 	}
 }
@@ -471,9 +487,7 @@ func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiextensionsv1.JSON
 		return &apiextensionsv1.JSONSchemaProps{}
 	}
 
-	//nolint:goconst
 	return &apiextensionsv1.JSONSchemaProps{
-		//nolint:goconst // this is a constant, but it's more readable to have it here
 		Type: "object",
 		AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
 			Schema: valSchema,

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -232,9 +232,26 @@ type CronJobSpec struct {
 	// This tests that associative lists work via a nested type using the +k8s:listType alias.
 	K8sNestedAssociativeList K8sNestedAssociativeList `json:"k8sNestedAssociativeList"`
 
+	// This tests that +listType can be applied at the field level for type aliases (issue #988).
+	// +listType=map
+	// +listMapKey=name
+	// +listMapKey=secondary
+	FieldLevelListType ConditionsWithoutMarker `json:"fieldLevelListType"`
+
+	// This tests that a field-level +listType combined with a type-level +listType
+	// is preserved at the top level instead of being wiped into allOf (issue #988).
+	// +listType=map
+	// +listMapKey=name
+	// +listMapKey=secondary
+	ListTypeFromTypeAndField NestedAssociativeList `json:"listTypeFromTypeAndField"`
+
 	// A map that allows different actors to manage different fields
 	// +mapType=granular
 	MapOfInfo map[string][]byte `json:"mapOfInfo"`
+
+	// This tests that +mapType can be applied at the field level for type aliases (issue #988).
+	// +mapType=granular
+	FieldLevelMapType MapWithoutMarker `json:"fieldLevelMapType"`
 
 	// A map that allows different actors to manage different fields via a nested type.
 	NestedMapOfInfo NestedMapOfInfo `json:"nestedMapOfInfo"`
@@ -599,6 +616,14 @@ type K8sNestedAssociativeList []AssociativeType
 
 // +mapType=granular
 type NestedMapOfInfo map[string][]byte
+
+// ConditionsWithoutMarker is a type alias to a slice without type-level markers.
+// This tests that +listType can be applied at the field level (issue #988).
+type ConditionsWithoutMarker []AssociativeType
+
+// MapWithoutMarker is a type alias to a map without type-level markers.
+// This tests that +mapType can be applied at the field level (issue #988).
+type MapWithoutMarker map[string][]byte
 
 // +kubebuilder:validation:MinLength=4
 // This tests that markers that are allowed on both fields and types are applied to types

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -235,6 +235,27 @@ spec:
                   This tests that field-level overrides are handled correctly
                   for local type aliases.
                 type: string
+              fieldLevelListType:
+                description: 'This tests that +listType can be applied at the field
+                  level for type aliases (issue #988).'
+                items:
+                  properties:
+                    foo:
+                      type: string
+                    name:
+                      type: string
+                    secondary:
+                      type: integer
+                  required:
+                  - foo
+                  - name
+                  - secondary
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - secondary
+                x-kubernetes-list-type: map
               fieldLevelLocalDeclarationOverride:
                 allOf:
                 - minLength: 4
@@ -244,6 +265,14 @@ spec:
                   for local type declarations.
                 maxLength: 10
                 type: string
+              fieldLevelMapType:
+                additionalProperties:
+                  format: byte
+                  type: string
+                description: 'This tests that +mapType can be applied at the field
+                  level for type aliases (issue #988).'
+                type: object
+                x-kubernetes-map-type: granular
               float64WithValidations:
                 maximum: 1.5
                 minimum: -0.5
@@ -9501,6 +9530,28 @@ spec:
                 default: forty-two
                 description: This tests that primitive defaulting can be performed.
                 type: string
+              listTypeFromTypeAndField:
+                description: |-
+                  This tests that a field-level +listType combined with a type-level +listType
+                  is preserved at the top level instead of being wiped into allOf (issue #988).
+                items:
+                  properties:
+                    foo:
+                      type: string
+                    name:
+                      type: string
+                    secondary:
+                      type: integer
+                  required:
+                  - foo
+                  - name
+                  - secondary
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - secondary
+                x-kubernetes-list-type: map
               locallyBoundedInteger:
                 description: |-
                   This tests that unmarkered types are handled correctly.
@@ -9824,6 +9875,8 @@ spec:
             - explicitlyRequiredK8s
             - explicitlyRequiredKubebuilder
             - explicitlyRequiredKubernetes
+            - fieldLevelListType
+            - fieldLevelMapType
             - float64WithValidations
             - floatWithValidations
             - foo
@@ -9838,6 +9891,7 @@ spec:
             - kubernetesDefaultedObject
             - kubernetesDefaultedSlice
             - kubernetesDefaultedString
+            - listTypeFromTypeAndField
             - mapOfInfo
             - nestedMapOfInfo
             - nestedStructWithSeveralFields


### PR DESCRIPTION
Include underlying type info (array/object) in schema for slice/map type aliases, allowing field-level markers like +listType to work.

Fixes #988

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
