### PR TITLE
🌱 Add OS-specific files and build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,16 @@
 *~
 .vscode/
 
+# OS-specific files
+.DS_Store
+Thumbs.db
+
 # Tools binaries.
 out
 hack/tools/bin
+/bin/
 
+# Test and build artifacts
 junit-report.xml
 /artifacts
+*.log


### PR DESCRIPTION
Improve .gitignore to avoid we commit files that we should not.