### PR TITLE
⚠️ Deprecated +kubebuilder:validation:Required and +kubebuilder:validation:Optional markers in favor of shorter +required and +optional forms (both continue to work)

### DIFF
--- a/pkg/crd/markers/package.go
+++ b/pkg/crd/markers/package.go
@@ -29,10 +29,10 @@ func init() {
 			WithHelp(markers.SimpleHelp("CRD", "overrides the API group version for this package (defaults to the package name). Example: +versionName=v1beta1")),
 
 		must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesPackage, struct{}{})).
-			WithHelp(markers.SimpleHelp("CRD validation", "specifies that all fields in this package are optional by default.")),
+			WithHelp(markers.DeprecatedHelp("", "CRD validation", "specifies that all fields in this package are optional by default. Prefer using field-level +optional markers instead.")),
 
 		must(markers.MakeDefinition("kubebuilder:validation:Required", markers.DescribesPackage, struct{}{})).
-			WithHelp(markers.SimpleHelp("CRD validation", "specifies that all fields in this package are required by default.")),
+			WithHelp(markers.DeprecatedHelp("", "CRD validation", "specifies that all fields in this package are required by default. Prefer using field-level +required markers instead.")),
 
 		must(markers.MakeDefinition("kubebuilder:skip", markers.DescribesPackage, struct{}{})).
 			WithHelp(markers.SimpleHelp("CRD", "don't consider this package as an API version. Use this to exclude internal or helper packages from CRD generation.")),

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -107,9 +107,9 @@ var TypeOnlyMarkers = []*definitionWithHelp{
 // sense on a type, and thus aren't in ValidationMarkers).
 var FieldOnlyMarkers = []*definitionWithHelp{
 	must(markers.MakeDefinition("kubebuilder:validation:Required", markers.DescribesField, struct{}{})).
-		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is required.")),
+		WithHelp(markers.DeprecatedHelp("required", "CRD validation", "specifies that this field is required.")),
 	must(markers.MakeDefinition("kubebuilder:validation:Optional", markers.DescribesField, struct{}{})).
-		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional.")),
+		WithHelp(markers.DeprecatedHelp("optional", "CRD validation", "specifies that this field is optional.")),
 	must(markers.MakeDefinition("required", markers.DescribesField, struct{}{})).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is required.")),
 	must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})).


### PR DESCRIPTION
To simplify, the  `+kubebuilder:validation:Required` and `+kubebuilder:validation:Optional` markers are now deprecated in favor of the simpler +required and +optional markers.
                                                                                        
Fixes #1241                                    