### PR TITLE
🌱Add envtest tests for +kubebuilder:default={} with nested field defaults

### DIFF
--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -196,6 +196,17 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 			})
 		})
 
+		Context("EmptyObjectDefault API", func() {
+			BeforeEach(func() {
+				pkgPaths = []string{"./emptyobjectdefault/..."}
+				expPkgLen = 1
+			})
+			It("should generate default: {} for pointer fields defaulting to an empty object", func() {
+				assertCRD(pkgs[0], "EmptyObjectDefault", "testdata.kubebuilder.io_emptyobjectdefaults.yaml")
+				assertCRD(pkgs[0], "RequiredChildDefault", "testdata.kubebuilder.io_requiredchilddefaults.yaml")
+			})
+		})
+
 		Context("Enum API with marker on field", func() {
 			BeforeEach(func() {
 				pkgPaths = []string{"./enum_error/..."}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 // TODO(directxman12): test this across both versions (right now we're just
 // trusting k/k conversion, which is probably fine though)
 
-//go:generate ../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true,allowDangerousTypes=true paths=./;./deprecated;./unserved;./job/...;./immutable output:dir=.
+//go:generate ../../../.run-controller-gen.sh crd:ignoreUnexportedFields=true,allowDangerousTypes=true paths=./;./deprecated;./unserved;./job/...;./immutable;./emptyobjectdefault output:dir=.
 
 // +groupName=testdata.kubebuilder.io
 // +versionName=v1

--- a/pkg/crd/testdata/emptyobjectdefault/types.go
+++ b/pkg/crd/testdata/emptyobjectdefault/types.go
@@ -1,0 +1,107 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package emptyobjectdefault
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PolicyAuditConfig is a nested struct whose fields each define a default.
+type PolicyAuditConfig struct {
+	// +kubebuilder:default=20
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	RateLimit *uint32 `json:"rateLimit,omitempty"`
+
+	// +kubebuilder:default=50
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	MaxFileSize *uint32 `json:"maxFileSize,omitempty"`
+
+	// +kubebuilder:default=null
+	// +optional
+	Destination string `json:"destination,omitempty"`
+
+	// +kubebuilder:default=local0
+	// +optional
+	SyslogFacility string `json:"syslogFacility,omitempty"`
+}
+
+// EmptyObjectDefaultSpec defaults a pointer field to an empty object. The nested
+// fields still need their defaults, so the parent must render as default: {} and
+// not default: null.
+type EmptyObjectDefaultSpec struct {
+	// +kubebuilder:default={}
+	// +optional
+	PolicyAuditConfig *PolicyAuditConfig `json:"policyAuditConfig,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// EmptyObjectDefault is the Schema for the emptyobjectdefault API
+type EmptyObjectDefault struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec EmptyObjectDefaultSpec `json:"spec"`
+}
+
+// +kubebuilder:object:root=true
+
+// EmptyObjectDefaultList contains a list of EmptyObjectDefault
+type EmptyObjectDefaultList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []EmptyObjectDefault `json:"items"`
+}
+
+// StageConfig has a required field. When the parent defaults to an empty object,
+// the API server rejects the CRD because the default must satisfy the schema and
+// the required field is missing.
+type StageConfig struct {
+	// +kubebuilder:validation:Enum=pending;running;done
+	Stage string `json:"stage"`
+}
+
+// RequiredChildDefaultSpec defaults a pointer field to an empty object whose
+// child is required.
+type RequiredChildDefaultSpec struct {
+	// +kubebuilder:default={}
+	// +optional
+	Status *StageConfig `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// RequiredChildDefault is the Schema for the requiredchilddefaults API
+type RequiredChildDefault struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec RequiredChildDefaultSpec `json:"spec"`
+}
+
+// +kubebuilder:object:root=true
+
+// RequiredChildDefaultList contains a list of RequiredChildDefault
+type RequiredChildDefaultList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []RequiredChildDefault `json:"items"`
+}

--- a/pkg/crd/testdata/emptyobjectdefault_test.go
+++ b/pkg/crd/testdata/emptyobjectdefault_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cronjob
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+var _ = Describe("EmptyObjectDefault CRD", func() {
+	newObj := func(name string, policyAuditConfig map[string]any) *unstructured.Unstructured {
+		spec := map[string]any{}
+		if policyAuditConfig != nil {
+			spec["policyAuditConfig"] = policyAuditConfig
+		}
+		return &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "testdata.kubebuilder.io/v1",
+				"kind":       "EmptyObjectDefault",
+				"metadata": map[string]any{
+					"name":      name,
+					"namespace": "default",
+				},
+				"spec": spec,
+			},
+		}
+	}
+
+	getPolicyAuditConfig := func(ctx SpecContext, obj *unstructured.Unstructured) map[string]any {
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		cfg, found, err := unstructured.NestedMap(obj.Object, "spec", "policyAuditConfig")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue(), "policyAuditConfig should be defaulted to an object, not left unset")
+		return cfg
+	}
+
+	It("should apply the empty object default and fill in all nested defaults when the field is omitted", func(ctx SpecContext) {
+		obj := newObj("defaults-omitted", nil)
+		Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+
+		Expect(getPolicyAuditConfig(ctx, obj)).To(Equal(map[string]any{
+			"rateLimit":      int64(20),
+			"maxFileSize":    int64(50),
+			"destination":    "null",
+			"syslogFacility": "local0",
+		}))
+	})
+
+	It("should keep explicitly set values and only default the missing nested fields", func(ctx SpecContext) {
+		obj := newObj("defaults-partial", map[string]any{
+			"rateLimit": int64(5),
+		})
+		Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+
+		Expect(getPolicyAuditConfig(ctx, obj)).To(Equal(map[string]any{
+			"rateLimit":      int64(5),
+			"maxFileSize":    int64(50),
+			"destination":    "null",
+			"syslogFacility": "local0",
+		}))
+	})
+
+	It("should reject a nested value that violates its validation even though the parent defaults to {}", func(ctx SpecContext) {
+		obj := newObj("defaults-invalid", map[string]any{
+			"rateLimit": int64(0),
+		})
+		Expect(k8sClient.Create(ctx, obj)).To(MatchError(ContainSubstring("greater than or equal to 1")))
+	})
+})
+
+var _ = Describe("RequiredChildDefault CRD", func() {
+	It("should be rejected by the API server because the {} default is missing the required child field", func(ctx SpecContext) {
+		data, err := os.ReadFile("testdata.kubebuilder.io_requiredchilddefaults.yaml")
+		Expect(err).NotTo(HaveOccurred())
+
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		Expect(yaml.UnmarshalStrict(data, crd)).To(Succeed())
+
+		err = k8sClient.Create(ctx, crd)
+		Expect(err).To(MatchError(And(
+			ContainSubstring("default"),
+			ContainSubstring("stage"),
+		)))
+	})
+})

--- a/pkg/crd/testdata/suite_test.go
+++ b/pkg/crd/testdata/suite_test.go
@@ -38,6 +38,7 @@ func TestCRD(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{CRDInstallOptions: envtest.CRDInstallOptions{Paths: []string{
+		"testdata.kubebuilder.io_emptyobjectdefaults.yaml",
 		"testdata.kubebuilder.io_enums.yaml",
 		"testdata.kubebuilder.io_immutabletypes.yaml",
 	}}}

--- a/pkg/crd/testdata/testdata.kubebuilder.io_emptyobjectdefaults.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_emptyobjectdefaults.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  name: emptyobjectdefaults.testdata.kubebuilder.io
+spec:
+  group: testdata.kubebuilder.io
+  names:
+    kind: EmptyObjectDefault
+    listKind: EmptyObjectDefaultList
+    plural: emptyobjectdefaults
+    singular: emptyobjectdefault
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: EmptyObjectDefault is the Schema for the emptyobjectdefault API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              EmptyObjectDefaultSpec defaults a pointer field to an empty object. The nested
+              fields still need their defaults, so the parent must render as default: {} and
+              not default: null.
+            properties:
+              policyAuditConfig:
+                default: {}
+                description: PolicyAuditConfig is a nested struct whose fields each
+                  define a default.
+                properties:
+                  destination:
+                    default: "null"
+                    type: string
+                  maxFileSize:
+                    default: 50
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  rateLimit:
+                    default: 20
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  syslogFacility:
+                    default: local0
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/pkg/crd/testdata/testdata.kubebuilder.io_requiredchilddefaults.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_requiredchilddefaults.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  name: requiredchilddefaults.testdata.kubebuilder.io
+spec:
+  group: testdata.kubebuilder.io
+  names:
+    kind: RequiredChildDefault
+    listKind: RequiredChildDefaultList
+    plural: requiredchilddefaults
+    singular: requiredchilddefault
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: RequiredChildDefault is the Schema for the requiredchilddefaults
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              RequiredChildDefaultSpec defaults a pointer field to an empty object whose
+              child is required.
+            properties:
+              status:
+                default: {}
+                description: |-
+                  StageConfig has a required field. When the parent defaults to an empty object,
+                  the API server rejects the CRD because the default must satisfy the schema and
+                  the required field is missing.
+                properties:
+                  stage:
+                    enum:
+                    - pending
+                    - running
+                    - done
+                    type: string
+                required:
+                - stage
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
Adds test coverage for the scenarios in #622 (+kubebuilder:default={} on a pointer field whose nested fields have their own defaults)