### PR TITLE
🐛 fix(controller-gen): correctly handle individual file paths (e.g.,paths=./apis/v1/types.go) instead of only accepting directories or recursive patterns.

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -567,33 +567,58 @@ func LoadRootsWithConfig(cfg *packages.Config, roots ...string) ([]*Package, err
 	//    2. update the loader config's Dir property to be the directory from
 	//       step one
 	//
-	//    3. determine whether the root passed to the loader should be "./."
-	//       or "./..."
+	//    3. determine whether the root passed to the loader should be "./.",
+	//       "./...", or an individual file
 	//
 	//    4. execute the loader with the value from step three
 	for _, r := range fspRoots {
 		b, d := filepath.Base(r), filepath.Dir(r)
 
-		// we want the base part of the path to be either "..." or ".", except
-		// Go's filepath utilities clean paths during manipulation, removing the
-		// ".". thus, if not "...", let's update the path components so that:
-		//
-		//   d = r
-		//   b = "."
-		if b != "..." {
-			d = r
-			b = "."
+		// we want the base part of the path to be either "...", ".", or a filename.
+		// handle "..." first since it's not a real path that can be stat'd
+		if b == "..." {
+			// update the loader configuration's Dir field to the directory part of
+			// the root
+			l.cfg.Dir = d
+
+			// update the root to be "./..."
+			// (with OS-specific filepath separator). please note filepath.Join
+			// would clean up the trailing "." character that we want preserved,
+			// hence the more manual path concatenation logic
+			r = fmt.Sprintf(".%s%s", string(filepath.Separator), b)
+		} else {
+			// os.Stat follows symlinks, so links resolve to their target
+			fi, err := os.Stat(r)
+			if err != nil {
+				return nil, fmt.Errorf("unable to stat path %q: %w", r, err)
+			}
+
+			switch {
+			case fi.Mode().IsRegular():
+				// for individual files, set the working dir to the containing
+				// directory and pass the filename to the loader
+				l.cfg.Dir = d
+				r = fmt.Sprintf(".%s%s", string(filepath.Separator), b)
+			case fi.IsDir():
+				// for directories (not "..."), treat the entire path as the directory
+				d = r
+				b = "."
+
+				// update the loader configuration's Dir field to the directory part of
+				// the root
+				l.cfg.Dir = d
+
+				// update the root to be "./."
+				// (with OS-specific filepath separator). please note filepath.Join
+				// would clean up the trailing "." character that we want preserved,
+				// hence the more manual path concatenation logic
+				r = fmt.Sprintf(".%s%s", string(filepath.Separator), b)
+			default:
+				// Only regular files and directories can be loaded. Anything
+				// else is rejected because trying to load it can hang.
+				return nil, fmt.Errorf("unsupported file type %s at path %q", fi.Mode().Type(), r)
+			}
 		}
-
-		// update the loader configuration's Dir field to the directory part of
-		// the root
-		l.cfg.Dir = d
-
-		// update the root to be "./..." or "./."
-		// (with OS-specific filepath separator). please note filepath.Join
-		// would clean up the trailing "." character that we want preserved,
-		// hence the more manual path concatenation logic
-		r = fmt.Sprintf(".%s%s", string(filepath.Separator), b)
 
 		// load the packages from the roots
 		pkgs, err := loadPackages(r)

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -18,6 +18,9 @@ package loader_test
 
 import (
 	"os"
+	"path/filepath"
+	"syscall"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -185,6 +188,127 @@ var _ = Describe("Loader parsing root module", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pkgs).To(HaveLen(1))
 			assertPkgExists(testmodPkg+"/submod1/subdir1", pkgs)
+		})
+	})
+
+	Context("with roots=[./testmod/dummy.go]", func() {
+		It("should load one package from individual file", func() {
+			By("loading individual file path")
+			pkgs, err := loader.LoadRoots("./testmod/dummy.go")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pkgs).To(HaveLen(1))
+			By("verifying package ID is command-line-arguments for individual files")
+			Expect(pkgs[0].ID).To(Equal("command-line-arguments"))
+			Expect(pkgs[0].Name).To(Equal("dummy"))
+		})
+	})
+
+	Context("with roots=[./testmod/submod1/dummy.go]", func() {
+		It("should load one package from individual file", func() {
+			By("loading individual file from subdirectory")
+			pkgs, err := loader.LoadRoots("./testmod/submod1/dummy.go")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pkgs).To(HaveLen(1))
+			By("verifying package ID is command-line-arguments for individual files")
+			Expect(pkgs[0].ID).To(Equal("command-line-arguments"))
+			Expect(pkgs[0].Name).To(Equal("dummy"))
+		})
+	})
+
+	Context("with roots=[./testmod/subdir1/dummy.go]", func() {
+		It("should load one package from individual file in subdirectory", func() {
+			By("loading individual file from nested subdirectory")
+			pkgs, err := loader.LoadRoots("./testmod/subdir1/dummy.go")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pkgs).To(HaveLen(1))
+			Expect(pkgs[0].ID).To(Equal("command-line-arguments"))
+			Expect(pkgs[0].Name).To(Equal("dummy"))
+		})
+	})
+
+	Context("with roots=[./testmod/dummy.go, ./testmod/submod1]", func() {
+		It("should load packages from both file and directory", func() {
+			By("loading mixed file and directory paths")
+			pkgs, err := loader.LoadRoots("./testmod/dummy.go", "./testmod/submod1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pkgs).To(HaveLen(2))
+			By("verifying first package from individual file")
+			Expect(pkgs[0].ID).To(Equal("command-line-arguments"))
+			Expect(pkgs[0].Name).To(Equal("dummy"))
+			By("verifying second package from directory")
+			assertPkgExists(testmodPkg+"/submod1", pkgs)
+		})
+	})
+
+	Context("with roots=[./testmod/subdir1/../dummy.go]", func() {
+		It("should load one package from individual file with relative path", func() {
+			pkgs, err := loader.LoadRoots("./testmod/subdir1/../dummy.go")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pkgs).To(HaveLen(1))
+			Expect(pkgs[0].ID).To(Equal("command-line-arguments"))
+			Expect(pkgs[0].Name).To(Equal("dummy"))
+		})
+	})
+
+	Context("with roots=[./testmod/nonexistent.go]", func() {
+		It("should return error for non-existent file", func() {
+			_, err := loader.LoadRoots("./testmod/nonexistent.go")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to stat path"))
+		})
+	})
+
+	Context("when a root points to a named pipe", func() {
+		It("should return an unsupported file type error instead of hanging the loader", func() {
+			tmpDir, err := os.MkdirTemp("", "loader-fifo")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+
+			fifoPath := filepath.Join(tmpDir, "pipe.go")
+			Expect(syscall.Mkfifo(fifoPath, 0600)).To(Succeed())
+
+			errCh := make(chan error, 1)
+			go func() {
+				_, err := loader.LoadRoots(fifoPath)
+				errCh <- err
+			}()
+
+			select {
+			case err := <-errCh:
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unsupported file type"))
+			case <-time.After(30 * time.Second):
+				Fail("LoadRoots did not return for a named pipe; it likely hung on go list")
+			}
+		})
+	})
+
+	Context("when a root is a symlink to a file", func() {
+		It("should follow the link and load the file as one package", func() {
+			linkPath := "./testmod/link_dummy.go"
+			_ = os.Remove(linkPath)
+			Expect(os.Symlink("dummy.go", linkPath)).To(Succeed())
+			defer os.Remove(linkPath)
+
+			pkgs, err := loader.LoadRoots(linkPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pkgs).To(HaveLen(1))
+			Expect(pkgs[0].ID).To(Equal("command-line-arguments"))
+			Expect(pkgs[0].Name).To(Equal("dummy"))
+		})
+	})
+
+	Context("when a root is a symlink to a directory", func() {
+		It("should follow the link and load the directory as one package", func() {
+			linkPath := "./testmod/link_subdir"
+			_ = os.Remove(linkPath)
+			Expect(os.Symlink("subdir1", linkPath)).To(Succeed())
+			defer os.Remove(linkPath)
+
+			pkgs, err := loader.LoadRoots(linkPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pkgs).To(HaveLen(1))
+			Expect(pkgs[0].Name).To(Equal("dummy"))
 		})
 	})
 })


### PR DESCRIPTION
### What was broken                                                           
                                                            
The loader treated all filesystem paths as directories, causing errors when individual files were specified:
                                                                                
  ```bash                                                   
  # This failed with "not a directory" error
  controller-gen object paths=./apis/v1beta1/some_types.go
                                                                                
  Error: load packages in root ".../some_types.go": err: fork/exec
  /usr/local/go/bin/go: not a directory                                         
  ```
                                                            
### What this fixes                                                               
                                                            
Added file detection logic to distinguish between files and directories. Now individual file paths work correctly:
                                                                                
```                                                                 
  controller-gen object paths=./apis/v1beta1/some_types.go                      
  controller-gen object paths=./apis/v1          # still works                  
  controller-gen object paths=./apis/...         # still works    
```

PS: We are increasing the coverage as well to ensure that it works well with all scenarios. 

Closes: https://github.com/kubernetes-sigs/controller-tools/issues/837
