### PR TITLE
✨Implement opaque declarative validation marker

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -42,7 +42,8 @@ const (
 	ValidationAtLeastOneOfPrefix = validationPrefix + "AtLeastOneOf"
 
 	// K8sEnumTag indicates that the given type is an enum; all const values of this type are considered values in the enum
-	K8sEnumTag = "k8s:enum"
+	K8sEnumTag      = "k8s:enum"
+	OpaqueFieldName = "k8s:opaque"
 )
 
 // ValidationMarkers lists all available markers that affect CRD schema generation,
@@ -137,6 +138,8 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("k8s:immutable", markers.DescribesField, Immutable{})).
 		WithHelp(Immutable{}.Help()),
+	must(markers.MakeDefinition(OpaqueFieldName, markers.DescribesField, Opaque{})).
+		WithHelp(Opaque{}.Help()),
 }
 
 // ValidationIshMarkers are field-and-type markers that don't fall under the
@@ -608,6 +611,12 @@ func (m Immutable) ApplyToSchema(_ *SchemaContext, schema *apiextensionsv1.JSONS
 	})
 	return nil
 }
+
+// Opaque instructs the CRD generator to suppress inheritance of type-level
+// validation for this field. Field-level markers still apply.
+//
+// +controllertools:marker:generateHelp:category="CRD validation"
+type Opaque struct{}
 
 func hasNumericType(schema *apiextensionsv1.JSONSchemaProps) bool {
 	return schema.Type == string(Integer) || schema.Type == string(Number)

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -42,8 +42,8 @@ const (
 	ValidationAtLeastOneOfPrefix = validationPrefix + "AtLeastOneOf"
 
 	// K8sEnumTag indicates that the given type is an enum; all const values of this type are considered values in the enum
-	K8sEnumTag      = "k8s:enum"
-	OpaqueFieldName = "k8s:opaque"
+	K8sEnumTag          = "k8s:enum"
+	OpaqueTypeFieldName = "k8s:opaqueType"
 )
 
 // ValidationMarkers lists all available markers that affect CRD schema generation,
@@ -138,8 +138,8 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("k8s:immutable", markers.DescribesField, Immutable{})).
 		WithHelp(Immutable{}.Help()),
-	must(markers.MakeDefinition(OpaqueFieldName, markers.DescribesField, Opaque{})).
-		WithHelp(Opaque{}.Help()),
+	must(markers.MakeDefinition(OpaqueTypeFieldName, markers.DescribesField, OpaqueType{})).
+		WithHelp(OpaqueType{}.Help()),
 }
 
 // ValidationIshMarkers are field-and-type markers that don't fall under the
@@ -612,11 +612,11 @@ func (m Immutable) ApplyToSchema(_ *SchemaContext, schema *apiextensionsv1.JSONS
 	return nil
 }
 
-// Opaque instructs the CRD generator to suppress inheritance of type-level
+// OpaqueType instructs the CRD generator to suppress inheritance of type-level
 // validation for this field. Field-level markers still apply.
 //
 // +controllertools:marker:generateHelp:category="CRD validation"
-type Opaque struct{}
+type OpaqueType struct{}
 
 func hasNumericType(schema *apiextensionsv1.JSONSchemaProps) bool {
 	return schema.Type == string(Integer) || schema.Type == string(Number)

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -359,6 +359,17 @@ func (Nullable) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (Opaque) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "instructs the CRD generator to suppress inheritance of type-level",
+			Details: "validation for this field. Field-level markers still apply.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (Pattern) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -359,7 +359,7 @@ func (Nullable) Help() *markers.DefinitionHelp {
 	}
 }
 
-func (Opaque) Help() *markers.DefinitionHelp {
+func (OpaqueType) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -73,6 +73,7 @@ type schemaContext struct {
 
 	allowDangerousTypes    bool
 	ignoreUnexportedFields bool
+	opaque                 bool
 }
 
 // newSchemaContext constructs a new schemaContext for the given package and schema requester.
@@ -97,6 +98,16 @@ func (c *schemaContext) ForInfo(info *markers.TypeInfo) *schemaContext {
 		allowDangerousTypes:    c.allowDangerousTypes,
 		ignoreUnexportedFields: c.ignoreUnexportedFields,
 	}
+}
+
+// ForInfoOpaque produces a new schemaContext with containing the same information
+// as this one, except with the given type information and marked as opaque.
+// An opaque context prevents the emission of $ref to the type's schema, suppressing
+// inherited type-level validations.
+func (c *schemaContext) ForInfoOpaque(info *markers.TypeInfo) *schemaContext {
+	ctx := c.ForInfo(info)
+	ctx.opaque = true
+	return ctx
 }
 
 // requestSchema asks for the schema for a type in the package with the
@@ -321,6 +332,12 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		// > Otherwise, the alias information is only in the type name, which
 		// > points directly to the actual (aliased) type.
 		if typeInfo.Name() != ident.Name {
+			if ctx.opaque {
+				return &apiextensionsv1.JSONSchemaProps{
+					Type:   typ,
+					Format: fmt,
+				}
+			}
 			ctx.requestSchema("", ident.Name)
 			link := TypeRefLink("", ident.Name)
 			return &apiextensionsv1.JSONSchemaProps{
@@ -345,8 +362,6 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		if pkg == ctx.pkg.Types {
 			pkgPath = ""
 		}
-		ctx.requestSchemaWithPkg(pkgPath, typeNameInfo.Name(), pkg)
-		link := TypeRefLink(pkgPath, typeNameInfo.Name())
 
 		// In cases where we have a named type, apply the type and format from the named schema
 		// to allow markers that need this information to apply correctly.
@@ -363,11 +378,18 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 			}
 		}
 
-		return &apiextensionsv1.JSONSchemaProps{
+		props := &apiextensionsv1.JSONSchemaProps{
 			Type:   typ,
 			Format: fmt,
-			Ref:    &link,
 		}
+
+		if !ctx.opaque {
+			ctx.requestSchemaWithPkg(pkgPath, typeNameInfo.Name(), pkg)
+			link := TypeRefLink(pkgPath, typeNameInfo.Name())
+			props.Ref = &link
+		}
+
+		return props
 	default:
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unsupported type %T for identifier %s", typeInfo, ident.Name), ident))
 		return &apiextensionsv1.JSONSchemaProps{}
@@ -592,9 +614,12 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 		}
 
 		var propSchema *apiextensionsv1.JSONSchemaProps
-		if field.Markers.Get(crdmarkers.SchemalessName) != nil {
+		switch {
+		case field.Markers.Get(crdmarkers.SchemalessName) != nil:
 			propSchema = &apiextensionsv1.JSONSchemaProps{}
-		} else {
+		case field.Markers.Get(crdmarkers.OpaqueFieldName) != nil:
+			propSchema = typeToSchema(ctx.ForInfoOpaque(&markers.TypeInfo{}), field.RawField.Type)
+		default:
 			propSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), field.RawField.Type)
 		}
 		propSchema.Description = field.Doc

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -73,6 +73,7 @@ type schemaContext struct {
 
 	allowDangerousTypes    bool
 	ignoreUnexportedFields bool
+	opaque                 bool
 }
 
 // newSchemaContext constructs a new schemaContext for the given package and schema requester.
@@ -97,6 +98,16 @@ func (c *schemaContext) ForInfo(info *markers.TypeInfo) *schemaContext {
 		allowDangerousTypes:    c.allowDangerousTypes,
 		ignoreUnexportedFields: c.ignoreUnexportedFields,
 	}
+}
+
+// ForInfoOpaque produces a new schemaContext with containing the same information
+// as this one, except with the given type information and marked as opaque.
+// An opaque context prevents the emission of $ref to the type's schema, suppressing
+// inherited type-level validations.
+func (c *schemaContext) ForInfoOpaque(info *markers.TypeInfo) *schemaContext {
+	ctx := c.ForInfo(info)
+	ctx.opaque = true
+	return ctx
 }
 
 // requestSchema asks for the schema for a type in the package with the
@@ -321,6 +332,12 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		// > Otherwise, the alias information is only in the type name, which
 		// > points directly to the actual (aliased) type.
 		if typeInfo.Name() != ident.Name {
+			if ctx.opaque {
+				return &apiextensionsv1.JSONSchemaProps{
+					Type:   typ,
+					Format: fmt,
+				}
+			}
 			ctx.requestSchema("", ident.Name)
 			link := TypeRefLink("", ident.Name)
 			return &apiextensionsv1.JSONSchemaProps{
@@ -345,8 +362,6 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		if pkg == ctx.pkg.Types {
 			pkgPath = ""
 		}
-		ctx.requestSchemaWithPkg(pkgPath, typeNameInfo.Name(), pkg)
-		link := TypeRefLink(pkgPath, typeNameInfo.Name())
 
 		// In cases where we have a named type, apply the type and format from the named schema
 		// to allow markers that need this information to apply correctly.
@@ -363,11 +378,18 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 			}
 		}
 
-		return &apiextensionsv1.JSONSchemaProps{
+		props := &apiextensionsv1.JSONSchemaProps{
 			Type:   typ,
 			Format: fmt,
-			Ref:    &link,
 		}
+
+		if !ctx.opaque {
+			ctx.requestSchemaWithPkg(pkgPath, typeNameInfo.Name(), pkg)
+			link := TypeRefLink(pkgPath, typeNameInfo.Name())
+			props.Ref = &link
+		}
+
+		return props
 	default:
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unsupported type %T for identifier %s", typeInfo, ident.Name), ident))
 		return &apiextensionsv1.JSONSchemaProps{}
@@ -593,9 +615,12 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 		}
 
 		var propSchema *apiextensionsv1.JSONSchemaProps
-		if field.Markers.Get(crdmarkers.SchemalessName) != nil {
+		switch {
+		case field.Markers.Get(crdmarkers.SchemalessName) != nil:
 			propSchema = &apiextensionsv1.JSONSchemaProps{}
-		} else {
+		case field.Markers.Get(crdmarkers.OpaqueFieldName) != nil:
+			propSchema = typeToSchema(ctx.ForInfoOpaque(&markers.TypeInfo{}), field.RawField.Type)
+		default:
 			propSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), field.RawField.Type)
 		}
 		propSchema.Description = field.Doc

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -97,6 +97,7 @@ func (c *schemaContext) ForInfo(info *markers.TypeInfo) *schemaContext {
 		schemaRequester:        c.schemaRequester,
 		allowDangerousTypes:    c.allowDangerousTypes,
 		ignoreUnexportedFields: c.ignoreUnexportedFields,
+		opaque:                 c.opaque,
 	}
 }
 
@@ -411,6 +412,36 @@ func namedToSchema(ctx *schemaContext, named *ast.SelectorExpr) *apiextensionsv1
 	typeNameInfo := typeInfo.Obj()
 	typesPkg := typeNameInfo.Pkg()
 	nonVendorPath := loader.NonVendorPath(typesPkg.Path())
+
+	if ctx.opaque {
+		typeInfoToCheck := typeInfoRaw
+		if aliasInfo, isAlias := typeInfoToCheck.(*types.Alias); isAlias {
+			typeInfoToCheck = aliasInfo.Rhs()
+		}
+		if namedInfo, isNamed := typeInfoToCheck.(*types.Named); isNamed {
+			if basic, isBasic := namedInfo.Underlying().(*types.Basic); isBasic {
+				typ, fmt, err := builtinToType(basic, ctx.allowDangerousTypes)
+				if err != nil {
+					ctx.pkg.AddError(loader.ErrFromNode(err, named))
+				}
+				return &apiextensionsv1.JSONSchemaProps{
+					Type:   typ,
+					Format: fmt,
+				}
+			}
+		}
+		if basic, isBasic := typeInfoToCheck.(*types.Basic); isBasic {
+			typ, fmt, err := builtinToType(basic, ctx.allowDangerousTypes)
+			if err != nil {
+				ctx.pkg.AddError(loader.ErrFromNode(err, named))
+			}
+			return &apiextensionsv1.JSONSchemaProps{
+				Type:   typ,
+				Format: fmt,
+			}
+		}
+	}
+
 	ctx.requestSchemaWithPkg(nonVendorPath, typeNameInfo.Name(), typesPkg)
 	link := TypeRefLink(nonVendorPath, typeNameInfo.Name())
 	return &apiextensionsv1.JSONSchemaProps{
@@ -618,7 +649,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 		switch {
 		case field.Markers.Get(crdmarkers.SchemalessName) != nil:
 			propSchema = &apiextensionsv1.JSONSchemaProps{}
-		case field.Markers.Get(crdmarkers.OpaqueFieldName) != nil:
+		case field.Markers.Get(crdmarkers.OpaqueTypeFieldName) != nil:
 			propSchema = typeToSchema(ctx.ForInfoOpaque(&markers.TypeInfo{}), field.RawField.Type)
 		default:
 			propSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), field.RawField.Type)

--- a/pkg/crd/testdata/crd_test.go
+++ b/pkg/crd/testdata/crd_test.go
@@ -16,13 +16,16 @@ limitations under the License.
 package cronjob
 
 import (
+	"context"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 )
 
@@ -37,6 +40,102 @@ var _ = Describe("CronJob CRD", func() {
 
 		err = k8sClient.Create(ctx, crd)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("validating opaque markers", func() {
+		applyCronJob := func(ctx context.Context, name, opaqueVal, nonOpaqueVal string) error {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "testdata.kubebuilder.io",
+				Version: "v1",
+				Kind:    "CronJob",
+			})
+			obj.SetName(name)
+			obj.SetNamespace("default")
+
+			spec := map[string]interface{}{
+				"schedule":                      "*/5 * * * *", // required field
+				"foo":                           "bar",
+				"baz":                           "baz",
+				"binaryName":                    "YmluYXJ5", // base64 for "binary"
+				"canBeNull":                     "ok",
+				"defaultedEmptyMap":             map[string]interface{}{},
+				"defaultedEmptyObject":          map[string]interface{}{},
+				"defaultedEmptySlice":           []interface{}{},
+				"defaultedObject":               []interface{}{},
+				"defaultedSlice":                []interface{}{},
+				"defaultedString":               "some string",
+				"doubleDefaultedString":         "some string",
+				"embeddedResource":              map[string]interface{}{"kind": "Pod", "apiVersion": "v1"},
+				"explicitlyRequiredK8s":         "required",
+				"explicitlyRequiredKubebuilder": "required",
+				"explicitlyRequiredKubernetes":  "required",
+				"float64WithValidations":        1.5,
+				"floatWithValidations":          1.5,
+				"int32WithValidations":          2,
+				"intWithValidations":            2,
+				"jobTemplate": map[string]interface{}{
+					"template": map[string]interface{}{},
+				},
+				"kubernetesDefaultedEmptyMap":               map[string]interface{}{},
+				"kubernetesDefaultedEmptyObject":            map[string]interface{}{},
+				"kubernetesDefaultedEmptySlice":             []interface{}{},
+				"kubernetesDefaultedObject":                 []interface{}{},
+				"kubernetesDefaultedSlice":                  []interface{}{},
+				"kubernetesDefaultedString":                 "string",
+				"mapOfInfo":                                 map[string]interface{}{},
+				"nestedMapOfInfo":                           map[string]interface{}{},
+				"nestedStructWithSeveralFields":             map[string]interface{}{"foo": "str", "bar": true},
+				"nestedStructWithSeveralFieldsDoubleMarked": map[string]interface{}{"foo": "str", "bar": true},
+				"nestedassociativeList":                     []interface{}{},
+				"k8sAssociativeList":                        []interface{}{},
+				"k8sNestedAssociativeList":                  []interface{}{},
+				"patternObject":                             "https://example.com",
+				"stringPair":                                []interface{}{"a", "b"},
+				"structWithSeveralFields":                   map[string]interface{}{"foo": "str", "bar": true},
+				"twoOfAKindPart0":                           "longenough",
+				"twoOfAKindPart1":                           "longenough",
+				"unprunedEmbeddedResource":                  map[string]interface{}{"kind": "Pod", "apiVersion": "v1"},
+				"unprunedFomType":                           map[string]interface{}{},
+				"unprunedFomTypeAndField":                   map[string]interface{}{},
+				"unprunedJSON":                              map[string]interface{}{"foo": "str", "bar": true},
+				"associativeList":                           []interface{}{},
+			}
+			if opaqueVal != "" {
+				spec["opaqueField"] = opaqueVal
+			}
+			if nonOpaqueVal != "" {
+				spec["nonOpaqueField"] = nonOpaqueVal
+			}
+			obj.Object["spec"] = spec
+
+			return k8sClient.Create(ctx, obj)
+		}
+
+		It("should suppress type-level validation for fields with +k8s:opaque", func(ctx SpecContext) {
+			// type-level validation is MinLength=4
+			// field-level validation is MaxLength=5
+
+			By("allowing opaqueField with length 3 (suppresses type-level MinLength=4)")
+			Eventually(func() error {
+				return applyCronJob(ctx, "test-opaque-short", "abc", "")
+			}, 5*time.Second, 1*time.Second).Should(Succeed())
+
+			By("rejecting nonOpaqueField with length 3 (inherits type-level MinLength=4)")
+			err := applyCronJob(ctx, "test-non-opaque-short", "", "abc")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("should be at least 4 chars long"))
+
+			By("rejecting opaqueField with length 6 (applies field-level MaxLength=5)")
+			err = applyCronJob(ctx, "test-opaque-long", "abcdef", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Too long"))
+
+			By("rejecting nonOpaqueField with length 6 (applies field-level MaxLength=5)")
+			err = applyCronJob(ctx, "test-non-opaque-long", "", "abcdef")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Too long"))
+		})
 	})
 })
 

--- a/pkg/crd/testdata/crd_test.go
+++ b/pkg/crd/testdata/crd_test.go
@@ -100,6 +100,7 @@ var _ = Describe("CronJob CRD", func() {
 				"unprunedFomTypeAndField":                   map[string]interface{}{},
 				"unprunedJSON":                              map[string]interface{}{"foo": "str", "bar": true},
 				"associativeList":                           []interface{}{},
+				"duplicateListMapKey":                       []interface{}{},
 			}
 			if opaqueVal != "" {
 				spec["opaqueField"] = opaqueVal

--- a/pkg/crd/testdata/crd_test.go
+++ b/pkg/crd/testdata/crd_test.go
@@ -43,7 +43,7 @@ var _ = Describe("CronJob CRD", func() {
 	})
 
 	Context("validating opaque markers", func() {
-		applyCronJob := func(ctx context.Context, name, opaqueVal, nonOpaqueVal string) error {
+		applyCronJob := func(ctx context.Context, name, opaqueVal, nonOpaqueVal, opaquePointerVal string) error {
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "testdata.kubebuilder.io",
@@ -107,32 +107,45 @@ var _ = Describe("CronJob CRD", func() {
 			if nonOpaqueVal != "" {
 				spec["nonOpaqueField"] = nonOpaqueVal
 			}
+			if opaquePointerVal != "" {
+				spec["opaquePointerField"] = opaquePointerVal
+			}
 			obj.Object["spec"] = spec
 
 			return k8sClient.Create(ctx, obj)
 		}
 
-		It("should suppress type-level validation for fields with +k8s:opaque", func(ctx SpecContext) {
+		It("should suppress type-level validation for fields with +k8s:opaqueType", func(ctx SpecContext) {
 			// type-level validation is MinLength=4
 			// field-level validation is MaxLength=5
 
 			By("allowing opaqueField with length 3 (suppresses type-level MinLength=4)")
 			Eventually(func() error {
-				return applyCronJob(ctx, "test-opaque-short", "abc", "")
+				return applyCronJob(ctx, "test-opaque-short", "abc", "", "")
 			}, 5*time.Second, 1*time.Second).Should(Succeed())
 
 			By("rejecting nonOpaqueField with length 3 (inherits type-level MinLength=4)")
-			err := applyCronJob(ctx, "test-non-opaque-short", "", "abc")
+			err := applyCronJob(ctx, "test-non-opaque-short", "", "abc", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("should be at least 4 chars long"))
 
 			By("rejecting opaqueField with length 6 (applies field-level MaxLength=5)")
-			err = applyCronJob(ctx, "test-opaque-long", "abcdef", "")
+			err = applyCronJob(ctx, "test-opaque-long", "abcdef", "", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Too long"))
 
 			By("rejecting nonOpaqueField with length 6 (applies field-level MaxLength=5)")
-			err = applyCronJob(ctx, "test-non-opaque-long", "", "abcdef")
+			err = applyCronJob(ctx, "test-non-opaque-long", "", "abcdef", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Too long"))
+
+			By("allowing opaquePointerField with length 3 (suppresses type-level MinLength=4 on pointer)")
+			Eventually(func() error {
+				return applyCronJob(ctx, "test-opaque-ptr-short", "", "", "abc")
+			}, 5*time.Second, 1*time.Second).Should(Succeed())
+
+			By("rejecting opaquePointerField with length 6 (applies field-level MaxLength=5 on pointer)")
+			err = applyCronJob(ctx, "test-opaque-ptr-long", "", "", "abcdef")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Too long"))
 		})

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -475,6 +475,21 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:MinLength=10
 	// +kubebuilder:validation:MaxLength=10
 	FieldLevelLocalDeclarationOverride LongerString `json:"fieldLevelLocalDeclarationOverride,omitempty"`
+
+	// This tests that +k8s:opaque suppresses type-level validation from LongerString (MinLength=4).
+	// +k8s:opaque
+	// +kubebuilder:validation:MaxLength=5
+	OpaqueField LongerString `json:"opaqueField,omitempty"`
+
+	// This tests that without +k8s:opaque, type-level validations from LongerString are inherited.
+	// +kubebuilder:validation:MaxLength=5
+	NonOpaqueField LongerString `json:"nonOpaqueField,omitempty"`
+
+	// This tests that +k8s:opaque allows a field to completely replace a type-level validation.
+	// LongerString has MinLength=4. This field should have only MinLength=2.
+	// +k8s:opaque
+	// +kubebuilder:validation:MinLength=2
+	OpaqueMinLengthField LongerString `json:"opaqueMinLengthField,omitempty"`
 }
 
 type InlineAlias = EmbeddedStruct

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -487,20 +487,25 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:MaxLength=10
 	FieldLevelLocalDeclarationOverride LongerString `json:"fieldLevelLocalDeclarationOverride,omitempty"`
 
-	// This tests that +k8s:opaque suppresses type-level validation from LongerString (MinLength=4).
-	// +k8s:opaque
+	// This tests that +k8s:opaqueType suppresses type-level validation from LongerString (MinLength=4).
+	// +k8s:opaqueType
 	// +kubebuilder:validation:MaxLength=5
 	OpaqueField LongerString `json:"opaqueField,omitempty"`
 
-	// This tests that without +k8s:opaque, type-level validations from LongerString are inherited.
+	// This tests that without +k8s:opaqueType, type-level validations from LongerString are inherited.
 	// +kubebuilder:validation:MaxLength=5
 	NonOpaqueField LongerString `json:"nonOpaqueField,omitempty"`
 
-	// This tests that +k8s:opaque allows a field to completely replace a type-level validation.
+	// This tests that +k8s:opaqueType allows a field to completely replace a type-level validation.
 	// LongerString has MinLength=4. This field should have only MinLength=2.
-	// +k8s:opaque
+	// +k8s:opaqueType
 	// +kubebuilder:validation:MinLength=2
 	OpaqueMinLengthField LongerString `json:"opaqueMinLengthField,omitempty"`
+
+	// This tests that +k8s:opaqueType suppresses type-level validation on pointer fields.
+	// +k8s:opaqueType
+	// +kubebuilder:validation:MaxLength=5
+	OpaquePointerField *LongerString `json:"opaquePointerField,omitempty"`
 }
 
 type InlineAlias = EmbeddedStruct

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -486,6 +486,21 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:MinLength=10
 	// +kubebuilder:validation:MaxLength=10
 	FieldLevelLocalDeclarationOverride LongerString `json:"fieldLevelLocalDeclarationOverride,omitempty"`
+
+	// This tests that +k8s:opaque suppresses type-level validation from LongerString (MinLength=4).
+	// +k8s:opaque
+	// +kubebuilder:validation:MaxLength=5
+	OpaqueField LongerString `json:"opaqueField,omitempty"`
+
+	// This tests that without +k8s:opaque, type-level validations from LongerString are inherited.
+	// +kubebuilder:validation:MaxLength=5
+	NonOpaqueField LongerString `json:"nonOpaqueField,omitempty"`
+
+	// This tests that +k8s:opaque allows a field to completely replace a type-level validation.
+	// LongerString has MinLength=4. This field should have only MinLength=2.
+	// +k8s:opaque
+	// +kubebuilder:validation:MinLength=2
+	OpaqueMinLengthField LongerString `json:"opaqueMinLengthField,omitempty"`
 }
 
 type InlineAlias = EmbeddedStruct

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9645,6 +9645,12 @@ spec:
                   This flag is like suspend, but for when you really mean it.
                   It helps test the +kubebuilder:validation:Type marker.
                 type: string
+              nonOpaqueField:
+                description: This tests that without +k8s:opaque, type-level validations
+                  from LongerString are inherited.
+                maxLength: 5
+                minLength: 4
+                type: string
               onlyAllowSettingOnUpdate:
                 description: Test that we can add a field that can only be set to
                   a non-default value on updates using XValidation OptionalOldSelf.
@@ -9655,6 +9661,17 @@ spec:
                     an update.
                   optionalOldSelf: true
                   rule: oldSelf.hasValue() || self == 0
+              opaqueField:
+                description: This tests that +k8s:opaque suppresses type-level validation
+                  from LongerString (MinLength=4).
+                maxLength: 5
+                type: string
+              opaqueMinLengthField:
+                description: |-
+                  This tests that +k8s:opaque allows a field to completely replace a type-level validation.
+                  LongerString has MinLength=4. This field should have only MinLength=2.
+                minLength: 2
+                type: string
               patternObject:
                 description: This tests that pattern validator is properly applied.
                 pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -10145,6 +10145,12 @@ spec:
                   This flag is like suspend, but for when you really mean it.
                   It helps test the +kubebuilder:validation:Type marker.
                 type: string
+              nonOpaqueField:
+                description: This tests that without +k8s:opaque, type-level validations
+                  from LongerString are inherited.
+                maxLength: 5
+                minLength: 4
+                type: string
               onlyAllowSettingOnUpdate:
                 description: Test that we can add a field that can only be set to
                   a non-default value on updates using XValidation OptionalOldSelf.
@@ -10155,6 +10161,17 @@ spec:
                     an update.
                   optionalOldSelf: true
                   rule: oldSelf.hasValue() || self == 0
+              opaqueField:
+                description: This tests that +k8s:opaque suppresses type-level validation
+                  from LongerString (MinLength=4).
+                maxLength: 5
+                type: string
+              opaqueMinLengthField:
+                description: |-
+                  This tests that +k8s:opaque allows a field to completely replace a type-level validation.
+                  LongerString has MinLength=4. This field should have only MinLength=2.
+                minLength: 2
+                type: string
               patternObject:
                 description: This tests that pattern validator is properly applied.
                 pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -10146,7 +10146,7 @@ spec:
                   It helps test the +kubebuilder:validation:Type marker.
                 type: string
               nonOpaqueField:
-                description: This tests that without +k8s:opaque, type-level validations
+                description: This tests that without +k8s:opaqueType, type-level validations
                   from LongerString are inherited.
                 maxLength: 5
                 minLength: 4
@@ -10162,15 +10162,20 @@ spec:
                   optionalOldSelf: true
                   rule: oldSelf.hasValue() || self == 0
               opaqueField:
-                description: This tests that +k8s:opaque suppresses type-level validation
-                  from LongerString (MinLength=4).
+                description: This tests that +k8s:opaqueType suppresses type-level
+                  validation from LongerString (MinLength=4).
                 maxLength: 5
                 type: string
               opaqueMinLengthField:
                 description: |-
-                  This tests that +k8s:opaque allows a field to completely replace a type-level validation.
+                  This tests that +k8s:opaqueType allows a field to completely replace a type-level validation.
                   LongerString has MinLength=4. This field should have only MinLength=2.
                 minLength: 2
+                type: string
+              opaquePointerField:
+                description: This tests that +k8s:opaqueType suppresses type-level
+                  validation on pointer fields.
+                maxLength: 5
                 type: string
               patternObject:
                 description: This tests that pattern validator is properly applied.


### PR DESCRIPTION
###  What does this do, and why do we need it? 

When a Go type has type-level validation markers, those markers are automatically inherited by all fields that use that type. This PR introduces `+k8s: opaque`, a field-level marker that suppresses type-level validation inheritance for a specific field.

This marker gives users a way to opt-out of type level validations when reusing a go type in a CRD struct field, so they can define custom field level validations without inheriting any conflicts.

### Which issue(s) this PR is related to:

Fixes #1301 
