### PR TITLE
🐛Fix "literal not terminated" error for markers with unpaired backticks in Pattern   

### DIFF
--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -812,7 +812,20 @@ func (d *Definition) loadFields() error {
 func parserScanner(raw string, err func(*sc.Scanner, string)) *sc.Scanner {
 	scanner := &sc.Scanner{}
 	scanner.Init(bytes.NewBufferString(raw))
-	scanner.Mode = sc.ScanIdents | sc.ScanInts | sc.ScanFloats | sc.ScanStrings | sc.ScanRawStrings | sc.SkipComments
+
+	// Base scanning modes we always want enabled.
+	mode := sc.ScanIdents | sc.ScanInts | sc.ScanFloats | sc.ScanStrings | sc.SkipComments
+
+	// ScanRawStrings causes the scanner to treat backticks (`) as raw string delimiters.
+	// If the input contains an unbalanced (odd) number of backticks the scanner will
+	// report "literal not terminated". To avoid that error for annotations that may
+	// include unpaired backticks, only enable ScanRawStrings when the number of
+	// backticks is even (i.e. balanced).
+	if strings.Count(raw, "`")%2 == 0 {
+		mode |= sc.ScanRawStrings
+	}
+
+	scanner.Mode = uint(mode)
 	scanner.Error = err
 
 	return scanner

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -847,6 +847,10 @@ type markerParser interface {
 // Parse uses the type information in this Definition to parse the given
 // raw marker in the form `+a:b:c=arg,d=arg` into an output object of the
 // type specified in the definition.
+//
+// Parse attempts to support both raw strings (backtick-delimited) and literal
+// backtick characters by retrying without raw string support if parsing fails
+// with "literal not terminated" error.
 func (d *Definition) Parse(rawMarker string) (any, error) {
 	// Try with ScanRawStrings enabled first (supports raw strings like `pattern`).
 	result, errs := d.parse(rawMarker, true)
@@ -854,7 +858,11 @@ func (d *Definition) Parse(rawMarker string) (any, error) {
 	// may be literal characters (e.g. inside a regex character class), not raw string
 	// delimiters.
 	if hasTerminatedErr(errs) {
-		result, errs = d.parse(rawMarker, false)
+		result, retryErr := d.parse(rawMarker, false)
+		if retryErr != nil {
+			return result, fmt.Errorf("parse failed (tried with and without raw strings): %w", retryErr)
+		}
+		return result, nil
 	}
 	return result, errs
 }
@@ -863,7 +871,10 @@ func hasTerminatedErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "literal not terminated")
+	// Check for the specific scanner error, not just string matching
+	errStr := err.Error()
+	return strings.Contains(errStr, "literal not terminated") ||
+		strings.Contains(errStr, "string not terminated")
 }
 
 func (d *Definition) parse(rawMarker string, rawStrings bool) (any, error) {

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -265,7 +265,7 @@ func guessType(scanner *sc.Scanner, raw string, allowSlice bool) *Argument {
 		maybeItem := guessType(scanner, raw, false)
 
 		subRaw := raw[scanner.Pos().Offset:]
-		subScanner := parserScanner(subRaw, scanner.Error, true)
+		subScanner := parserScanner(subRaw, func(*sc.Scanner, string) {}, true)
 
 		var tok rune
 		for {

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -830,7 +830,20 @@ func (d *Definition) loadFields() error {
 func parserScanner(raw string, err func(*sc.Scanner, string)) *sc.Scanner {
 	scanner := &sc.Scanner{}
 	scanner.Init(bytes.NewBufferString(raw))
-	scanner.Mode = sc.ScanIdents | sc.ScanInts | sc.ScanFloats | sc.ScanStrings | sc.ScanRawStrings | sc.SkipComments
+
+	// Base scanning modes we always want enabled.
+	mode := sc.ScanIdents | sc.ScanInts | sc.ScanFloats | sc.ScanStrings | sc.SkipComments
+
+	// ScanRawStrings causes the scanner to treat backticks (`) as raw string delimiters.
+	// If the input contains an unbalanced (odd) number of backticks the scanner will
+	// report "literal not terminated". To avoid that error for annotations that may
+	// include unpaired backticks, only enable ScanRawStrings when the number of
+	// backticks is even (i.e. balanced).
+	if strings.Count(raw, "`")%2 == 0 {
+		mode |= sc.ScanRawStrings
+	}
+
+	scanner.Mode = uint(mode)
 	scanner.Error = err
 
 	return scanner

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -265,7 +265,7 @@ func guessType(scanner *sc.Scanner, raw string, allowSlice bool) *Argument {
 		maybeItem := guessType(scanner, raw, false)
 
 		subRaw := raw[scanner.Pos().Offset:]
-		subScanner := parserScanner(subRaw, func(*sc.Scanner, string) {})
+		subScanner := parserScanner(subRaw, scanner.Error, true)
 
 		var tok rune
 		for {
@@ -292,7 +292,7 @@ func guessType(scanner *sc.Scanner, raw string, allowSlice bool) *Argument {
 	// go to use this -- Go doesn't like scanners that can be rewound).
 	subRaw := raw[scanner.Pos().Offset:]
 	var hadScanError bool
-	subScanner := parserScanner(subRaw, func(*sc.Scanner, string) { hadScanError = true })
+	subScanner := parserScanner(subRaw, func(*sc.Scanner, string) { hadScanError = true }, true)
 
 	// skip whitespace
 	hint := peekNoSpace(subScanner)
@@ -827,23 +827,14 @@ func (d *Definition) loadFields() error {
 }
 
 // parserScanner makes a new scanner appropriate for use in parsing definitions and arguments.
-func parserScanner(raw string, err func(*sc.Scanner, string)) *sc.Scanner {
+// If rawStrings is true, backticks are treated as raw string delimiters.
+func parserScanner(raw string, err func(*sc.Scanner, string), rawStrings bool) *sc.Scanner {
 	scanner := &sc.Scanner{}
 	scanner.Init(bytes.NewBufferString(raw))
-
-	// Base scanning modes we always want enabled.
-	mode := sc.ScanIdents | sc.ScanInts | sc.ScanFloats | sc.ScanStrings | sc.SkipComments
-
-	// ScanRawStrings causes the scanner to treat backticks (`) as raw string delimiters.
-	// If the input contains an unbalanced (odd) number of backticks the scanner will
-	// report "literal not terminated". To avoid that error for annotations that may
-	// include unpaired backticks, only enable ScanRawStrings when the number of
-	// backticks is even (i.e. balanced).
-	if strings.Count(raw, "`")%2 == 0 {
-		mode |= sc.ScanRawStrings
+	scanner.Mode = sc.ScanIdents | sc.ScanInts | sc.ScanFloats | sc.ScanStrings | sc.SkipComments
+	if rawStrings {
+		scanner.Mode |= sc.ScanRawStrings
 	}
-
-	scanner.Mode = uint(mode)
 	scanner.Error = err
 
 	return scanner
@@ -857,6 +848,25 @@ type markerParser interface {
 // raw marker in the form `+a:b:c=arg,d=arg` into an output object of the
 // type specified in the definition.
 func (d *Definition) Parse(rawMarker string) (any, error) {
+	// Try with ScanRawStrings enabled first (supports raw strings like `pattern`).
+	result, errs := d.parse(rawMarker, true)
+	// Retry without ScanRawStrings if we get "literal not terminated" — the backticks
+	// may be literal characters (e.g. inside a regex character class), not raw string
+	// delimiters.
+	if hasTerminatedErr(errs) {
+		result, errs = d.parse(rawMarker, false)
+	}
+	return result, errs
+}
+
+func hasTerminatedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "literal not terminated")
+}
+
+func (d *Definition) parse(rawMarker string, rawStrings bool) (any, error) {
 	name, anonName, fields := splitMarker(rawMarker)
 
 	outPointer := reflect.New(d.Output)
@@ -876,7 +886,7 @@ func (d *Definition) Parse(rawMarker string) (any, error) {
 	var errs []error
 	scanner := parserScanner(fields, func(scanner *sc.Scanner, msg string) {
 		errs = append(errs, &ScannerError{Msg: msg, Pos: scanner.Position})
-	})
+	}, rawStrings)
 
 	// TODO(directxman12): strict parsing where we error out if certain fields aren't optional
 	seen := make(map[string]struct{}, len(d.Fields))

--- a/pkg/markers/parse_internal_test.go
+++ b/pkg/markers/parse_internal_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package markers
+
+import (
+	"fmt"
+	sc "text/scanner"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parserScanner backticks handling", func() {
+	// This tests the issue reported in https://github.com/kubernetes-sigs/controller-tools/issues/1084
+	// When a marker contains an odd number of backticks (e.g., Pattern=^[`a-zA-Z]+$),
+	// the scanner should NOT enable ScanRawStrings to avoid "literal not terminated" errors.
+
+	It("should handle pattern with single backtick without error", func() {
+		// Pattern with single backtick: ^[`a-zA-Z]+$
+		// This is the real-world case from issue #1084
+		raw := "^[`a-zA-Z]+$"
+		errFunc := func(s *sc.Scanner, msg string) {
+			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
+		}
+
+		scanner := parserScanner(raw, errFunc)
+
+		// With odd number of backticks (1), ScanRawStrings should be disabled
+		Expect(scanner.Mode&sc.ScanRawStrings).To(BeZero(), "ScanRawStrings should be disabled with odd backticks")
+
+		// The scanner should be able to scan the pattern without errors
+		tokens := []rune{}
+		for {
+			tok := scanner.Scan()
+			if tok == sc.EOF {
+				break
+			}
+			tokens = append(tokens, tok)
+		}
+		Expect(tokens).NotTo(BeEmpty(), "should have scanned some tokens")
+	})
+
+	It("should handle kubebuilder validation items pattern with single backtick", func() {
+		// Full marker as it would appear in source code
+		raw := "+kubebuilder:validation:items:Pattern=^[`a-zA-Z]+$"
+		errFunc := func(s *sc.Scanner, msg string) {
+			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
+		}
+
+		scanner := parserScanner(raw, errFunc)
+
+		// With 1 backtick (odd), ScanRawStrings should be disabled
+		Expect(scanner.Mode&sc.ScanRawStrings).To(BeZero(), "ScanRawStrings should be disabled with 1 backtick")
+	})
+
+	It("should handle pattern with two backticks (balanced)", func() {
+		// Pattern with two backticks (balanced)
+		raw := "^[`a-zA-Z`]+$"
+		errFunc := func(s *sc.Scanner, msg string) {
+			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
+		}
+
+		scanner := parserScanner(raw, errFunc)
+
+		// With 2 backticks (even), ScanRawStrings should be enabled
+		Expect(scanner.Mode&uint(sc.ScanRawStrings)).To(Equal(uint(sc.ScanRawStrings)), "ScanRawStrings should be enabled with even backticks")
+	})
+
+	It("should handle pattern with three backticks (unbalanced)", func() {
+		// Pattern with three backticks (unbalanced)
+		raw := "^[`a-zA-Z`a-z`]+$"
+		errFunc := func(s *sc.Scanner, msg string) {
+			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
+		}
+
+		scanner := parserScanner(raw, errFunc)
+
+		// With 3 backticks (odd), ScanRawStrings should be disabled
+		Expect(scanner.Mode&sc.ScanRawStrings).To(BeZero(), "ScanRawStrings should be disabled with 3 backticks")
+	})
+
+	It("should handle empty string without backticks", func() {
+		raw := ""
+		errFunc := func(s *sc.Scanner, msg string) {
+			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
+		}
+
+		scanner := parserScanner(raw, errFunc)
+
+		// With 0 backticks (even), ScanRawStrings should be enabled
+		Expect(scanner.Mode&uint(sc.ScanRawStrings)).To(Equal(uint(sc.ScanRawStrings)), "ScanRawStrings should be enabled with 0 backticks")
+	})
+})

--- a/pkg/markers/parse_internal_test.go
+++ b/pkg/markers/parse_internal_test.go
@@ -81,7 +81,7 @@ var _ = Describe("parserScanner backticks handling", func() {
 
 		scanner := parserScanner(raw, errFunc, true)
 
-		Expect(scanner.Mode & sc.ScanRawStrings).To(Equal(uint(sc.ScanRawStrings)),
+		Expect(scanner.Mode&sc.ScanRawStrings).To(Equal(uint(sc.ScanRawStrings)),
 			"ScanRawStrings should be enabled when rawStrings=true")
 
 		tokens := []rune{}
@@ -123,7 +123,7 @@ var _ = Describe("parserScanner backticks handling", func() {
 
 		scanner := parserScanner(raw, errFunc, true)
 
-		Expect(scanner.Mode & sc.ScanRawStrings).To(Equal(uint(sc.ScanRawStrings)),
+		Expect(scanner.Mode&sc.ScanRawStrings).To(Equal(uint(sc.ScanRawStrings)),
 			"ScanRawStrings should be enabled when rawStrings=true")
 	})
 

--- a/pkg/markers/parse_internal_test.go
+++ b/pkg/markers/parse_internal_test.go
@@ -26,10 +26,11 @@ import (
 
 var _ = Describe("parserScanner backticks handling", func() {
 	// This tests the issue reported in https://github.com/kubernetes-sigs/controller-tools/issues/1084
-	// When a marker contains an odd number of backticks (e.g., Pattern=^[`a-zA-Z]+$),
-	// the scanner should NOT enable ScanRawStrings to avoid "literal not terminated" errors.
+	// When a marker contains backticks as literal characters (e.g. Pattern=^[`a-zA-Z]+$),
+	// the scanner should gracefully handle them without "literal not terminated" errors.
+	// The error recovery in Parse() retries without ScanRawStrings if needed.
 
-	It("should handle pattern with single backtick without error", func() {
+	It("should handle pattern with single backtick without error (rawStrings=false)", func() {
 		// Pattern with single backtick: ^[`a-zA-Z]+$
 		// This is the real-world case from issue #1084
 		raw := "^[`a-zA-Z]+$"
@@ -37,10 +38,7 @@ var _ = Describe("parserScanner backticks handling", func() {
 			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
 		}
 
-		scanner := parserScanner(raw, errFunc)
-
-		// With odd number of backticks (1), ScanRawStrings should be disabled
-		Expect(scanner.Mode&sc.ScanRawStrings).To(BeZero(), "ScanRawStrings should be disabled with odd backticks")
+		scanner := parserScanner(raw, errFunc, false)
 
 		// The scanner should be able to scan the pattern without errors
 		tokens := []rune{}
@@ -54,54 +52,99 @@ var _ = Describe("parserScanner backticks handling", func() {
 		Expect(tokens).NotTo(BeEmpty(), "should have scanned some tokens")
 	})
 
-	It("should handle kubebuilder validation items pattern with single backtick", func() {
+	It("should handle kubebuilder validation items pattern with single backtick (rawStrings=false)", func() {
 		// Full marker as it would appear in source code
 		raw := "+kubebuilder:validation:items:Pattern=^[`a-zA-Z]+$"
 		errFunc := func(s *sc.Scanner, msg string) {
 			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
 		}
 
-		scanner := parserScanner(raw, errFunc)
+		scanner := parserScanner(raw, errFunc, false)
 
-		// With 1 backtick (odd), ScanRawStrings should be disabled
-		Expect(scanner.Mode&sc.ScanRawStrings).To(BeZero(), "ScanRawStrings should be disabled with 1 backtick")
+		tokens := []rune{}
+		for {
+			tok := scanner.Scan()
+			if tok == sc.EOF {
+				break
+			}
+			tokens = append(tokens, tok)
+		}
+		Expect(tokens).NotTo(BeEmpty(), "should have scanned some tokens")
 	})
 
-	It("should handle pattern with two backticks (balanced)", func() {
-		// Pattern with two backticks (balanced)
+	It("should handle pattern with two backticks as raw string (rawStrings=true)", func() {
+		// Two backticks form a valid raw string: ^[`a-zA-Z`]+$
 		raw := "^[`a-zA-Z`]+$"
 		errFunc := func(s *sc.Scanner, msg string) {
 			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
 		}
 
-		scanner := parserScanner(raw, errFunc)
+		scanner := parserScanner(raw, errFunc, true)
 
-		// With 2 backticks (even), ScanRawStrings should be enabled
-		Expect(scanner.Mode&uint(sc.ScanRawStrings)).To(Equal(uint(sc.ScanRawStrings)), "ScanRawStrings should be enabled with even backticks")
+		Expect(scanner.Mode & sc.ScanRawStrings).To(Equal(uint(sc.ScanRawStrings)),
+			"ScanRawStrings should be enabled when rawStrings=true")
+
+		tokens := []rune{}
+		for {
+			tok := scanner.Scan()
+			if tok == sc.EOF {
+				break
+			}
+			tokens = append(tokens, tok)
+		}
+		Expect(tokens).NotTo(BeEmpty(), "should have scanned some tokens")
 	})
 
-	It("should handle pattern with three backticks (unbalanced)", func() {
-		// Pattern with three backticks (unbalanced)
+	It("should handle pattern with three backticks without error (rawStrings=false)", func() {
+		// Three backticks: odd count, fallback mode
 		raw := "^[`a-zA-Z`a-z`]+$"
 		errFunc := func(s *sc.Scanner, msg string) {
 			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
 		}
 
-		scanner := parserScanner(raw, errFunc)
+		scanner := parserScanner(raw, errFunc, false)
 
-		// With 3 backticks (odd), ScanRawStrings should be disabled
-		Expect(scanner.Mode&sc.ScanRawStrings).To(BeZero(), "ScanRawStrings should be disabled with 3 backticks")
+		tokens := []rune{}
+		for {
+			tok := scanner.Scan()
+			if tok == sc.EOF {
+				break
+			}
+			tokens = append(tokens, tok)
+		}
+		Expect(tokens).NotTo(BeEmpty(), "should have scanned some tokens")
 	})
 
-	It("should handle empty string without backticks", func() {
+	It("should handle empty string without error", func() {
 		raw := ""
 		errFunc := func(s *sc.Scanner, msg string) {
 			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
 		}
 
-		scanner := parserScanner(raw, errFunc)
+		scanner := parserScanner(raw, errFunc, true)
 
-		// With 0 backticks (even), ScanRawStrings should be enabled
-		Expect(scanner.Mode&uint(sc.ScanRawStrings)).To(Equal(uint(sc.ScanRawStrings)), "ScanRawStrings should be enabled with 0 backticks")
+		Expect(scanner.Mode & sc.ScanRawStrings).To(Equal(uint(sc.ScanRawStrings)),
+			"ScanRawStrings should be enabled when rawStrings=true")
+	})
+
+	It("should handle two literal backticks inside regex character class (rawStrings=false)", func() {
+		// Backticks as literal regex characters, not raw string delimiters:
+		// ^[`a-zA-Z`]+$  -- these backticks are inside a character class
+		raw := "^[`a-zA-Z`]+$"
+		errFunc := func(s *sc.Scanner, msg string) {
+			Fail(fmt.Sprintf("scanner error: %s (at %s)", msg, s.Position))
+		}
+
+		scanner := parserScanner(raw, errFunc, false)
+
+		tokens := []rune{}
+		for {
+			tok := scanner.Scan()
+			if tok == sc.EOF {
+				break
+			}
+			tokens = append(tokens, tok)
+		}
+		Expect(tokens).NotTo(BeEmpty(), "should have scanned some tokens")
 	})
 })

--- a/pkg/markers/parse_internal_test.go
+++ b/pkg/markers/parse_internal_test.go
@@ -152,7 +152,7 @@ var _ = Describe("parserScanner backticks handling", func() {
 		// Test the complete Parse() flow, not just parserScanner
 		registry := &Registry{}
 		def := Must(MakeDefinition("kubebuilder:validation:Pattern", DescribesField, ""))
-		registry.Register(def)
+		Expect(registry.Register(def)).NotTo(HaveOccurred())
 
 		// This should trigger the retry mechanism internally
 		result, err := def.Parse("+kubebuilder:validation:Pattern=^[`a-zA-Z]+$")

--- a/pkg/markers/parse_internal_test.go
+++ b/pkg/markers/parse_internal_test.go
@@ -147,4 +147,16 @@ var _ = Describe("parserScanner backticks handling", func() {
 		}
 		Expect(tokens).NotTo(BeEmpty(), "should have scanned some tokens")
 	})
+
+	It("should handle full marker parsing with backtick retry", func() {
+		// Test the complete Parse() flow, not just parserScanner
+		registry := &Registry{}
+		def := Must(MakeDefinition("kubebuilder:validation:Pattern", DescribesField, ""))
+		registry.Register(def)
+
+		// This should trigger the retry mechanism internally
+		result, err := def.Parse("+kubebuilder:validation:Pattern=^[`a-zA-Z]+$")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil())
+	})
 })


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->

## Summary

Fixes the scanner error "literal not terminated" when parsing markers that contain an unpaired backtick in their pattern values, such as: 
```go                                                                                                                                                    
  // +kubebuilder:validation:items:Pattern=^[`a-zA-Z]+$                                                                                                      
```       

Closes: #1084                                                                                                                      
                                                                                                                                                             
## Changes                                                                                                                                                      
   
  1. `pkg/markers/parse.go` - Modified parserScanner function to:                                                                                                
    - `parserScanner` — replaced the backtick-counting heuristic with a simple rawStrings bool parameter                                                                       
    - `Parse + parse` function — extracted parsing logic into parse(rawMarker, rawStrings) helper; Parse now tries with rawStrings=true first, then retries with false if "literal not  
  terminated" error occurs                                                                                                                                                  
    - hasTerminatedErr — new helper to detect the specific error that triggers fallback                                                                                    
    - guessType — updated two internal parserScanner calls to pass true (preserves original behavior)                                                                                                  
                                                                          
  2. `pkg/markers/parse_internal_test.go` ( add new file) - Added test cases covering:                                                                                
    - Updated all parserScanner calls to include the new rawStrings parameter                                                                                                
    - Fixed type mismatch in assertions (uint vs int)                                                                                                                      
    - Added test case for two literal backticks inside regex character class (addresses camilamacedo86's concern)                                                            
    - Removed misleading "balanced" terminology from comments