### PR TITLE
:bug: fix(crd): panic when parsing type aliases from indirectly imported packages

### DIFF
--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -277,6 +277,29 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 				assertCRDForGroupKind(pkgs[0], schema.GroupKind{Kind: "CronJob"}, "testdata._cronjobs.yaml")
 			})
 		})
+
+		Context("Type Alias API", func() {
+			BeforeEach(func() {
+				pkgPaths = []string{"./typealias_indirect"}
+				expPkgLen = 1
+			})
+			It("should handle types from indirectly imported packages via type aliases", func() {
+				By("verifying no errors occurred during package loading and parsing")
+				Expect(packageErrors(pkgs[0])).NotTo(HaveOccurred())
+
+				By("requesting schema for type with indirect alias")
+				typeIdent := crd.TypeIdent{
+					Package: pkgs[0],
+					Name:    "IndirectAliasSpec",
+				}
+				parser.NeedSchemaFor(typeIdent)
+
+				By("verifying the schema includes properties from the base type")
+				schema, found := parser.Schemata[typeIdent]
+				Expect(found).To(BeTrue(), "schema for IndirectAliasSpec should be generated")
+				Expect(schema.Properties).To(HaveKey("field"), "should have field property")
+			})
+		})
 	})
 
 	It("should generate plural words for Kind correctly", func() {

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -102,14 +102,48 @@ func (c *schemaContext) ForInfo(info *markers.TypeInfo) *schemaContext {
 // requestSchema asks for the schema for a type in the package with the
 // given import path.
 func (c *schemaContext) requestSchema(pkgPath, typeName string) {
+	c.requestSchemaWithPkg(pkgPath, typeName, nil)
+}
+
+func (c *schemaContext) requestSchemaWithPkg(pkgPath, typeName string, typesPkg *types.Package) {
 	pkg := c.pkg
 	if pkgPath != "" {
 		pkg = c.pkg.Imports()[pkgPath]
+		if pkg == nil && typesPkg != nil {
+			pkg = c.findPackageRecursive(typesPkg.Path())
+		}
+		if pkg == nil {
+			c.pkg.AddError(fmt.Errorf("unable to find package %q for type %s (not in direct imports)", pkgPath, typeName))
+			return
+		}
 	}
 	c.schemaRequester.NeedSchemaFor(TypeIdent{
 		Package: pkg,
 		Name:    typeName,
 	})
+}
+
+func (c *schemaContext) findPackageRecursive(pkgPath string) *loader.Package {
+	visited := make(map[*loader.Package]bool)
+	queue := []*loader.Package{c.pkg}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		if visited[current] {
+			continue
+		}
+		visited[current] = true
+
+		for importPath, importPkg := range current.Imports() {
+			if loader.NonVendorPath(importPath) == loader.NonVendorPath(pkgPath) {
+				return importPkg
+			}
+			queue = append(queue, importPkg)
+		}
+	}
+	return nil
 }
 
 // infoToSchema creates a schema for the type in the given set of type information.
@@ -310,7 +344,7 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		if pkg == ctx.pkg.Types {
 			pkgPath = ""
 		}
-		ctx.requestSchema(pkgPath, typeNameInfo.Name())
+		ctx.requestSchemaWithPkg(pkgPath, typeNameInfo.Name(), pkg)
 		link := TypeRefLink(pkgPath, typeNameInfo.Name())
 
 		// In cases where we have a named type, apply the type and format from the named schema
@@ -352,8 +386,9 @@ func namedToSchema(ctx *schemaContext, named *ast.SelectorExpr) *apiextensionsv1
 	}
 	typeInfo := typeInfoRaw.(interface{ Obj() *types.TypeName })
 	typeNameInfo := typeInfo.Obj()
-	nonVendorPath := loader.NonVendorPath(typeNameInfo.Pkg().Path())
-	ctx.requestSchema(nonVendorPath, typeNameInfo.Name())
+	typesPkg := typeNameInfo.Pkg()
+	nonVendorPath := loader.NonVendorPath(typesPkg.Path())
+	ctx.requestSchemaWithPkg(nonVendorPath, typeNameInfo.Name(), typesPkg)
 	link := TypeRefLink(nonVendorPath, typeNameInfo.Name())
 	return &apiextensionsv1.JSONSchemaProps{
 		Ref: &link,

--- a/pkg/crd/testdata/typealias_base/types.go
+++ b/pkg/crd/testdata/typealias_base/types.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typealias_base
+
+type BaseStruct struct {
+	Value string `json:"value"`
+}

--- a/pkg/crd/testdata/typealias_indirect/types.go
+++ b/pkg/crd/testdata/typealias_indirect/types.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package typealias_indirect
+
+import "testdata.kubebuilder.io/cronjob/typealias_middle"
+
+type IndirectAliasSpec struct {
+	Field typealias_middle.AliasedStruct `json:"field"`
+}

--- a/pkg/crd/testdata/typealias_middle/types.go
+++ b/pkg/crd/testdata/typealias_middle/types.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package typealias_middle
+
+import "testdata.kubebuilder.io/cronjob/typealias_base"
+
+type AliasedStruct = typealias_base.BaseStruct


### PR DESCRIPTION
## Problem

`controller-gen` may be crashing when a type alias points to a package that is not directly imported.

Example 

```text
panic: runtime error: invalid memory address or nil pointer dereference
at Parser.NeedPackage
```

### When this happens

* Package A uses a type from package B
* Package B defines it as an alias to a type in package C
* Package A imports B, but not C
* The real type lives in C

Result: generator cannot find the package and crashes

## Solution

Make type resolution smarter.

* Use Go type info to find where the type actually comes from
* If not in direct imports, search through imported packages recursively
* If still not found, return a clear error instead of crashing

## Why this works

Before:

* Only checked direct imports
* Missing package caused a nil pointer → panic

Now:

* Walks the full import graph
* Correctly resolves types through aliases

Fixes #1063
