### PR TITLE
🐛 (applyconfiguration): applyconfiguration: add a `year` option to pin the copyright year in generated file headers, matching the object generator and avoiding annual diffs on regeneration.

### DIFF
--- a/pkg/applyconfiguration/gen.go
+++ b/pkg/applyconfiguration/gen.go
@@ -62,6 +62,9 @@ type Generator struct {
 	// HeaderFile specifies the header text (e.g. license) to prepend to generated files.
 	HeaderFile string `marker:",optional"`
 
+	// Year specifies the year to substitute for " YEAR" in the header file.
+	Year string `marker:",optional"`
+
 	// ExternalApplyConfigurations provides mappings between external types and their applyconfiguration packages.
 	//
 	// Use this to reference apply configuration types for external types referenced
@@ -144,12 +147,25 @@ func isCRD(info *markers.TypeInfo) bool {
 func (d Generator) Generate(ctx *genall.GenerationContext) error {
 	headerFilePath := d.HeaderFile
 
-	if headerFilePath == "" {
+	if d.HeaderFile != "" {
+		headerBytes, err := ctx.ReadFile(d.HeaderFile)
+		if err != nil {
+			return err
+		}
+		headerText := string(headerBytes)
+		headerText = strings.ReplaceAll(headerText, " YEAR", " "+d.Year)
+
 		tmpFile, err := os.CreateTemp("", "applyconfig-header-*.txt")
 		if err != nil {
 			return fmt.Errorf("failed to create temporary file: %w", err)
 		}
+		if _, err := tmpFile.WriteString(headerText); err != nil {
+			tmpFile.Close()
+			os.Remove(tmpFile.Name())
+			return fmt.Errorf("failed to write to temporary file: %w", err)
+		}
 		if err := tmpFile.Close(); err != nil {
+			os.Remove(tmpFile.Name())
 			return fmt.Errorf("failed to close temporary file: %w", err)
 		}
 

--- a/pkg/applyconfiguration/gen.go
+++ b/pkg/applyconfiguration/gen.go
@@ -62,6 +62,9 @@ type Generator struct {
 	// HeaderFile specifies the header text (e.g. license) to prepend to generated files.
 	HeaderFile string `marker:",optional"`
 
+	// Year specifies the year to substitute for " YEAR" in the header file.
+	Year string `marker:",optional"`
+
 	// ExternalApplyConfigurations provides mappings between external types and their applyconfiguration packages.
 	//
 	// Use this to reference apply configuration types for external types referenced
@@ -154,6 +157,30 @@ func (d Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 
 		defer os.Remove(tmpFile.Name())
+
+		headerFilePath = tmpFile.Name()
+	} else {
+		// Substitute the year into the header and write the result to a temp
+		// file, since the generator reads the header from a file.
+		headerBytes, err := ctx.ReadFile(d.HeaderFile)
+		if err != nil {
+			return err
+		}
+		headerText := strings.ReplaceAll(string(headerBytes), " YEAR", " "+d.Year)
+
+		tmpFile, err := os.CreateTemp("", "applyconfig-header-*.txt")
+		if err != nil {
+			return fmt.Errorf("failed to create temporary file: %w", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, err := tmpFile.WriteString(headerText); err != nil {
+			_ = tmpFile.Close()
+			return fmt.Errorf("failed to write to temporary file: %w", err)
+		}
+		if err := tmpFile.Close(); err != nil {
+			return fmt.Errorf("failed to close temporary file: %w", err)
+		}
 
 		headerFilePath = tmpFile.Name()
 	}

--- a/pkg/applyconfiguration/year_integration_test.go
+++ b/pkg/applyconfiguration/year_integration_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applyconfiguration
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-tools/pkg/genall"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var _ = Describe("ApplyConfiguration header year substitution", func() {
+	generate := func(headerOptions string) string {
+		optionsRegistry := &markers.Registry{}
+		Expect(genall.RegisterOptionsMarkers(optionsRegistry)).To(Succeed())
+		Expect(optionsRegistry.Register(markers.Must(markers.MakeDefinition("applyconfiguration", markers.DescribesPackage, Generator{})))).To(Succeed())
+
+		genOpt := "applyconfiguration"
+		if headerOptions != "" {
+			genOpt += ":" + headerOptions
+		}
+		rt, err := genall.FromOptions(optionsRegistry, []string{
+			genOpt,
+			"paths=./api/v1",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(rt.Run()).To(BeFalse(), "generator should run without errors")
+
+		data, err := os.ReadFile(filepath.Join("api/v1", applyConfigurationDir, "utils.go"))
+		Expect(err).NotTo(HaveOccurred())
+		return string(data)
+	}
+
+	DescribeTable("writes the resolved header into generated files",
+		func(headerContent, headerOptions, expectPresent string, expectAbsent ...string) {
+			tmpDir, err := os.MkdirTemp("", "applyconfiguration-year-test")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { Expect(os.RemoveAll(tmpDir)).To(Succeed()) }()
+
+			Expect(os.CopyFS(tmpDir, os.DirFS(cronjobDir))).To(Succeed())
+			Expect(os.RemoveAll(filepath.Join(tmpDir, "api/v1", applyConfigurationDir))).To(Succeed())
+
+			cwd, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Chdir(tmpDir)).To(Succeed())
+			defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+			if headerContent != "" {
+				Expect(os.WriteFile("boilerplate.txt", []byte(headerContent), 0o644)).To(Succeed())
+			}
+
+			generated := generate(headerOptions)
+
+			Expect(generated).To(ContainSubstring(expectPresent))
+			for _, absent := range expectAbsent {
+				Expect(generated).NotTo(ContainSubstring(absent))
+			}
+		},
+		// Pin to a historical year: the underlying generator substitutes the
+		// current year for any leftover YEAR, so this value can never match it.
+		Entry("substitutes YEAR with the given year",
+			"/*\nCopyright YEAR The Kubernetes Authors.\n*/\n",
+			"headerFile=boilerplate.txt,year=2000",
+			"Copyright 2000 The Kubernetes Authors.",
+			"YEAR"),
+		Entry("drops the year when none is given",
+			"/*\nCopyright YEAR The Kubernetes Authors.\n*/\n",
+			"headerFile=boilerplate.txt",
+			"Copyright  The Kubernetes Authors.",
+			"YEAR"),
+		Entry("leaves a header without YEAR untouched",
+			"/*\nCopyright 2023 The Kubernetes Authors.\n*/\n",
+			"headerFile=boilerplate.txt,year=2000",
+			"Copyright 2023 The Kubernetes Authors.",
+			"YEAR"),
+		Entry("omits the license header when no header file is given",
+			"",
+			"",
+			"DO NOT EDIT.",
+			"Copyright"),
+	)
+})

--- a/pkg/applyconfiguration/year_test.go
+++ b/pkg/applyconfiguration/year_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applyconfiguration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestYearSubstitution(t *testing.T) {
+	tests := []struct {
+		name           string
+		headerContent  string
+		year           string
+		expectedOutput string
+	}{
+		{
+			name:           "year substitution with year specified",
+			headerContent:  "Copyright YEAR The Kubernetes Authors.",
+			year:           "2024",
+			expectedOutput: "Copyright 2024 The Kubernetes Authors.",
+		},
+		{
+			name:           "year substitution with empty year",
+			headerContent:  "Copyright YEAR The Kubernetes Authors.",
+			year:           "",
+			expectedOutput: "Copyright  The Kubernetes Authors.",
+		},
+		{
+			name:           "no YEAR placeholder in header",
+			headerContent:  "Copyright 2023 The Kubernetes Authors.",
+			year:           "2024",
+			expectedOutput: "Copyright 2023 The Kubernetes Authors.",
+		},
+		{
+			name:           "multiple YEAR placeholders",
+			headerContent:  "Copyright YEAR- YEAR The Kubernetes Authors.",
+			year:           "2024",
+			expectedOutput: "Copyright 2024- 2024 The Kubernetes Authors.",
+		},
+		{
+			name:           "YEAR without space not replaced",
+			headerContent:  "CopyrightYEAR YEAR",
+			year:           "2024",
+			expectedOutput: "CopyrightYEAR 2024",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			headerFile := filepath.Join(tmpDir, "header.txt")
+
+			if err := os.WriteFile(headerFile, []byte(tt.headerContent), 0644); err != nil {
+				t.Fatalf("failed to write header file: %v", err)
+			}
+
+			result := strings.ReplaceAll(tt.headerContent, " YEAR", " "+tt.year)
+
+			if result != tt.expectedOutput {
+				t.Errorf("expected %q, got %q", tt.expectedOutput, result)
+			}
+		})
+	}
+}

--- a/pkg/applyconfiguration/zz_generated.markerhelp.go
+++ b/pkg/applyconfiguration/zz_generated.markerhelp.go
@@ -36,6 +36,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "specifies the header text (e.g. license) to prepend to generated files.",
 				Details: "",
 			},
+			"Year": {
+				Summary: "specifies the year to substitute for \" YEAR\" in the header file.",
+				Details: "",
+			},
 			"ExternalApplyConfigurations": {
 				Summary: "provides mappings between external types and their applyconfiguration packages.",
 				Details: "Use this to reference apply configuration types for external types referenced\nby the Go structs provided as input. Each entry should be in the format:\n  <package>.<TypeName>@<applyconfiguration-package>\n\nFor example, to reference the apply configuration for corev1.LocalObjectReference:\n  k8s.io/api/core/v1.LocalObjectReference@k8s.io/client-go/applyconfigurations/core/v1",


### PR DESCRIPTION
## What

Add a `year=<value>` option to the `applyconfiguration` generator, matching the existing `object` generator.

## Why

Today, the applyconfiguration generator passes the boilerplate header directly to the `applyconfiguration-gen`, which replaces `YEAR` with the current calendar year at generation time.

For example:

```text
# boilerplate.go.txt
Copyright YEAR The Kubernetes Authors.
```

Without a `year=` option:

- Jan 2024: `make generate` → `Copyright 2024`
- Jan 2025: `make generate` again (even with no API changes) → `Copyright 2025`

This results in a large, unnecessary diff every January.

The `object` generator already supports `year=`, producing deterministic output without annual copyright churn. This change brings the applyconfiguration generator to the same behavior.

Example: 

- **Dec 31** — your generated files say `Copyright 2024`. The working tree is clean.
- **Jan 1** — a teammate (or CI) runs `make generate`. Nothing in the API has changed, but the generator now stamps `Copyright 2025` into every generated applyconfiguration file.
- **Result** — **every generated applyconfiguration file changes, producing a large, meaningless diff caused solely by the calendar rolling over. That is the problem solved here.** 

## How

Before invoking the upstream generator, this change:

1. Reads the boilerplate header.
2. Replaces `YEAR` with the configured `year=` value.
3. Writes the result to a temporary file.
4. Passes the temporary file to the upstream generator.

Because `YEAR` has already been replaced, the upstream generator has nothing left
to substitute with the current calendar year, so the configured year remains
unchanged.

For example, with `year=2024`:

- Jan 2024: `make generate` → `Copyright 2024`
**- Jan 2025: `make generate` → still `Copyright 2024`**

This pins a single year for the entire generation run, matching the behavior of the `object` generator. It does **not** preserve the existing copyright year of individual generated files.

## References

- Discussion: https://github.com/kubernetes-sigs/controller-tools/pull/1379
- Existing `year=` support for `object`: https://github.com/kubernetes-sigs/controller-tools/pull/544
- `gengo` performs the `YEAR` substitution: https://github.com/kubernetes/gengo/blob/5ee0d033ba5bcb073f0e69c32057520b82d75ccb/v2/execute.go#L59
- Kubernetes removed the year to avoid annual churn: https://github.com/kubernetes/kubernetes/pull/59172
- Issue in Kubebuilder https://github.com/kubernetes-sigs/kubebuilder/issues/5553 

Fixes: https://github.com/kubernetes-sigs/controller-tools/issues/1371