### PR TITLE
:bug: (for all generators): fix being silently ignored when placed directly above var/const/func declarations without a blank line. Both with and without blank line styles now work

### DIFF
--- a/pkg/applyconfiguration/marker_placement_test.go
+++ b/pkg/applyconfiguration/marker_placement_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applyconfiguration_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	pkgstest "golang.org/x/tools/go/packages/packagestest"
+
+	"sigs.k8s.io/controller-tools/pkg/applyconfiguration"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var _ = Describe("ApplyConfiguration markers on var/const/func declarations", func() {
+	var col *markers.Collector
+	var pkg *loader.Package
+	var exported *pkgstest.Exported
+
+	BeforeEach(func() {
+		By("setting up a fake package with applyconfiguration markers on var/const/func")
+		modules := []pkgstest.Module{
+			{
+				Name: "sigs.k8s.io/controller-tools/pkg/applyconfiguration/testdata/markerplacement",
+				Files: map[string]any{
+					"markerplacement.go": `package markerplacement
+
+// ApplyConfiguration generate marker directly above var (no blank line)
+// +kubebuilder:ac:generate=true
+var DirectVar = "test"
+
+// ApplyConfiguration output package marker with blank line above const
+// +kubebuilder:ac:output:package=myapplyconfig
+
+const BlankLineConst = "test"
+
+// ApplyConfiguration generate marker directly above func
+// +kubebuilder:ac:generate=true
+func DirectFunc() {}
+`,
+				},
+			},
+		}
+
+		var pkgs []*loader.Package
+		var err error
+		pkgs, exported, err = testloader.LoadFakeRoots(pkgstest.Modules, modules, "sigs.k8s.io/controller-tools/pkg/applyconfiguration/testdata/markerplacement")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		pkg = pkgs[0]
+
+		By("setting up the registry and collector with applyconfiguration markers")
+		reg := &markers.Registry{}
+		gen := applyconfiguration.Generator{}
+		Expect(gen.RegisterMarkers(reg)).To(Succeed())
+		col = &markers.Collector{Registry: reg}
+	})
+
+	AfterEach(func() {
+		if exported != nil {
+			exported.Cleanup()
+		}
+	})
+
+	It("should recognise applyconfiguration markers on var/const/func declarations", func() {
+		By("collecting package markers")
+		pkgMarkers, err := markers.PackageMarkers(col, pkg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkg.Errors).To(HaveLen(0))
+
+		By("checking that kubebuilder:ac:generate markers were collected")
+		acGenMarkers := pkgMarkers["kubebuilder:ac:generate"]
+		Expect(acGenMarkers).NotTo(BeNil(), "no kubebuilder:ac:generate markers found")
+		Expect(acGenMarkers).To(HaveLen(2), "expected 2 kubebuilder:ac:generate markers")
+
+		By("verifying marker values")
+		for _, marker := range acGenMarkers {
+			enabled := marker.(bool)
+			Expect(enabled).To(BeTrue())
+		}
+
+		By("checking that kubebuilder:ac:output:package marker was collected")
+		outputPkgMarkers := pkgMarkers["kubebuilder:ac:output:package"]
+		Expect(outputPkgMarkers).NotTo(BeNil(), "no kubebuilder:ac:output:package markers found")
+		Expect(outputPkgMarkers).To(HaveLen(1), "expected 1 kubebuilder:ac:output:package marker")
+
+		outputPkg := outputPkgMarkers[0].(string)
+		Expect(outputPkg).To(Equal("myapplyconfig"))
+	})
+})

--- a/pkg/crd/marker_placement_test.go
+++ b/pkg/crd/marker_placement_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	pkgstest "golang.org/x/tools/go/packages/packagestest"
+
+	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var _ = Describe("CRD package markers on var/const/func declarations", func() {
+	var col *markers.Collector
+	var pkg *loader.Package
+	var exported *pkgstest.Exported
+
+	BeforeEach(func() {
+		By("setting up a fake package with CRD package markers on var/const/func")
+		modules := []pkgstest.Module{
+			{
+				Name: "sigs.k8s.io/controller-tools/pkg/crd/testdata/markerplacement",
+				Files: map[string]any{
+					"markerplacement.go": `package markerplacement
+
+// CRD groupName marker directly above var (no blank line)
+// +groupName=test.example.com
+var DirectVar = "test"
+
+// CRD versionName marker with blank line above const
+// +versionName=v1beta1
+
+const BlankLineConst = "test"
+
+// CRD skip marker directly above func
+// +kubebuilder:skip
+func DirectFunc() {}
+
+// CRD validation marker on var
+// +kubebuilder:validation:Optional
+var OptionalVar = "test"
+
+// CRD validation marker on const
+// +kubebuilder:validation:Required
+const RequiredConst = "test"
+`,
+				},
+			},
+		}
+
+		var pkgs []*loader.Package
+		var err error
+		pkgs, exported, err = testloader.LoadFakeRoots(pkgstest.Modules, modules, "sigs.k8s.io/controller-tools/pkg/crd/testdata/markerplacement")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		pkg = pkgs[0]
+
+		By("setting up the registry and collector with CRD markers")
+		reg := &markers.Registry{}
+		Expect(crdmarkers.Register(reg)).To(Succeed())
+		col = &markers.Collector{Registry: reg}
+	})
+
+	AfterEach(func() {
+		if exported != nil {
+			exported.Cleanup()
+		}
+	})
+
+	It("should recognise CRD package markers on var/const/func declarations", func() {
+		By("collecting package markers")
+		pkgMarkers, err := markers.PackageMarkers(col, pkg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkg.Errors).To(HaveLen(0))
+
+		By("checking that groupName marker was collected")
+		groupNameMarkers := pkgMarkers["groupName"]
+		Expect(groupNameMarkers).NotTo(BeNil(), "no groupName markers found")
+		Expect(groupNameMarkers).To(HaveLen(1), "expected 1 groupName marker")
+		Expect(groupNameMarkers[0].(string)).To(Equal("test.example.com"))
+
+		By("checking that versionName marker was collected")
+		versionNameMarkers := pkgMarkers["versionName"]
+		Expect(versionNameMarkers).NotTo(BeNil(), "no versionName markers found")
+		Expect(versionNameMarkers).To(HaveLen(1), "expected 1 versionName marker")
+		Expect(versionNameMarkers[0].(string)).To(Equal("v1beta1"))
+
+		By("checking that kubebuilder:skip marker was collected")
+		skipMarkers := pkgMarkers["kubebuilder:skip"]
+		Expect(skipMarkers).NotTo(BeNil(), "no kubebuilder:skip markers found")
+		Expect(skipMarkers).To(HaveLen(1), "expected 1 kubebuilder:skip marker")
+
+		By("checking that validation markers were collected")
+		optionalMarkers := pkgMarkers["kubebuilder:validation:Optional"]
+		Expect(optionalMarkers).NotTo(BeNil(), "no validation:Optional markers found")
+		Expect(optionalMarkers).To(HaveLen(1), "expected 1 validation:Optional marker")
+
+		requiredMarkers := pkgMarkers["kubebuilder:validation:Required"]
+		Expect(requiredMarkers).NotTo(BeNil(), "no validation:Required markers found")
+		Expect(requiredMarkers).To(HaveLen(1), "expected 1 validation:Required marker")
+	})
+})

--- a/pkg/deepcopy/marker_placement_test.go
+++ b/pkg/deepcopy/marker_placement_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deepcopy_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	pkgstest "golang.org/x/tools/go/packages/packagestest"
+
+	"sigs.k8s.io/controller-tools/pkg/deepcopy"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var _ = Describe("Deepcopy markers on var/const/func declarations", func() {
+	var col *markers.Collector
+	var pkg *loader.Package
+	var exported *pkgstest.Exported
+
+	BeforeEach(func() {
+		By("setting up a fake package with deepcopy markers on var/const/func")
+		modules := []pkgstest.Module{
+			{
+				Name: "sigs.k8s.io/controller-tools/pkg/deepcopy/testdata/markerplacement",
+				Files: map[string]any{
+					"markerplacement.go": `package markerplacement
+
+// Deepcopy marker directly above var (no blank line)
+// +kubebuilder:object:generate=true
+var DirectVar = "test"
+
+// Deepcopy marker with blank line above const
+// +kubebuilder:object:generate=true
+
+const BlankLineConst = "test"
+
+// Legacy deepcopy marker directly above func
+// +k8s:deepcopy-gen=package
+func DirectFunc() {}
+`,
+				},
+			},
+		}
+
+		var pkgs []*loader.Package
+		var err error
+		pkgs, exported, err = testloader.LoadFakeRoots(pkgstest.Modules, modules, "sigs.k8s.io/controller-tools/pkg/deepcopy/testdata/markerplacement")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		pkg = pkgs[0]
+
+		By("setting up the registry and collector with deepcopy markers")
+		reg := &markers.Registry{}
+		gen := deepcopy.Generator{}
+		Expect(gen.RegisterMarkers(reg)).To(Succeed())
+		col = &markers.Collector{Registry: reg}
+	})
+
+	AfterEach(func() {
+		if exported != nil {
+			exported.Cleanup()
+		}
+	})
+
+	It("should recognise deepcopy markers on var/const/func declarations", func() {
+		By("collecting package markers")
+		pkgMarkers, err := markers.PackageMarkers(col, pkg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkg.Errors).To(HaveLen(0))
+
+		By("checking that kubebuilder:object:generate markers were collected")
+		objectGenMarkers := pkgMarkers["kubebuilder:object:generate"]
+		Expect(objectGenMarkers).NotTo(BeNil(), "no kubebuilder:object:generate markers found")
+		Expect(objectGenMarkers).To(HaveLen(2), "expected 2 kubebuilder:object:generate markers")
+
+		By("verifying marker values")
+		for _, marker := range objectGenMarkers {
+			enabled := marker.(bool)
+			Expect(enabled).To(BeTrue())
+		}
+
+		By("checking that legacy k8s:deepcopy-gen marker was collected")
+		legacyMarkers := pkgMarkers["k8s:deepcopy-gen"]
+		Expect(legacyMarkers).NotTo(BeNil(), "no k8s:deepcopy-gen markers found")
+		Expect(legacyMarkers).To(HaveLen(1), "expected 1 k8s:deepcopy-gen marker")
+	})
+})

--- a/pkg/markers/collect.go
+++ b/pkg/markers/collect.go
@@ -158,37 +158,68 @@ func (c *Collector) associateFileMarkers(file *ast.File) map[ast.Node][]markerCo
 	lastFileMarkers := visitor.markersBetween(false, visitor.commentInd, len(visitor.allComments))
 	visitor.pkgMarkers = append(visitor.pkgMarkers, lastFileMarkers...)
 
-	// figure out if any type-level markers are actually package-level markers
+	// figure out if any type/var/const/func markers are actually package-level markers.
+	// This is required to support package-level markers (RBAC, webhook, CRD, deepcopy, applyconfiguration)
+	// placed directly above declarations without blank lines - they're initially on the node but belong at package scope.
+	//
+	// Precedence rules:
+	// - types prefer type-level markers (skipGodocMarkers=true, preferPackageLevel=false)
+	// - var/const prefer package-level markers (skipGodocMarkers=false, preferPackageLevel=true)
+	// - func prefer package-level markers (skipGodocMarkers=false, preferPackageLevel=true)
 	for node, markers := range visitor.nodeMarkers {
-		_, isType := node.(*ast.TypeSpec)
-		if !isType {
+		var shouldReClassify bool
+		var skipGodocMarkers bool
+		var preferPackageLevel bool
+		switch node.(type) {
+		case *ast.TypeSpec:
+			shouldReClassify = true
+			skipGodocMarkers = true
+			preferPackageLevel = false
+		case *ast.ValueSpec:
+			shouldReClassify = true
+			skipGodocMarkers = false
+			preferPackageLevel = true
+		case *ast.FuncDecl:
+			shouldReClassify = true
+			skipGodocMarkers = false
+			preferPackageLevel = true
+		default:
 			continue
 		}
+
+		if !shouldReClassify {
+			continue
+		}
+
 		endOfMarkers := 0
 		for _, marker := range markers {
-			if marker.fromGodoc {
-				// markers from godoc are never package level
+			if marker.fromGodoc && skipGodocMarkers {
+				// godoc markers stay with the type
 				markers[endOfMarkers] = marker
 				endOfMarkers++
 				continue
 			}
 			markerText := marker.Text()
+			pkgDef := c.Registry.Lookup(markerText, DescribesPackage)
 			typeDef := c.Registry.Lookup(markerText, DescribesType)
-			if typeDef != nil {
-				// prefer assuming type-level markers
+
+			// Decide where the marker should go based on context and available definitions
+			switch {
+			case preferPackageLevel && pkgDef != nil:
+				// var/const/func prefers package-level when available
+				visitor.pkgMarkers = append(visitor.pkgMarkers, marker)
+			case typeDef != nil:
+				// type-level definition exists, keep at type level
 				markers[endOfMarkers] = marker
 				endOfMarkers++
-				continue
-			}
-			def := c.Registry.Lookup(markerText, DescribesPackage)
-			if def == nil {
-				// assume type-level unless proven otherwise
+			case pkgDef != nil:
+				// only package-level definition exists
+				visitor.pkgMarkers = append(visitor.pkgMarkers, marker)
+			default:
+				// no definition found, assume type-level
 				markers[endOfMarkers] = marker
 				endOfMarkers++
-				continue
 			}
-			// it's package-level, since a package-level definition exists
-			visitor.pkgMarkers = append(visitor.pkgMarkers, marker)
 		}
 		visitor.nodeMarkers[node] = markers[:endOfMarkers] // re-set after trimming the package markers
 	}
@@ -349,13 +380,13 @@ func (v markerSubVisitor) Visit(node ast.Node) ast.Visitor {
 	// associate those markers with a node
 	switch typedNode := node.(type) {
 	case *ast.GenDecl:
-		// save the comments associated with the gen-decl if it's a single-line type decl
-		if typedNode.Lparen != token.NoPos || typedNode.Tok != token.TYPE {
-			// not a single-line type spec, treat them as free comments
+		// save the comments associated with the gen-decl if it's a single-line decl (type/var/const)
+		if typedNode.Lparen != token.NoPos {
+			// not a single-line decl, treat them as free comments
 			v.pkgMarkers = append(v.pkgMarkers, markerCommentBlock...)
 			break
 		}
-		// save these, we'll need them when we encounter the actual type spec
+		// save these, we'll need them when we encounter the actual type/value spec
 		v.declComments = append(v.declComments, markerCommentBlock...)
 		v.declComments = append(v.declComments, docCommentBlock...)
 	case *ast.TypeSpec:
@@ -367,6 +398,16 @@ func (v markerSubVisitor) Visit(node ast.Node) ast.Visitor {
 
 		v.declComments = nil
 		v.collectPackageLevel = false // don't collect package-level inside type structs
+	case *ast.ValueSpec:
+		// Only use declComments (from GenDecl) to avoid re-classifying markers inside var() blocks
+		if len(v.declComments) > 0 {
+			v.nodeMarkers[node] = append(v.nodeMarkers[node], v.declComments...)
+			v.declComments = nil
+		}
+	case *ast.FuncDecl:
+		// Associate markers for re-classification
+		v.nodeMarkers[node] = append(v.nodeMarkers[node], markerCommentBlock...)
+		v.nodeMarkers[node] = append(v.nodeMarkers[node], docCommentBlock...)
 	case *ast.Field:
 		v.nodeMarkers[node] = append(v.nodeMarkers[node], markerCommentBlock...)
 		v.nodeMarkers[node] = append(v.nodeMarkers[node], docCommentBlock...)

--- a/pkg/markers/collect_test.go
+++ b/pkg/markers/collect_test.go
@@ -86,6 +86,36 @@ var _ = Describe("Collecting", func() {
 			By("checking that it doesn't contain any markers it's not supposed to")
 			Expect(pkgMarkers).To(HaveKeyWithValue("testing:pkglvl", Not(ContainElement(ContainSubstring("not here")))))
 		})
+
+		It("should re-associate package-level markers from var declarations", func() {
+			By("grabbing package markers")
+			pkgMarkers, err := PackageMarkers(col, fakePkg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fakePkg.Errors).To(HaveLen(0))
+
+			By("checking that the marker got reassociated from var")
+			Expect(pkgMarkers).To(HaveKeyWithValue("testing:pkglvl", ContainElement("here reassociated from var")))
+		})
+
+		It("should re-associate package-level markers from const declarations", func() {
+			By("grabbing package markers")
+			pkgMarkers, err := PackageMarkers(col, fakePkg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fakePkg.Errors).To(HaveLen(0))
+
+			By("checking that the marker got reassociated from const")
+			Expect(pkgMarkers).To(HaveKeyWithValue("testing:pkglvl", ContainElement("here reassociated from const")))
+		})
+
+		It("should re-associate package-level markers from func declarations", func() {
+			By("grabbing package markers")
+			pkgMarkers, err := PackageMarkers(col, fakePkg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fakePkg.Errors).To(HaveLen(0))
+
+			By("checking that the marker got reassociated from func")
+			Expect(pkgMarkers).To(HaveKeyWithValue("testing:pkglvl", ContainElement("here reassociated from func")))
+		})
 	})
 
 	Context("of type-level markers", func() {

--- a/pkg/markers/markers_suite_test.go
+++ b/pkg/markers/markers_suite_test.go
@@ -122,6 +122,18 @@ var _ = BeforeSuite(func() {
 
 					type Quux string
 
+					// Re-classify package marker from var
+					// +testing:pkglvl="here reassociated from var"
+					var varWithPkgMarker = "test"
+
+					// Re-classify package marker from const
+					// +testing:pkglvl="here reassociated from const"
+					const constWithPkgMarker = "test"
+
+					// Re-classify package marker from func
+					// +testing:pkglvl="here reassociated from func"
+					func funcWithPkgMarker() {}
+
 					// +testing:pkglvl="here at end after last node"
 
 					/* +testing:pkglvl="not here in block" */

--- a/pkg/markers/package_marker_placement_test.go
+++ b/pkg/markers/package_marker_placement_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package markers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	pkgstest "golang.org/x/tools/go/packages/packagestest"
+	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
+	. "sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var _ = Describe("Package-level markers on var/const/func", func() {
+	It("should re-classify all package-level marker types", func() {
+		By("setting up a package with various package-level markers on var/const/func")
+		modules := []pkgstest.Module{
+			{
+				Name: "sigs.k8s.io/controller-tools/pkg/markers/testdata/pkgmarkers",
+				Files: map[string]any{
+					"pkgmarkers.go": `package pkgmarkers
+
+// CRD markers on var/const/func (no blank line)
+// +groupName=test.example.com
+var varWithGroupName = "test"
+
+// +versionName=v1beta1
+const constWithVersionName = "test"
+
+// +kubebuilder:skip
+func funcWithSkip() {}
+
+// +kubebuilder:validation:Optional
+var varWithOptional = "test"
+
+// +kubebuilder:validation:Required
+const constWithRequired = "test"
+
+// Deepcopy markers
+// +kubebuilder:object:generate=true
+var varWithObjectGenerate = "test"
+
+// +k8s:deepcopy-gen=package
+const constWithDeepCopyGen = "test"
+
+// ApplyConfiguration markers
+// +kubebuilder:ac:generate=true
+func funcWithACGenerate() {}
+
+// +kubebuilder:ac:output:package=myapplyconfig
+var varWithACOutputPackage = "test"
+
+// Webhook markers
+// +kubebuilder:webhook:path=/validate,mutating=false,failurePolicy=fail,sideEffects=None,groups=test,resources=foos,verbs=create,versions=v1,name=test.example.com,admissionReviewVersions=v1
+var varWithWebhook = "test"
+
+// +kubebuilder:webhookconfiguration:name=my-webhook-config,mutating=false
+const constWithWebhookConfig = "test"
+
+// Multiple package markers on var (no blank line)
+// +groupName=multi.example.com
+// +versionName=v1alpha1
+var varWithMultipleMarkers = "test"
+`,
+				},
+			},
+		}
+
+		pkgs, exported, err := testloader.LoadFakeRoots(pkgstest.Modules, modules, "sigs.k8s.io/controller-tools/pkg/markers/testdata/pkgmarkers")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+		defer exported.Cleanup()
+
+		pkg := pkgs[0]
+
+		By("setting up registry with all package-level markers")
+		reg := &Registry{}
+		Expect(reg.Define("groupName", DescribesPackage, "")).To(Succeed())
+		Expect(reg.Define("versionName", DescribesPackage, "")).To(Succeed())
+		Expect(reg.Define("kubebuilder:skip", DescribesPackage, struct{}{})).To(Succeed())
+		Expect(reg.Define("kubebuilder:validation:Optional", DescribesPackage, struct{}{})).To(Succeed())
+		Expect(reg.Define("kubebuilder:validation:Required", DescribesPackage, struct{}{})).To(Succeed())
+		Expect(reg.Define("kubebuilder:object:generate", DescribesPackage, false)).To(Succeed())
+		Expect(reg.Define("k8s:deepcopy-gen", DescribesPackage, "")).To(Succeed())
+		Expect(reg.Define("kubebuilder:ac:generate", DescribesPackage, false)).To(Succeed())
+		Expect(reg.Define("kubebuilder:ac:output:package", DescribesPackage, "")).To(Succeed())
+		Expect(reg.Define("kubebuilder:webhook", DescribesPackage, struct {
+			Path                    string
+			Mutating                bool
+			FailurePolicy           string
+			SideEffects             string
+			Groups                  []string
+			Resources               []string
+			Verbs                   []string
+			Versions                []string
+			Name                    string
+			AdmissionReviewVersions []string
+		}{})).To(Succeed())
+		Expect(reg.Define("kubebuilder:webhookconfiguration", DescribesPackage, struct {
+			Name     string
+			Mutating bool
+		}{})).To(Succeed())
+
+		col := &Collector{Registry: reg}
+
+		By("collecting package markers")
+		pkgMarkers, err := PackageMarkers(col, pkg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkg.Errors).To(HaveLen(0))
+
+		By("verifying all CRD package-level markers were collected")
+		Expect(pkgMarkers).To(HaveKey("groupName"))
+		Expect(pkgMarkers).To(HaveKey("versionName"))
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:skip"))
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:validation:Optional"))
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:validation:Required"))
+
+		By("verifying deepcopy markers were collected")
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:object:generate"))
+		Expect(pkgMarkers).To(HaveKey("k8s:deepcopy-gen"))
+
+		By("verifying applyconfiguration markers were collected")
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:ac:generate"))
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:ac:output:package"))
+
+		By("verifying webhook markers were collected")
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:webhook"))
+		Expect(pkgMarkers).To(HaveKey("kubebuilder:webhookconfiguration"))
+
+		By("verifying marker values are correct")
+		Expect(pkgMarkers["groupName"]).To(ContainElement("test.example.com"))
+		Expect(pkgMarkers["versionName"]).To(ContainElement("v1beta1"))
+		Expect(pkgMarkers["kubebuilder:ac:output:package"]).To(ContainElement("myapplyconfig"))
+
+		By("verifying multiple markers on same var")
+		Expect(pkgMarkers["groupName"]).To(ContainElement("multi.example.com"))
+		Expect(pkgMarkers["versionName"]).To(ContainElement("v1alpha1"))
+	})
+
+	It("should work with blank lines (backward compatibility)", func() {
+		By("setting up a package with blank lines before declarations")
+		modules := []pkgstest.Module{
+			{
+				Name: "sigs.k8s.io/controller-tools/pkg/markers/testdata/pkgmarkersblank",
+				Files: map[string]any{
+					"pkgmarkers.go": `package pkgmarkersblank
+
+// groupName marker with blank line
+// +groupName=blank.example.com
+
+var varWithBlankLine = "test"
+`,
+				},
+			},
+		}
+
+		pkgs, exported, err := testloader.LoadFakeRoots(pkgstest.Modules, modules, "sigs.k8s.io/controller-tools/pkg/markers/testdata/pkgmarkersblank")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+		defer exported.Cleanup()
+
+		pkg := pkgs[0]
+
+		reg := &Registry{}
+		Expect(reg.Define("groupName", DescribesPackage, "")).To(Succeed())
+		col := &Collector{Registry: reg}
+
+		By("collecting package markers")
+		pkgMarkers, err := PackageMarkers(col, pkg)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("verifying blank line style still works")
+		Expect(pkgMarkers["groupName"]).To(ContainElement("blank.example.com"))
+	})
+})

--- a/pkg/rbac/marker_placement_test.go
+++ b/pkg/rbac/marker_placement_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	pkgstest "golang.org/x/tools/go/packages/packagestest"
+
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+	"sigs.k8s.io/controller-tools/pkg/rbac"
+)
+
+var _ = Describe("RBAC markers on var/const/func declarations", func() {
+	var col *markers.Collector
+	var pkg *loader.Package
+	var exported *pkgstest.Exported
+
+	BeforeEach(func() {
+		By("setting up a fake package with RBAC markers on var/const/func")
+		modules := []pkgstest.Module{
+			{
+				Name: "sigs.k8s.io/controller-tools/pkg/rbac/testdata/markerplacement",
+				Files: map[string]any{
+					"markerplacement.go": `package markerplacement
+
+// RBAC marker directly above var (no blank line)
+// +kubebuilder:rbac:groups=test,resources=directvar,verbs=get
+var DirectVar = "test"
+
+// RBAC marker with blank line above var
+// +kubebuilder:rbac:groups=test,resources=blanklinevar,verbs=get
+
+var BlankLineVar = "test"
+
+// RBAC marker directly above const
+// +kubebuilder:rbac:groups=test,resources=directconst,verbs=get
+const DirectConst = "test"
+
+// RBAC marker directly above func
+// +kubebuilder:rbac:groups=test,resources=directfunc,verbs=get
+func DirectFunc() {}
+`,
+				},
+			},
+		}
+
+		var pkgs []*loader.Package
+		var err error
+		pkgs, exported, err = testloader.LoadFakeRoots(pkgstest.Modules, modules, "sigs.k8s.io/controller-tools/pkg/rbac/testdata/markerplacement")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		pkg = pkgs[0]
+
+		By("setting up the registry and collector with RBAC marker")
+		reg := &markers.Registry{}
+		Expect(reg.Register(rbac.RuleDefinition)).To(Succeed())
+		col = &markers.Collector{Registry: reg}
+	})
+
+	AfterEach(func() {
+		if exported != nil {
+			exported.Cleanup()
+		}
+	})
+
+	It("should recognise RBAC marker directly above var declaration", func() {
+		By("collecting package markers")
+		pkgMarkers, err := markers.PackageMarkers(col, pkg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkg.Errors).To(HaveLen(0))
+
+		By("checking that all RBAC markers were collected at package level")
+		rbacMarkers := pkgMarkers["kubebuilder:rbac"]
+		Expect(rbacMarkers).NotTo(BeNil(), "no RBAC markers found")
+		Expect(rbacMarkers).To(HaveLen(4), "expected 4 RBAC markers")
+
+		By("verifying each marker was collected")
+		resources := make([]string, 0)
+		for _, marker := range rbacMarkers {
+			rule := marker.(rbac.Rule)
+			if len(rule.Resources) > 0 {
+				resources = append(resources, rule.Resources[0])
+			}
+		}
+
+		Expect(resources).To(ContainElement("directvar"), "directvar marker should be collected")
+		Expect(resources).To(ContainElement("blanklinevar"), "blanklinevar marker should be collected")
+		Expect(resources).To(ContainElement("directconst"), "directconst marker should be collected")
+		Expect(resources).To(ContainElement("directfunc"), "directfunc marker should be collected")
+	})
+})

--- a/pkg/rbac/testdata/controller.go
+++ b/pkg/rbac/testdata/controller.go
@@ -44,3 +44,20 @@ package controller
 // +kubebuilder:rbac:groups=apps,namespace=infrastructure,roleName=infra-deployment-manager,resources=statefulsets,verbs=get;list
 // Test backward compatibility - no roleName specified (uses default)
 // +kubebuilder:rbac:groups=monitoring,namespace=observability,resources=prometheuses,verbs=get;list
+
+// RBAC marker directly above var (no blank line)
+// +kubebuilder:rbac:groups=vartest,resources=directvar,verbs=get;list
+var DirectVarWithMarker = "test"
+
+// RBAC marker with blank line above var
+// +kubebuilder:rbac:groups=vartest,resources=blanklinevar,verbs=get;list
+
+var BlankLineVarWithMarker = "test"
+
+// RBAC marker directly above const
+// +kubebuilder:rbac:groups=vartest,resources=directconst,verbs=get;list
+const DirectConstWithMarker = "test"
+
+// RBAC marker directly above func
+// +kubebuilder:rbac:groups=vartest,resources=directfunc,verbs=get;list
+func DirectFuncWithMarker() {}

--- a/pkg/rbac/testdata/role.yaml
+++ b/pkg/rbac/testdata/role.yaml
@@ -128,6 +128,16 @@ rules:
   - another
   verbs:
   - list
+- apiGroups:
+  - vartest
+  resources:
+  - blanklinevar
+  - directconst
+  - directfunc
+  - directvar
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/webhook/marker_placement_test.go
+++ b/pkg/webhook/marker_placement_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	pkgstest "golang.org/x/tools/go/packages/packagestest"
+
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+	"sigs.k8s.io/controller-tools/pkg/webhook"
+)
+
+var _ = Describe("Webhook markers on var/const/func declarations", func() {
+	var col *markers.Collector
+	var pkg *loader.Package
+	var exported *pkgstest.Exported
+
+	BeforeEach(func() {
+		By("setting up a fake package with webhook markers on var/const/func")
+		modules := []pkgstest.Module{
+			{
+				Name: "sigs.k8s.io/controller-tools/pkg/webhook/testdata/markerplacement",
+				Files: map[string]any{
+					"markerplacement.go": `package markerplacement
+
+// Webhook marker directly above var (no blank line)
+// +kubebuilder:webhook:path=/validate-v1,mutating=false,failurePolicy=fail,sideEffects=None,groups=test.example.com,resources=foos,verbs=create;update,versions=v1,name=validate.foo.test.example.com,admissionReviewVersions=v1
+var DirectVar = "test"
+
+// Webhook marker with blank line above const
+// +kubebuilder:webhook:path=/mutate-v1,mutating=true,failurePolicy=fail,sideEffects=None,groups=test.example.com,resources=bars,verbs=create,versions=v1,name=mutate.bar.test.example.com,admissionReviewVersions=v1
+
+const BlankLineConst = "test"
+
+// WebhookConfiguration marker directly above func
+// +kubebuilder:webhookconfiguration:mutating=true,name=my-mutating-webhook-configuration
+func DirectFunc() {}
+`,
+				},
+			},
+		}
+
+		var pkgs []*loader.Package
+		var err error
+		pkgs, exported, err = testloader.LoadFakeRoots(pkgstest.Modules, modules, "sigs.k8s.io/controller-tools/pkg/webhook/testdata/markerplacement")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkgs).To(HaveLen(1))
+
+		pkg = pkgs[0]
+
+		By("setting up the registry and collector with webhook markers")
+		reg := &markers.Registry{}
+		Expect(reg.Register(webhook.ConfigDefinition)).To(Succeed())
+		Expect(reg.Register(webhook.WebhookConfigDefinition)).To(Succeed())
+		col = &markers.Collector{Registry: reg}
+	})
+
+	AfterEach(func() {
+		if exported != nil {
+			exported.Cleanup()
+		}
+	})
+
+	It("should recognise webhook markers on var/const/func declarations", func() {
+		By("collecting package markers")
+		pkgMarkers, err := markers.PackageMarkers(col, pkg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pkg.Errors).To(HaveLen(0))
+
+		By("checking that webhook markers were collected at package level")
+		webhookMarkers := pkgMarkers["kubebuilder:webhook"]
+		Expect(webhookMarkers).NotTo(BeNil(), "no webhook markers found")
+		Expect(webhookMarkers).To(HaveLen(2), "expected 2 webhook markers")
+
+		By("verifying webhook paths are correct")
+		paths := make([]string, 0, len(webhookMarkers))
+		for _, marker := range webhookMarkers {
+			config := marker.(webhook.Config)
+			paths = append(paths, config.Path)
+		}
+		Expect(paths).To(ContainElement("/validate-v1"), "validate webhook marker should be collected")
+		Expect(paths).To(ContainElement("/mutate-v1"), "mutate webhook marker should be collected")
+
+		By("checking that webhookconfiguration marker was collected")
+		webhookConfigMarkers := pkgMarkers["kubebuilder:webhookconfiguration"]
+		Expect(webhookConfigMarkers).NotTo(BeNil(), "no webhookconfiguration markers found")
+		Expect(webhookConfigMarkers).To(HaveLen(1), "expected 1 webhookconfiguration marker")
+
+		webhookConfig := webhookConfigMarkers[0].(webhook.WebhookConfig)
+		Expect(webhookConfig.Name).To(Equal("my-mutating-webhook-configuration"))
+		Expect(webhookConfig.Mutating).To(BeTrue())
+	})
+})


### PR DESCRIPTION
Package-level markers like +kubebuilder:rbac, +kubebuilder:webhook,  +groupName, etc. were silently ignored when placed directly above             
                                                                               
Both styles now work (backward compatible):
  - With blank line (already worked)                                            
  - Without blank line (now fixed)                  
                                                                                                                                                                
Closes #551                                             

Assisted-by: Claude
