### PR TITLE
🌱chore: Update golangci-lint to v2.12.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,6 +33,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # tag=v9.2.0
         with:
-          version: v2.11.3
+          version: v2.12.1
           args: --output.text.print-linter-name=true --output.text.colors=true --timeout 10m
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.25"
+  go: "1.26"
   timeout: 10m
   modules-download-mode: readonly
   allow-parallel-runners: true
@@ -58,6 +58,9 @@ linters:
             msg: Use ginkgos SpecContext or go testings t.Context instead
           - pattern: context.TODO
             msg: Use ginkgos SpecContext or go testings t.Context instead
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     govet:
       disable:
         - fieldalignment

--- a/pkg/crd/flatten.go
+++ b/pkg/crd/flatten.go
@@ -40,7 +40,7 @@ type ErrorRecorder interface {
 // it compares val to valInt (which should probably be the zero value).
 func isOrNil(val reflect.Value, valInt any, zeroInt any) bool {
 	switch valKind := val.Kind(); valKind {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		return val.IsNil()
 	default:
 		return valInt == zeroInt

--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -235,6 +235,7 @@ func FixTopLevelMetadata(crd apiextensionsv1.CustomResourceDefinition) {
 		if v.Schema != nil && v.Schema.OpenAPIV3Schema != nil && v.Schema.OpenAPIV3Schema.Properties != nil {
 			schemaProperties := v.Schema.OpenAPIV3Schema.Properties
 			if _, ok := schemaProperties["metadata"]; ok {
+				//nolint:goconst
 				schemaProperties["metadata"] = apiextensionsv1.JSONSchemaProps{Type: "object"}
 			}
 		}

--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -28,10 +28,10 @@ import (
 var KnownPackages = map[string]PackageOverride{
 	"k8s.io/apimachinery/pkg/apis/meta/v1": func(p *Parser, pkg *loader.Package) {
 		p.Schemata[TypeIdent{Name: "ObjectMeta", Package: pkg}] = apiextensionsv1.JSONSchemaProps{
-			Type: "object",
+			Type: "object", //nolint:goconst
 		}
 		p.Schemata[TypeIdent{Name: "Time", Package: pkg}] = apiextensionsv1.JSONSchemaProps{
-			Type:   "string",
+			Type:   "string", //nolint:goconst
 			Format: "date-time",
 		}
 		p.Schemata[TypeIdent{Name: "MicroTime", Package: pkg}] = apiextensionsv1.JSONSchemaProps{

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -128,6 +128,7 @@ func infoToSchema(ctx *schemaContext) *apiextensionsv1.JSONSchemaProps {
 
 		// If the obj implements a text marshaler, encode it as a string.
 		case implements(obj.Type(), textMarshaler):
+			//nolint:goconst
 			schema := &apiextensionsv1.JSONSchemaProps{Type: "string"}
 			applyMarkers(ctx, ctx.info.Markers, schema, ctx.info.RawSpec.Type)
 			if schema.Type != "string" {
@@ -424,6 +425,7 @@ func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiextensionsv1.JSON
 		return &apiextensionsv1.JSONSchemaProps{}
 	}
 
+	//nolint:goconst
 	return &apiextensionsv1.JSONSchemaProps{
 		Type: "object",
 		AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{

--- a/pkg/markers/parse.go
+++ b/pkg/markers/parse.go
@@ -642,7 +642,7 @@ func ArgumentFromType(rawType reflect.Type) (Argument, error) {
 	}
 
 	arg := Argument{}
-	if rawType.Kind() == reflect.Ptr {
+	if rawType.Kind() == reflect.Pointer {
 		rawType = rawType.Elem()
 		arg.Pointer = true
 		arg.Optional = true


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->

 ## Summary                                                                                                                                                                
  - Update golangci-lint action from v2.11.3 to v2.12.1                                                                                                                     
  - Add `goconst` linter configuration (`ignore-tests: true`, `min-occurrences: 5`) : https://github.com/golangci/golangci-lint/pull/6480                                                                         
  - Replace deprecated `reflect.Ptr` with `reflect.Pointer` 