### PR TITLE
🐛 Dedupe equal Default values in flattenAllOfInto

### DIFF
--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -48,6 +48,96 @@ func isOrNil(val reflect.Value, valInt any, zeroInt any) bool {
 	}
 }
 
+// resolveFieldConflict handles per-field merge logic when both src and dst
+// have non-zero values for fieldName. It returns true if the values were
+// hoisted into the allOf remainders (caller must set hoisted = true).
+func resolveFieldConflict(fieldName string, srcField, dstField reflect.Value, srcInt, dstInt any, errRec ErrorRecorder, srcRemVal, dstRemVal reflect.Value, fieldIndex int) bool {
+	switch fieldName {
+	case "Properties":
+		// merge if possible, use all of otherwise
+		srcMap := srcInt.(map[string]apiextensionsv1.JSONSchemaProps)
+		dstMap := dstInt.(map[string]apiextensionsv1.JSONSchemaProps)
+
+		for k, v := range srcMap {
+			dstProp, exists := dstMap[k]
+			if !exists {
+				dstMap[k] = v
+				continue
+			}
+			flattenAllOfInto(&dstProp, v, errRec)
+			dstMap[k] = dstProp
+		}
+		return false
+	case "Required":
+		// merge
+		dstField.Set(reflect.AppendSlice(dstField, srcField))
+		return false
+	case "Type":
+		if srcInt != dstInt {
+			// TODO(directxman12): figure out how to attach this back to a useful point in the Go source or in the schema
+			errRec.AddError(fmt.Errorf("conflicting types in allOf branches in schema: %s vs %s", dstInt, srcInt))
+		}
+		// keep the destination value, for now
+		return false
+	case "Default":
+		// Default is *apiextensionsv1.JSON, which is comparable by pointer
+		// address rather than by the raw bytes it wraps. The generic
+		// equality short-circuit in the caller therefore cannot detect that
+		// two distinct allocations carry the same JSON value, so without
+		// this case equal defaults arriving from different sources (a
+		// type-level schema with a baked-in default plus a field-level
+		// +default= marker, for example) would be hoisted into a fresh
+		// allOf and produce a structural-schema-violating CRD that the API
+		// server rejects at apply time.
+		//
+		// When the raw bytes match, dedupe and keep one. When they differ,
+		// keep dst (the parent / field-level value) and drop src, matching
+		// how XPreserveUnknownFields and XMapType are merged below.
+		srcDef := srcInt.(*apiextensionsv1.JSON)
+		dstDef := dstInt.(*apiextensionsv1.JSON)
+		if srcDef != nil && dstDef != nil && bytes.Equal(srcDef.Raw, dstDef.Raw) {
+			return false
+		}
+		// values differ: keep dst, drop src.
+		return false
+	// TODO(directxman12):
+	// - Dependencies: if field x is present, then either schema validates or all props are present
+	// - AdditionalItems: like AdditionalProperties
+	// - Definitions: common named validation sets that can be references (merge, bail if duplicate)
+	case "AdditionalProperties":
+		// as of the time of writing, `allows: false` is not allowed, so we don't have to handle it
+		srcProps := srcInt.(*apiextensionsv1.JSONSchemaPropsOrBool)
+		if srcProps.Schema == nil {
+			// nothing to merge
+			return false
+		}
+		dstProps := dstInt.(*apiextensionsv1.JSONSchemaPropsOrBool)
+		if dstProps.Schema == nil {
+			dstProps.Schema = &apiextensionsv1.JSONSchemaProps{}
+		}
+		flattenAllOfInto(dstProps.Schema, *srcProps.Schema, errRec)
+		return false
+	case "XPreserveUnknownFields":
+		dstField.Set(srcField)
+		return false
+	case "XMapType":
+		dstField.Set(srcField)
+		return false
+	case "XValidations":
+		dstField.Set(reflect.AppendSlice(srcField, dstField))
+		return false
+	// NB(directxman12): no need to explicitly handle nullable -- false is considered to be the zero value
+	// TODO(directxman12): src isn't necessarily the field value -- it's just the most recent allOf entry
+	default:
+		// hoist into allOf...
+		srcRemVal.Field(fieldIndex).Set(srcField)
+		dstRemVal.Field(fieldIndex).Set(dstField)
+		// ...and clear the original
+		dstField.Set(reflect.Zero(srcField.Type()))
+		return true
+	}
+}
+
 // flattenAllOfInto copies properties from src to dst, then copies the properties
 // of each item in src's allOf to dst's properties as well.
 func flattenAllOfInto(dst *apiextensionsv1.JSONSchemaProps, src apiextensionsv1.JSONSchemaProps, errRec ErrorRecorder) {
@@ -110,84 +200,8 @@ func flattenAllOfInto(dst *apiextensionsv1.JSONSchemaProps, src apiextensionsv1.
 			continue
 		}
 
-		// resolve conflict
-		switch fieldName {
-		case "Properties":
-			// merge if possible, use all of otherwise
-			srcMap := srcInt.(map[string]apiextensionsv1.JSONSchemaProps)
-			dstMap := dstInt.(map[string]apiextensionsv1.JSONSchemaProps)
-
-			for k, v := range srcMap {
-				dstProp, exists := dstMap[k]
-				if !exists {
-					dstMap[k] = v
-					continue
-				}
-				flattenAllOfInto(&dstProp, v, errRec)
-				dstMap[k] = dstProp
-			}
-		case "Required":
-			// merge
-			dstField.Set(reflect.AppendSlice(dstField, srcField))
-		case "Type":
-			if srcInt != dstInt {
-				// TODO(directxman12): figure out how to attach this back to a useful point in the Go source or in the schema
-				errRec.AddError(fmt.Errorf("conflicting types in allOf branches in schema: %s vs %s", dstInt, srcInt))
-			}
-			// keep the destination value, for now
-		case "Default":
-			// Default is *apiextensionsv1.JSON, which is comparable by pointer
-			// address rather than by the raw bytes it wraps. The generic
-			// equality short-circuit above therefore cannot detect that two
-			// distinct allocations carry the same JSON value, so without this
-			// case equal defaults arriving from different sources (a type-level
-			// schema with a baked-in default plus a field-level +default=
-			// marker, for example) would be hoisted into a fresh allOf and
-			// produce a structural-schema-violating CRD that the API server
-			// rejects at apply time.
-			//
-			// When the raw bytes match, dedupe and keep one. When they differ,
-			// keep dst (the parent / field-level value) and drop src, matching
-			// how XPreserveUnknownFields and XMapType are merged below.
-			srcDef := srcInt.(*apiextensionsv1.JSON)
-			dstDef := dstInt.(*apiextensionsv1.JSON)
-			if srcDef != nil && dstDef != nil && bytes.Equal(srcDef.Raw, dstDef.Raw) {
-				continue
-			}
-			// values differ: keep dst, drop src.
-			continue
-		// TODO(directxman12):
-		// - Dependencies: if field x is present, then either schema validates or all props are present
-		// - AdditionalItems: like AdditionalProperties
-		// - Definitions: common named validation sets that can be references (merge, bail if duplicate)
-		case "AdditionalProperties":
-			// as of the time of writing, `allows: false` is not allowed, so we don't have to handle it
-			srcProps := srcInt.(*apiextensionsv1.JSONSchemaPropsOrBool)
-			if srcProps.Schema == nil {
-				// nothing to merge
-				continue
-			}
-			dstProps := dstInt.(*apiextensionsv1.JSONSchemaPropsOrBool)
-			if dstProps.Schema == nil {
-				dstProps.Schema = &apiextensionsv1.JSONSchemaProps{}
-			}
-			flattenAllOfInto(dstProps.Schema, *srcProps.Schema, errRec)
-		case "XPreserveUnknownFields":
-			dstField.Set(srcField)
-		case "XMapType":
-			dstField.Set(srcField)
-		case "XValidations":
-			dstField.Set(reflect.AppendSlice(srcField, dstField))
-		// NB(directxman12): no need to explicitly handle nullable -- false is considered to be the zero value
-		// TODO(directxman12): src isn't necessarily the field value -- it's just the most recent allOf entry
-		default:
-			// hoist into allOf...
+		if resolveFieldConflict(fieldName, srcField, dstField, srcInt, dstInt, errRec, srcRemVal, dstRemVal, i) {
 			hoisted = true
-
-			srcRemVal.Field(i).Set(srcField)
-			dstRemVal.Field(i).Set(dstField)
-			// ...and clear the original
-			dstField.Set(zeroVal)
 		}
 	}
 

--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -17,6 +17,7 @@ limitations under the License.
 package crd
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"slices"
@@ -134,7 +135,25 @@ func flattenAllOfInto(dst *apiextensionsv1.JSONSchemaProps, src apiextensionsv1.
 				errRec.AddError(fmt.Errorf("conflicting types in allOf branches in schema: %s vs %s", dstInt, srcInt))
 			}
 			// keep the destination value, for now
-		// TODO(directxman12): Default -- use field?
+		case "Default":
+			// Default is *apiextensionsv1.JSON. Two pointers to equal-valued
+			// JSON are "comparable" in reflect's sense (any pointer is) but
+			// compare by address, not by the bytes they wrap. Without this
+			// case, two equal-valued defaults arriving from different sources
+			// (e.g. a type-level schema with a baked-in default plus a
+			// field-level +default= marker) get hoisted into allOf, producing
+			// the structural-schema-violating shape reported in #1027.
+			//
+			// Compare by raw bytes; if equal, dedupe. Otherwise keep dst
+			// (the parent / field-level value), matching how
+			// XPreserveUnknownFields and XMapType are merged below.
+			srcDef := srcInt.(*apiextensionsv1.JSON)
+			dstDef := dstInt.(*apiextensionsv1.JSON)
+			if srcDef != nil && dstDef != nil && bytes.Equal(srcDef.Raw, dstDef.Raw) {
+				continue
+			}
+			// values differ: keep dst, drop src.
+			continue
 		// TODO(directxman12):
 		// - Dependencies: if field x is present, then either schema validates or all props are present
 		// - AdditionalItems: like AdditionalProperties

--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -136,17 +136,19 @@ func flattenAllOfInto(dst *apiextensionsv1.JSONSchemaProps, src apiextensionsv1.
 			}
 			// keep the destination value, for now
 		case "Default":
-			// Default is *apiextensionsv1.JSON. Two pointers to equal-valued
-			// JSON are "comparable" in reflect's sense (any pointer is) but
-			// compare by address, not by the bytes they wrap. Without this
-			// case, two equal-valued defaults arriving from different sources
-			// (e.g. a type-level schema with a baked-in default plus a
-			// field-level +default= marker) get hoisted into allOf, producing
-			// the structural-schema-violating shape reported in #1027.
+			// Default is *apiextensionsv1.JSON, which is comparable by pointer
+			// address rather than by the raw bytes it wraps. The generic
+			// equality short-circuit above therefore cannot detect that two
+			// distinct allocations carry the same JSON value, so without this
+			// case equal defaults arriving from different sources (a type-level
+			// schema with a baked-in default plus a field-level +default=
+			// marker, for example) would be hoisted into a fresh allOf and
+			// produce a structural-schema-violating CRD that the API server
+			// rejects at apply time.
 			//
-			// Compare by raw bytes; if equal, dedupe. Otherwise keep dst
-			// (the parent / field-level value), matching how
-			// XPreserveUnknownFields and XMapType are merged below.
+			// When the raw bytes match, dedupe and keep one. When they differ,
+			// keep dst (the parent / field-level value) and drop src, matching
+			// how XPreserveUnknownFields and XMapType are merged below.
 			srcDef := srcInt.(*apiextensionsv1.JSON)
 			dstDef := dstInt.(*apiextensionsv1.JSON)
 			if srcDef != nil && dstDef != nil && bytes.Equal(srcDef.Raw, dstDef.Raw) {

--- a/pkg/crd/flatten_all_of_test.go
+++ b/pkg/crd/flatten_all_of_test.go
@@ -397,8 +397,8 @@ var _ = Describe("AllOf Flattening", func() {
 		}))
 	})
 
-	Context("when the same default appears on both the type schema and the field (the #1027 pattern)", func() {
-		It("should dedupe equal defaults instead of hoisting them into allOf", func() {
+	Context("when the same default appears on both the type schema and the field", func() {
+		It("should not allow duplications when default values are identical", func() {
 			By("flattening a schema where two AllOf branches carry equal-valued *JSON defaults from different allocations")
 			typeDefault := &apiextensionsv1.JSON{Raw: []byte(`"TCP"`)}
 			fieldDefault := &apiextensionsv1.JSON{Raw: []byte(`"TCP"`)} // same bytes, distinct alloc
@@ -425,7 +425,7 @@ var _ = Describe("AllOf Flattening", func() {
 			Expect(string(protocol.Default.Raw)).To(Equal(`"TCP"`))
 		})
 
-		It("should keep the parent-level default when the values differ", func() {
+		It("should keep the parent-level default when default values differ", func() {
 			By("flattening a schema where the parent and an embedded type carry different *JSON defaults")
 			typeDefault := &apiextensionsv1.JSON{Raw: []byte(`"TCP"`)}
 			fieldDefault := &apiextensionsv1.JSON{Raw: []byte(`"UDP"`)}

--- a/pkg/crd/flatten_all_of_test.go
+++ b/pkg/crd/flatten_all_of_test.go
@@ -396,4 +396,59 @@ var _ = Describe("AllOf Flattening", func() {
 			AllOf:     []apiextensionsv1.JSONSchemaProps{{Pattern: "^[abc]$"}, {Pattern: "^[abcdef]$"}},
 		}))
 	})
+
+	Context("when the same default appears on both the type schema and the field (the #1027 pattern)", func() {
+		It("should dedupe equal defaults instead of hoisting them into allOf", func() {
+			By("flattening a schema where two AllOf branches carry equal-valued *JSON defaults from different allocations")
+			typeDefault := &apiextensionsv1.JSON{Raw: []byte(`"TCP"`)}
+			fieldDefault := &apiextensionsv1.JSON{Raw: []byte(`"TCP"`)} // same bytes, distinct alloc
+
+			original := &apiextensionsv1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"protocol": {
+						AllOf: []apiextensionsv1.JSONSchemaProps{
+							{Type: "string", Default: typeDefault},
+							{Default: fieldDefault},
+						},
+					},
+				},
+			}
+
+			flattened := crd.FlattenEmbedded(original, errRec)
+			Expect(errRec.FirstError()).NotTo(HaveOccurred())
+
+			By("ensuring the flattened protocol has a single default and no allOf")
+			protocol := flattened.Properties["protocol"]
+			Expect(protocol.AllOf).To(BeEmpty())
+			Expect(protocol.Type).To(Equal("string"))
+			Expect(protocol.Default).NotTo(BeNil())
+			Expect(string(protocol.Default.Raw)).To(Equal(`"TCP"`))
+		})
+
+		It("should keep the parent-level default when the values differ", func() {
+			By("flattening a schema where the parent and an embedded type carry different *JSON defaults")
+			typeDefault := &apiextensionsv1.JSON{Raw: []byte(`"TCP"`)}
+			fieldDefault := &apiextensionsv1.JSON{Raw: []byte(`"UDP"`)}
+
+			original := &apiextensionsv1.JSONSchemaProps{
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"protocol": {
+						Default: fieldDefault,
+						AllOf: []apiextensionsv1.JSONSchemaProps{
+							{Type: "string", Default: typeDefault},
+						},
+					},
+				},
+			}
+
+			flattened := crd.FlattenEmbedded(original, errRec)
+			Expect(errRec.FirstError()).NotTo(HaveOccurred())
+
+			By("ensuring the parent (field-level) default wins and there is no allOf")
+			protocol := flattened.Properties["protocol"]
+			Expect(protocol.AllOf).To(BeEmpty())
+			Expect(protocol.Default).NotTo(BeNil())
+			Expect(string(protocol.Default.Raw)).To(Equal(`"UDP"`))
+		})
+	})
 })


### PR DESCRIPTION
Adds an explicit `case "Default":` so two *apiextensionsv1.JSON pointers with equal raw bytes are deduped instead of hoisted into a fresh allOf, and adds regression tests for the equal-bytes and differing-bytes cases.

Follow-up to #1027 / #1035.

## What does this do, and why do we need it?

Closes the `// TODO(directxman12): Default -- use field?` in `pkg/crd/flatten.go` by giving `Default` an explicit merge case in `flattenAllOfInto`.

Today the `Default` field of `JSONSchemaProps` is `*apiextensionsv1.JSON`. That type is `Comparable` in `reflect`'s sense, but `==` on it compares pointer addresses, not pointee bytes. The equality check at `flatten.go:107`:

```go
if fldTyp.Comparable() && srcInt == dstInt {
    continue // same value
}
```

returns `false` for two distinct allocations that both wrap `"TCP"`. With no explicit case, the field falls into the `default:` branch which hoists both values into a fresh `allOf`, producing structural-schema-violating output:

```yaml
protocol:
  allOf:
  - default: TCP
  - default: TCP
  type: string
```

The API server rejects this with:

```
properties[protocol].allOf[0].default: Forbidden: must be undefined to be structural
properties[protocol].allOf[1].default: Forbidden: must be undefined to be structural
```

## How this relates to #1035

#1035 fixed the only known producer of this shape by removing the hard-coded `corev1.Protocol` schema from `pkg/crd/known_types.go` once `k8s.io/api` started shipping the `+default="TCP"` marker upstream. That fix is preserved here — including the regression test on `CronJobSpec.Protocol` in `pkg/crd/testdata/cronjob_types.go`, which now also serves as a higher-level integration check for this PR.

This PR closes the **merge-logic** half of the problem so the same YAML can't recur from a future `KnownPackages` override, a `+default=`-carrying alias type, or any other code path that puts a default on a referenced type schema.

## Behavior change

`flattenAllOfInto` now handles `Default` explicitly:

- Equal raw bytes → dedupe, keep one, no `allOf`.
- Differing bytes → keep `dst` (parent / field-level value), drop `src`. This matches how `XPreserveUnknownFields` and `XMapType` are already merged: the field-level value wins over the type-level value, since users add `+default=` on a field precisely to override anything the type provides. No error is recorded — silently honoring the override is the less surprising behavior. If reviewers prefer an error here, swapping the final `continue` for `errRec.AddError(...)` is a one-line change.

No public API changes. No marker changes. No testdata bumps. Behavior change is limited to schemas that previously produced `default: ...` inside `allOf`, which were already broken at apply-time, so this can only fix CRDs, not break them.

## Test plan

```
go test ./pkg/crd/...
```

Two new specs in `pkg/crd/flatten_all_of_test.go`:

1. Two `*JSON` defaults with equal raw bytes (the #1027 shape) — expects no `allOf` and a single preserved default.
2. Two `*JSON` defaults with different raw bytes — expects the dst (field-level) value to win and no `allOf`.

The existing `It("should leave properties not in an AllOf branch ... alone")` spec still passes, confirming we haven't regressed the "no merge needed" path.

The `Protocol corev1.Protocol` field added to the cronjob testdata in #1035 continues to flatten to a single `default: TCP` (verified against `pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml`).

## What issue does this fix

Fixes #65

Follow-up to / completes #1027 (originally fixed by #1035).