### PR TITLE
🌱 Handle any/interface{} type in CRD generator with clear error

### DIFF
--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -234,6 +234,16 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 			})
 		})
 
+		Context("InterfaceField API with any/interface{} types", func() {
+			BeforeEach(func() {
+				pkgPaths = []string{"./iface/..."}
+				expPkgLen = 1
+			})
+			It("should error on any type", func() {
+				assertError(pkgs[0], "InterfaceField", "cannot generate schema for any")
+			})
+		})
+
 		Context("CronJob API without group", func() {
 			BeforeEach(func() {
 				pkgPaths = []string{"./nogroup"}

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -229,9 +229,11 @@ func typeToSchema(ctx *schemaContext, rawType ast.Expr) *apiextensionsv1.JSONSch
 		props = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), expr.X)
 	case *ast.StructType:
 		props = structToSchema(ctx, expr)
+	case *ast.InterfaceType:
+		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("interface type is not supported in CRD schemas; consider using an explicit type or apiextensionsv1.JSON instead"), rawType))
+		return &apiextensionsv1.JSONSchemaProps{}
 	default:
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unsupported AST kind %T", expr), rawType))
-		// NB(directxman12): we explicitly don't handle interfaces
 		return &apiextensionsv1.JSONSchemaProps{}
 	}
 
@@ -271,8 +273,9 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 	if aliasInfo, isAlias := typeInfo.(*types.Alias); isAlias {
 		typeInfo = aliasInfo.Rhs()
 	}
-	if basicInfo, isBasic := typeInfo.(*types.Basic); isBasic {
-		typ, fmt, err := builtinToType(basicInfo, ctx.allowDangerousTypes)
+	switch typeInfo := typeInfo.(type) {
+	case *types.Basic:
+		typ, fmt, err := builtinToType(typeInfo, ctx.allowDangerousTypes)
 		if err != nil {
 			ctx.pkg.AddError(loader.ErrFromNode(err, ident))
 		}
@@ -281,7 +284,7 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		// > For gotypesalias=1, alias declarations produce an Alias type.
 		// > Otherwise, the alias information is only in the type name, which
 		// > points directly to the actual (aliased) type.
-		if basicInfo.Name() != ident.Name {
+		if typeInfo.Name() != ident.Name {
 			ctx.requestSchema("", ident.Name)
 			link := TypeRefLink("", ident.Name)
 			return &apiextensionsv1.JSONSchemaProps{
@@ -294,37 +297,44 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 			Type:   typ,
 			Format: fmt,
 		}
-	}
-	// NB(directxman12): if there are dot imports, this might be an external reference,
-	// so use typechecking info to get the actual object
-	typeNameInfo := typeInfo.(interface{ Obj() *types.TypeName }).Obj()
-	pkg := typeNameInfo.Pkg()
-	pkgPath := loader.NonVendorPath(pkg.Path())
-	if pkg == ctx.pkg.Types {
-		pkgPath = ""
-	}
-	ctx.requestSchema(pkgPath, typeNameInfo.Name())
-	link := TypeRefLink(pkgPath, typeNameInfo.Name())
-
-	// In cases where we have a named type, apply the type and format from the named schema
-	// to allow markers that need this information to apply correctly.
-	var typ, fmt string
-	if namedInfo, isNamed := typeInfo.(*types.Named); isNamed {
-		// We don't want/need to do this for structs, maps, or arrays.
-		// These are already handled in infoToSchema if they have custom marshalling.
-		if _, isBasic := namedInfo.Underlying().(*types.Basic); isBasic {
-			namedTypeInfo := ctx.schemaRequester.LookupType(ctx.pkg, namedInfo.Obj().Name())
-
-			namedSchema := infoToSchema(ctx.ForInfo(namedTypeInfo))
-			typ = namedSchema.Type
-			fmt = namedSchema.Format
+	case *types.Interface:
+		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("cannot generate schema for %s; interface type is not supported in CRD schemas, consider using an explicit type or apiextensionsv1.JSON instead", ident.Name), ident))
+		return &apiextensionsv1.JSONSchemaProps{}
+	case interface{ Obj() *types.TypeName }:
+		// NB(directxman12): if there are dot imports, this might be an external reference,
+		// so use typechecking info to get the actual object
+		typeNameInfo := typeInfo.Obj()
+		pkg := typeNameInfo.Pkg()
+		pkgPath := loader.NonVendorPath(pkg.Path())
+		if pkg == ctx.pkg.Types {
+			pkgPath = ""
 		}
-	}
+		ctx.requestSchema(pkgPath, typeNameInfo.Name())
+		link := TypeRefLink(pkgPath, typeNameInfo.Name())
 
-	return &apiextensionsv1.JSONSchemaProps{
-		Type:   typ,
-		Format: fmt,
-		Ref:    &link,
+		// In cases where we have a named type, apply the type and format from the named schema
+		// to allow markers that need this information to apply correctly.
+		var typ, fmt string
+		if namedInfo, isNamed := typeInfo.(*types.Named); isNamed {
+			// We don't want/need to do this for structs, maps, or arrays.
+			// These are already handled in infoToSchema if they have custom marshalling.
+			if _, isBasic := namedInfo.Underlying().(*types.Basic); isBasic {
+				namedTypeInfo := ctx.schemaRequester.LookupType(ctx.pkg, namedInfo.Obj().Name())
+
+				namedSchema := infoToSchema(ctx.ForInfo(namedTypeInfo))
+				typ = namedSchema.Type
+				fmt = namedSchema.Format
+			}
+		}
+
+		return &apiextensionsv1.JSONSchemaProps{
+			Type:   typ,
+			Format: fmt,
+			Ref:    &link,
+		}
+	default:
+		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unsupported type %T for identifier %s", typeInfo, ident.Name), ident))
+		return &apiextensionsv1.JSONSchemaProps{}
 	}
 }
 
@@ -333,6 +343,10 @@ func namedToSchema(ctx *schemaContext, named *ast.SelectorExpr) *apiextensionsv1
 	typeInfoRaw := ctx.pkg.TypesInfo.TypeOf(named)
 	if typeInfoRaw == types.Typ[types.Invalid] {
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unknown type %v.%s", named.X, named.Sel.Name), named))
+		return &apiextensionsv1.JSONSchemaProps{}
+	}
+	if _, isInterface := typeInfoRaw.(*types.Interface); isInterface {
+		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("cannot generate schema for %v.%s; interface type is not supported in CRD schemas, consider using an explicit type or apiextensionsv1.JSON instead", named.X, named.Sel.Name), named))
 		return &apiextensionsv1.JSONSchemaProps{}
 	}
 	typeInfo := typeInfoRaw.(interface{ Obj() *types.TypeName })
@@ -401,6 +415,9 @@ func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiextensionsv1.JSON
 		valSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), val)
 	case *ast.MapType:
 		valSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), val)
+	case *ast.InterfaceType:
+		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("interface type is not supported as map value in CRD schemas; consider using an explicit type or apiextensionsv1.JSON instead"), mapType.Value))
+		return &apiextensionsv1.JSONSchemaProps{}
 	default:
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("not a supported map value type: %T", mapType.Value), mapType.Value))
 		return &apiextensionsv1.JSONSchemaProps{}

--- a/pkg/crd/testdata/iface/types.go
+++ b/pkg/crd/testdata/iface/types.go
@@ -1,0 +1,46 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package iface
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type InterfaceFieldSpec struct {
+	Bar any `json:"bar,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:singular=interfacefield
+
+// InterfaceField is the Schema for the InterfaceField API
+type InterfaceField struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec InterfaceFieldSpec `json:"spec,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// InterfaceFieldList contains a list of InterfaceField
+type InterfaceFieldList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []InterfaceField `json:"items"`
+}


### PR DESCRIPTION
Previously, using `any` or `interface{}` as a field type in CRD structs caused a panic in localNamedToSchema due to an unsafe type assertion on *types.Interface, which does not implement Obj(). The `interface{}` AST
form also hit unhelpful default error cases.

Refactor localNamedToSchema to a type switch and add explicit handling for interface types in typeToSchema, mapToSchema, and namedToSchema, returning clear error messages that suggest using apiextensionsv1.JSON
instead. This prevents panics and gives users actionable guidance.

Based on https://github.com/kubernetes-sigs/controller-tools/pull/1252 

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
