### PR TITLE
:sparkles: (crd): Add +kubebuilder:skip:description markers to omit package and spec descriptions

### DIFF
--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -169,6 +169,156 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		By("comparing the two")
 		Expect(out.buf.String()).To(Equal(string(expectedFile)), cmp.Diff(out.buf.String(), string(expectedFile)))
 	})
+
+	It("should skip spec desc when marker is found", func() {
+		By("switching to test directory")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		skipDescDir := filepath.Join(cwd, "testdata", "skip_desc")
+		Expect(os.Chdir(skipDescDir)).To(Succeed())
+
+		By("loading test packages")
+		pkgs, err := loader.LoadRoots(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		By("generating CRDs")
+		reg := &markers.Registry{}
+		Expect(crdmarkers.Register(reg)).To(Succeed())
+		out := &outputRule{buf: &bytes.Buffer{}}
+		ctx := &genall.GenerationContext{
+			Collector:  &markers.Collector{Registry: reg},
+			Roots:      pkgs,
+			Checker:    &loader.TypeChecker{},
+			OutputRule: out,
+		}
+
+		gen := &crd.Generator{
+			CRDVersions: []string{"v1"},
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("verifying marked specs have no desc")
+		output := out.buf.String()
+		Expect(output).NotTo(ContainSubstring("won't have this description"))
+
+		By("verifying normal specs keep their desc")
+		Expect(output).To(ContainSubstring("multi-line description"))
+		Expect(output).To(ContainSubstring("only affects"))
+	})
+
+	It("should skip all desc when package marker is found", func() {
+		By("switching to test directory")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		dir := filepath.Join(cwd, "testdata", "skip_desc_pkg")
+		Expect(os.Chdir(dir)).To(Succeed())
+
+		By("loading test packages")
+		pkgs, err := loader.LoadRoots(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		By("generating CRDs")
+		reg := &markers.Registry{}
+		Expect(crdmarkers.Register(reg)).To(Succeed())
+		out := &outputRule{buf: &bytes.Buffer{}}
+		ctx := &genall.GenerationContext{
+			Collector:  &markers.Collector{Registry: reg},
+			Roots:      pkgs,
+			Checker:    &loader.TypeChecker{},
+			OutputRule: out,
+		}
+
+		gen := &crd.Generator{
+			CRDVersions: []string{"v1"},
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("verifying all specs have no desc")
+		output := out.buf.String()
+		Expect(output).NotTo(ContainSubstring("won't appear"))
+		Expect(output).NotTo(ContainSubstring("package marker"))
+	})
+
+	It("should skip desc when spec has no doc", func() {
+		By("switching to test directory")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		skipDescDir := filepath.Join(cwd, "testdata", "skip_desc")
+		Expect(os.Chdir(skipDescDir)).To(Succeed())
+
+		By("loading test packages")
+		pkgs, err := loader.LoadRoots(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		By("generating CRDs")
+		reg := &markers.Registry{}
+		Expect(crdmarkers.Register(reg)).To(Succeed())
+		out := &outputRule{buf: &bytes.Buffer{}}
+		ctx := &genall.GenerationContext{
+			Collector:  &markers.Collector{Registry: reg},
+			Roots:      pkgs,
+			Checker:    &loader.TypeChecker{},
+			OutputRule: out,
+		}
+
+		gen := &crd.Generator{
+			CRDVersions: []string{"v1"},
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("verifying CRD generates successfully")
+		output := out.buf.String()
+		Expect(output).To(ContainSubstring("skipdescexamples.skipdesc.example.com"))
+	})
+
+	It("should skip desc when marker is used with maxDescLen", func() {
+		By("switching to test directory")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { Expect(os.Chdir(cwd)).To(Succeed()) }()
+
+		skipDescDir := filepath.Join(cwd, "testdata", "skip_desc")
+		Expect(os.Chdir(skipDescDir)).To(Succeed())
+
+		By("loading test packages")
+		pkgs, err := loader.LoadRoots(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		By("generating CRDs with maxDescLen")
+		reg := &markers.Registry{}
+		Expect(crdmarkers.Register(reg)).To(Succeed())
+		out := &outputRule{buf: &bytes.Buffer{}}
+		ctx := &genall.GenerationContext{
+			Collector:  &markers.Collector{Registry: reg},
+			Roots:      pkgs,
+			Checker:    &loader.TypeChecker{},
+			OutputRule: out,
+		}
+
+		fifty := 50
+		gen := &crd.Generator{
+			CRDVersions: []string{"v1"},
+			MaxDescLen:  &fifty,
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("verifying marked specs have no desc")
+		output := out.buf.String()
+		Expect(output).NotTo(ContainSubstring("won't have this description"))
+
+		By("verifying normal specs have truncated desc")
+		Expect(output).To(ContainSubstring("normalField"))
+	})
 })
 
 type outputRule struct {

--- a/pkg/crd/markers/crd.go
+++ b/pkg/crd/markers/crd.go
@@ -63,6 +63,9 @@ var CRDMarkers = []*definitionWithHelp{
 		WithHelp(ExternalDocs{}.Help()),
 	must(markers.MakeDefinition("kubebuilder:externalDocs", markers.DescribesType, ExternalDocs{})).
 		WithHelp(ExternalDocs{}.Help()),
+
+	must(markers.MakeDefinition("kubebuilder:skip:description", markers.DescribesField, SkipDescription{})).
+		WithHelp(SkipDescription{}.Help()),
 }
 
 // TODO: categories and singular used to be annotations types
@@ -565,5 +568,30 @@ func (m ExternalDocs) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) err
 		URL:         m.URL,
 		Description: m.Description,
 	}
+	return nil
+}
+
+// +controllertools:marker:generateHelp:category=CRD
+
+// SkipDescription omits spec descriptions from generated schemas.
+//
+// Reduces CRD size when types have extensive docs.
+// Apply to specific specs or at package level to skip all.
+//
+// Example:
+//
+//	type MyCRD struct {
+//	    // +kubebuilder:skip:description
+//	    LargeField ComplexType `json:"largeField"`
+//	}
+//
+// Package level:
+//
+//	// +kubebuilder:skip:description
+//	package v1alpha1
+type SkipDescription struct{}
+
+func (s SkipDescription) ApplyToSchema(schema *apiextensionsv1.JSONSchemaProps) error {
+	schema.Description = ""
 	return nil
 }

--- a/pkg/crd/markers/package.go
+++ b/pkg/crd/markers/package.go
@@ -36,5 +36,8 @@ func init() {
 
 		must(markers.MakeDefinition("kubebuilder:skip", markers.DescribesPackage, struct{}{})).
 			WithHelp(markers.SimpleHelp("CRD", "don't consider this package as an API version. Use this to exclude internal or helper packages from CRD generation.")),
+
+		must(markers.MakeDefinition("kubebuilder:skip:description", markers.DescribesPackage, struct{}{})).
+			WithHelp(markers.SimpleHelp("CRD", "omit all descriptions in this package to reduce CRD size.")),
 	)
 }

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -454,6 +454,17 @@ func (SelectableField) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (SkipDescription) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "omits spec descriptions from generated schemas.",
+			Details: "Reduces CRD size when types have extensive docs.\nApply to specific specs or at package level to skip all.\n\nExample:\n\n\ttype MyCRD struct {\n\t    // +kubebuilder:skip:description\n\t    LargeField ComplexType `json:\"largeField\"`\n\t}\n\nPackage level:\n\n\t// +kubebuilder:skip:description\n\tpackage v1alpha1",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (SkipVersion) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD",

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -237,7 +237,9 @@ func typeToSchema(ctx *schemaContext, rawType ast.Expr) *apiextensionsv1.JSONSch
 		return &apiextensionsv1.JSONSchemaProps{}
 	}
 
-	props.Description = ctx.info.Doc
+	if ctx.PackageMarkers.Get("kubebuilder:skip:description") == nil {
+		props.Description = ctx.info.Doc
+	}
 
 	applyMarkers(ctx, ctx.info.Markers, props, rawType)
 
@@ -542,7 +544,10 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 		} else {
 			propSchema = typeToSchema(ctx.ForInfo(&markers.TypeInfo{}), field.RawField.Type)
 		}
-		propSchema.Description = field.Doc
+
+		if ctx.PackageMarkers.Get("kubebuilder:skip:description") == nil {
+			propSchema.Description = field.Doc
+		}
 
 		applyMarkers(ctx, field.Markers, propSchema, field.RawField)
 

--- a/pkg/crd/testdata/skip_desc/types.go
+++ b/pkg/crd/testdata/skip_desc/types.go
@@ -1,0 +1,79 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=skipdesc.example.com
+// +versionName=v1
+package skipdesc
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SkipDescExample shows how skip description markers work.
+//
+// This type keeps its description since no skip marker was used.
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+type SkipDescExample struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   SkipDescExampleSpec   `json:"spec,omitempty"`
+	Status SkipDescExampleStatus `json:"status,omitempty"`
+}
+
+// SkipDescExampleSpec defines the spec.
+type SkipDescExampleSpec struct {
+	// NormalField keeps its description.
+	// This is a multi-line description to test that
+	// descriptions work normally when no skip marker is present.
+	NormalField string `json:"normalField"`
+
+	// SkippedField won't have this description in the CRD.
+	// +kubebuilder:skip:description
+	SkippedField string `json:"skippedField"`
+
+	// AnotherNormalField keeps its description.
+	// This field is used to verify that the skip marker only affects
+	// the specific field it's applied to.
+	AnotherNormalField int `json:"anotherNormalField"`
+
+	// ComplexField won't have this description.
+	// +kubebuilder:skip:description
+	ComplexField NestedType `json:"complexField"`
+}
+
+// NestedType is a nested structure.
+// This description appears since it's at the type level.
+type NestedType struct {
+	// NestedField has docs that appear in the CRD.
+	NestedField string `json:"nestedField"`
+
+	// AnotherField also has docs.
+	AnotherField int `json:"anotherField"`
+}
+
+// SkipDescExampleStatus defines the status.
+type SkipDescExampleStatus struct {
+	// Conditions represent the latest observations.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// SkipDescExampleList contains a list of SkipDescExample.
+// +kubebuilder:object:root=true
+type SkipDescExampleList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []SkipDescExample `json:"items"`
+}

--- a/pkg/crd/testdata/skip_desc_pkg/types.go
+++ b/pkg/crd/testdata/skip_desc_pkg/types.go
@@ -1,0 +1,63 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=skipdescpkg.example.com
+// +versionName=v1
+// +kubebuilder:skip:description
+package skipdescpkg
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PackageLevelSkip shows package-level skip in action.
+//
+// This description won't appear due to the package marker.
+// +kubebuilder:object:root=true
+type PackageLevelSkip struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec PackageLevelSkipSpec `json:"spec,omitempty"`
+}
+
+// PackageLevelSkipSpec defines the spec.
+// This description also won't appear.
+type PackageLevelSkipSpec struct {
+	// FieldOne has docs that won't appear
+	// due to the package-level marker.
+	FieldOne string `json:"fieldOne"`
+
+	// FieldTwo also has docs that won't appear.
+	FieldTwo int `json:"fieldTwo"`
+
+	// ComplexField has a nested type.
+	// All descriptions in this package are skipped.
+	ComplexField NestedType `json:"complexField"`
+}
+
+// NestedType is a nested type.
+// This description won't appear either.
+type NestedType struct {
+	// Value has docs that won't appear.
+	Value string `json:"value"`
+}
+
+// PackageLevelSkipList contains a list of PackageLevelSkip.
+// +kubebuilder:object:root=true
+type PackageLevelSkipList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []PackageLevelSkip `json:"items"`
+}


### PR DESCRIPTION
This adds two new markers to reduce CRD size when types have extensive documentation:        
                                                                                

-   **Spec-level: Skip description for specific specs**                             

```go
  type MyCRD struct {                                                           
      // This description will appear in the CRD                                
      ImportantField string `json:"importantField"`                             
                                                   
      // This long description won't appear in the CRD                          
      // +kubebuilder:skip:description                                     
      LargeField ComplexType `json:"largeField"`                                
  }
```                                                                   
                                                                                
- **Package-level: Skip all descriptions in a package**

```go    
  // +kubebuilder:skip:description                                              
  package v1alpha1                                          
```                                                                                

Useful when CRDs exceed size limits due to extensive godoc comments on deeply nested types.                                                                 
                   
Closes: https://github.com/kubernetes-sigs/controller-tools/issues/441