### PR TITLE
:bug: Handle `omitzero` in `OneOf` constraint validation

### DIFF
--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -201,6 +201,21 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 			})
 		})
 
+		Context("OneOf API with missing omitempty/omitzero tag", func() {
+			BeforeEach(func() {
+				pkgPaths = []string{"./oneof_missing_tag_error/..."}
+				expPkgLen = 1
+			})
+			It("should generate an error when OneOf field lacks omitempty or omitzero tag", func() {
+				kind := "Oneof"
+				groupKind := schema.GroupKind{Kind: kind, Group: "testdata.kubebuilder.io"}
+				parser.NeedCRDFor(groupKind, nil)
+
+				expectedErr := "field foo is part of OneOf constraint and must have omitempty or omitzero tag"
+				Expect(packageErrors(pkgs[0])).To(MatchError(ContainSubstring(expectedErr)))
+			})
+		})
+
 		Context("CronJob API with Wrong Annotation Format", func() {
 			BeforeEach(func() {
 				pkgPaths = []string{"./wrong_annotation_format"}

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -487,7 +487,7 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 			switch opt {
 			case "inline":
 				inline = true
-			case "omitempty":
+			case "omitempty", "omitzero":
 				omitEmpty = true
 			}
 		}
@@ -522,10 +522,10 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 
 		// if this package isn't set to optional default...
 		case defaultMode == "required":
-			// ...everything that's not inline / omitempty is required
+			// ...everything that's not inline / omitempty / omitzero is required
 			if !inline && !omitEmpty {
 				if exactlyOneOf.Has(fieldName) || atMostOneOf.Has(fieldName) || atLeastOneOf.Has(fieldName) {
-					ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("field %s is part of OneOf constraint and must have omitempty tag", fieldName), structType))
+					ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("field %s is part of OneOf constraint and must have omitempty or omitzero tag", fieldName), structType))
 					return props
 				}
 				props.Required = append(props.Required, fieldName)

--- a/pkg/crd/testdata/oneof/types.go
+++ b/pkg/crd/testdata/oneof/types.go
@@ -13,6 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:generate ../../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true,allowDangerousTypes=true paths=./... output:dir=..
+
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1beta1
 package oneof
@@ -36,6 +38,12 @@ type OneofSpec struct {
 	TypeWithMultipleAtLeastOneofs *TypeWithMultipleAtLeastOneofs `json:"typeWithMultipleAtLeastOneOf,omitempty"`
 
 	TypeWithAllOneOf *TypeWithAllOneofs `json:"typeWithAllOneOf,omitempty"`
+
+	TypeWithOmitZero *TypeWithOmitZero `json:"typeWithOmitZero,omitempty"`
+
+	TypeWithOmitZeroExact *TypeWithOmitZeroExact `json:"typeWithOmitZeroExact,omitempty"`
+
+	TypeWithOmitZeroAtLeastOneOf *TypeWithOmitZeroAtLeastOneOf `json:"typeWithOmitZeroAtLeastOneOf,omitempty"`
 
 	FirstCustomTypeAlias CustomTypeAlias `json:"firstCustomTypeAlias,omitempty"`
 
@@ -98,6 +106,24 @@ type TypeWithAllOneofs struct {
 
 	E *string `json:"e,omitempty"`
 	F *string `json:"f,omitempty"`
+}
+
+// +kubebuilder:validation:AtMostOneOf=foo;bar
+type TypeWithOmitZero struct {
+	Foo *string `json:"foo,omitzero"`
+	Bar *string `json:"bar,omitzero"`
+}
+
+// +kubebuilder:validation:ExactlyOneOf=a;b
+type TypeWithOmitZeroExact struct {
+	A *string `json:"a,omitzero"`
+	B *string `json:"b,omitzero"`
+}
+
+// +kubebuilder:validation:AtLeastOneOf=c;d
+type TypeWithOmitZeroAtLeastOneOf struct {
+	C *string `json:"c,omitzero"`
+	D *string `json:"d,omitzero"`
 }
 
 // CustomTypeAlias is a custom alias

--- a/pkg/crd/testdata/oneof_missing_tag_error/types.go
+++ b/pkg/crd/testdata/oneof_missing_tag_error/types.go
@@ -1,0 +1,56 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1beta1
+package oneof_missing_tag_error
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:singular=oneof
+
+// OneofSpec is the spec for the oneofs API.
+type OneofSpec struct {
+	TypeWithMissingTag *TypeWithMissingTag `json:"typeWithMissingTag,omitempty"`
+}
+
+// +kubebuilder:validation:AtMostOneOf=foo;bar
+type TypeWithMissingTag struct {
+	Foo *string `json:"foo"`
+	Bar *string `json:"bar"`
+}
+
+// Oneof is the Schema for the Oneof API
+type Oneof struct {
+	/*
+	 */
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec OneofSpec `json:"spec"`
+}
+
+// +kubebuilder:object:root=true
+
+// OneofList contains a list of Oneof
+type OneofList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Oneof `json:"items"`
+}

--- a/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
@@ -1,6 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   name: oneofs.testdata.kubebuilder.io
 spec:
   group: testdata.kubebuilder.io
@@ -145,15 +148,40 @@ spec:
                   rule: '[has(self.a),has(self.b)].filter(x,x==true).size() >= 1'
                 - message: at least one of the fields in [c d] must be set
                   rule: '[has(self.c),has(self.d)].filter(x,x==true).size() >= 1'
+              typeWithOmitZero:
+                properties:
+                  bar:
+                    type: string
+                  foo:
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: at most one of the fields in [foo bar] may be set
+                  rule: '[has(self.foo),has(self.bar)].filter(x,x==true).size() <=
+                    1'
+              typeWithOmitZeroAtLeastOneOf:
+                properties:
+                  c:
+                    type: string
+                  d:
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of the fields in [c d] must be set
+                  rule: '[has(self.c),has(self.d)].filter(x,x==true).size() >= 1'
+              typeWithOmitZeroExact:
+                properties:
+                  a:
+                    type: string
+                  b:
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of the fields in [a b] must be set
+                  rule: '[has(self.a),has(self.b)].filter(x,x==true).size() == 1'
             type: object
         required:
         - spec
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/pkg/crd/validation_test.go
+++ b/pkg/crd/validation_test.go
@@ -124,6 +124,94 @@ spec:
 `,
 			wantErr: `spec.typeWithAllOneOf: Invalid value: at least one of the fields in [e f] must be set`,
 		},
+		{
+			name: "satisfies AtMostOneOf constraint with omitzero fields",
+			obj: `---
+kind: Oneof
+apiVersion: testdata.kubebuilder.io/v1beta1
+metadata:
+  name: test
+spec:
+  typeWithOmitZero:
+    foo: "foo"
+`,
+		},
+		{
+			name: "AtMostOneOf constraint violated with omitzero fields",
+			obj: `---
+kind: Oneof
+apiVersion: testdata.kubebuilder.io/v1beta1
+metadata:
+  name: test
+spec:
+  typeWithOmitZero:
+    foo: "foo"
+    bar: "bar"
+`,
+			wantErr: `spec.typeWithOmitZero: Invalid value: at most one of the fields in [foo bar] may be set`,
+		},
+		{
+			name: "satisfies ExactlyOneOf constraint with omitzero fields",
+			obj: `---
+kind: Oneof
+apiVersion: testdata.kubebuilder.io/v1beta1
+metadata:
+  name: test
+spec:
+  typeWithOmitZeroExact:
+    a: "a"
+`,
+		},
+		{
+			name: "ExactlyOneOf constraint violated by specifying both omitzero fields",
+			obj: `---
+kind: Oneof
+apiVersion: testdata.kubebuilder.io/v1beta1
+metadata:
+  name: test
+spec:
+  typeWithOmitZeroExact:
+    a: "a"
+    b: "b"
+`,
+			wantErr: `spec.typeWithOmitZeroExact: Invalid value: exactly one of the fields in [a b] must be set`,
+		},
+		{
+			name: "ExactlyOneOf constraint violated by specifying no omitzero fields",
+			obj: `---
+kind: Oneof
+apiVersion: testdata.kubebuilder.io/v1beta1
+metadata:
+  name: test
+spec:
+  typeWithOmitZeroExact: {}
+`,
+			wantErr: `spec.typeWithOmitZeroExact: Invalid value: exactly one of the fields in [a b] must be set`,
+		},
+		{
+			name: "satisfies AtLeastOneOf constraint with omitzero fields",
+			obj: `---
+kind: Oneof
+apiVersion: testdata.kubebuilder.io/v1beta1
+metadata:
+  name: test
+spec:
+  typeWithOmitZeroAtLeastOneOf:
+    c: "c"
+`,
+		},
+		{
+			name: "AtLeastOneOf constraint violated by specifying no omitzero fields",
+			obj: `---
+kind: Oneof
+apiVersion: testdata.kubebuilder.io/v1beta1
+metadata:
+  name: test
+spec:
+  typeWithOmitZeroAtLeastOneOf: {}
+`,
+			wantErr: `spec.typeWithOmitZeroAtLeastOneOf: Invalid value: at least one of the fields in [c d] must be set`,
+		},
 	}
 
 	validator, err := newValidator(t.Context(), "./testdata/testdata.kubebuilder.io_oneofs.yaml")


### PR DESCRIPTION
The `OneOf`/`AtMostOneOf`/`AtLeastOneOf` constraint validation rejects fields that lack the `omitempty` json tag, since such fields would be marked as required, conflicting with being part of a `OneOf` group.

However, `omitzero` (supported since [Go 1.24](https://go.dev/doc/go1.24#encodingjsonpkgencodingjson) via `encoding/json`) serves the same serialization purpose: the field is omitted when it holds its zero value. The current check does not recognize `omitzero`, causing a false positive error for valid field declarations.

Example false positive error:
```
field endpointSelector is part of OneOf constraint and must have omitempty tag
```