### PR TITLE
:seedling: crd/markers: Emit cheaper CEL rules for `oneOf` markers

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -987,9 +987,8 @@ func (fields AtMostOneOf) ApplyToSchema(ctx *SchemaContext, schema *apiextension
 	if len(fields) == 0 {
 		return nil
 	}
-	rule := fieldsToOneOfCelRuleStr(fields)
 	xvalidation := XValidation{
-		Rule:    fmt.Sprintf("%s <= 1", rule),
+		Rule:    fmt.Sprintf("%s <= 1", fieldsToOneOfSumExpr(fields)),
 		Message: fmt.Sprintf("at most one of the fields in %v may be set", fields),
 	}
 	return xvalidation.ApplyToSchema(ctx, schema)
@@ -1004,9 +1003,8 @@ func (fields ExactlyOneOf) ApplyToSchema(ctx *SchemaContext, schema *apiextensio
 	if len(fields) == 0 {
 		return nil
 	}
-	rule := fieldsToOneOfCelRuleStr(fields)
 	xvalidation := XValidation{
-		Rule:    fmt.Sprintf("%s == 1", rule),
+		Rule:    fmt.Sprintf("%s == 1", fieldsToOneOfSumExpr(fields)),
 		Message: fmt.Sprintf("exactly one of the fields in %v must be set", fields),
 	}
 	return xvalidation.ApplyToSchema(ctx, schema)
@@ -1021,9 +1019,8 @@ func (fields AtLeastOneOf) ApplyToSchema(ctx *SchemaContext, schema *apiextensio
 	if len(fields) == 0 {
 		return nil
 	}
-	rule := fieldsToOneOfCelRuleStr(fields)
 	xvalidation := XValidation{
-		Rule:    fmt.Sprintf("%s >= 1", rule),
+		Rule:    fieldsToOneOfOrExpr(fields),
 		Message: fmt.Sprintf("at least one of the fields in %v must be set", fields),
 	}
 	return xvalidation.ApplyToSchema(ctx, schema)
@@ -1034,21 +1031,47 @@ func (AtLeastOneOf) ApplyPriority() ApplyPriority {
 	return ExactlyOneOf{}.ApplyPriority() + 1
 }
 
-// fieldsToOneOfCelRuleStr converts a slice of field names to a string representation
-// [has(self.field1),has(self.field1),...].filter(x, x == true).size()
-func fieldsToOneOfCelRuleStr(fields []string) string {
-	var list strings.Builder
-	list.WriteString("[")
+// fieldsToOneOfSumExpr returns a CEL expression that evaluates to the count of
+// the given fields that are set on self, using ternary-sum form:
+//
+//	(has(self.field1)?1:0) + (has(self.field2)?1:0) + ...
+//
+// The caller compares the result against a constant (== 1, <= 1).
+//
+// This form is preferred over [has(self.f1), has(self.f2), ...].filter(x, x == true).size()
+// because the latter pays for list construction and a comprehension over the list,
+// whereas the sum form is constant-cost scalar arithmetic.
+func fieldsToOneOfSumExpr(fields []string) string {
+	var b strings.Builder
 	for i, f := range fields {
 		if i > 0 {
-			list.WriteString(",")
+			b.WriteString("+")
 		}
-		list.WriteString("has(self.")
-		list.WriteString(f)
-		list.WriteString(")")
+		b.WriteString("(has(self.")
+		b.WriteString(f)
+		b.WriteString(")?1:0)")
 	}
-	list.WriteString("].filter(x,x==true).size()")
-	return list.String()
+	return b.String()
+}
+
+// fieldsToOneOfOrExpr returns a CEL boolean expression that is true when at
+// least one of the given fields is set on self:
+//
+//	has(self.field1) || has(self.field2) || ...
+//
+// This is strictly cheaper than counting and comparing >= 1 because || short-circuits
+// as soon as any field is found.
+func fieldsToOneOfOrExpr(fields []string) string {
+	var b strings.Builder
+	for i, f := range fields {
+		if i > 0 {
+			b.WriteString("||")
+		}
+		b.WriteString("has(self.")
+		b.WriteString(f)
+		b.WriteString(")")
+	}
+	return b.String()
 }
 
 // K8sEnumField exists solely to reject the k8s:enum marker when placed on a

--- a/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_oneofs.yaml
@@ -55,8 +55,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: exactly one of the fields in [foo bar] must be set
-                  rule: '[has(self.foo),has(self.bar)].filter(x,x==true).size() ==
-                    1'
+                  rule: (has(self.foo)?1:0)+(has(self.bar)?1:0) == 1
               firstTypeWithOneof:
                 properties:
                   bar:
@@ -68,8 +67,7 @@ spec:
                 - message: only one of foo|bar may be set
                   rule: '!(has(self.foo) && has(self.bar))'
                 - message: at most one of the fields in [foo bar] may be set
-                  rule: '[has(self.foo),has(self.bar)].filter(x,x==true).size() <=
-                    1'
+                  rule: (has(self.foo)?1:0)+(has(self.bar)?1:0) <= 1
               secondCustomTypeAlias:
                 description: This verifies if the custom type alias XValidation is
                   not duplicated.
@@ -91,9 +89,9 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: exactly one of the fields in [a b] must be set
-                  rule: '[has(self.a),has(self.b)].filter(x,x==true).size() == 1'
+                  rule: (has(self.a)?1:0)+(has(self.b)?1:0) == 1
                 - message: exactly one of the fields in [c d] must be set
-                  rule: '[has(self.c),has(self.d)].filter(x,x==true).size() == 1'
+                  rule: (has(self.c)?1:0)+(has(self.d)?1:0) == 1
               secondTypeWithOneof:
                 properties:
                   a:
@@ -107,9 +105,9 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: at most one of the fields in [a b] may be set
-                  rule: '[has(self.a),has(self.b)].filter(x,x==true).size() <= 1'
+                  rule: (has(self.a)?1:0)+(has(self.b)?1:0) <= 1
                 - message: at most one of the fields in [c d] may be set
-                  rule: '[has(self.c),has(self.d)].filter(x,x==true).size() <= 1'
+                  rule: (has(self.c)?1:0)+(has(self.d)?1:0) <= 1
               typeWithAllOneOf:
                 properties:
                   a:
@@ -127,11 +125,11 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: at most one of the fields in [a b] may be set
-                  rule: '[has(self.a),has(self.b)].filter(x,x==true).size() <= 1'
+                  rule: (has(self.a)?1:0)+(has(self.b)?1:0) <= 1
                 - message: exactly one of the fields in [c d] must be set
-                  rule: '[has(self.c),has(self.d)].filter(x,x==true).size() == 1'
+                  rule: (has(self.c)?1:0)+(has(self.d)?1:0) == 1
                 - message: at least one of the fields in [e f] must be set
-                  rule: '[has(self.e),has(self.f)].filter(x,x==true).size() >= 1'
+                  rule: has(self.e)||has(self.f)
               typeWithMultipleAtLeastOneOf:
                 properties:
                   a:
@@ -145,9 +143,9 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: at least one of the fields in [a b] must be set
-                  rule: '[has(self.a),has(self.b)].filter(x,x==true).size() >= 1'
+                  rule: has(self.a)||has(self.b)
                 - message: at least one of the fields in [c d] must be set
-                  rule: '[has(self.c),has(self.d)].filter(x,x==true).size() >= 1'
+                  rule: has(self.c)||has(self.d)
               typeWithOmitZero:
                 properties:
                   bar:
@@ -157,8 +155,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: at most one of the fields in [foo bar] may be set
-                  rule: '[has(self.foo),has(self.bar)].filter(x,x==true).size() <=
-                    1'
+                  rule: (has(self.foo)?1:0)+(has(self.bar)?1:0) <= 1
               typeWithOmitZeroAtLeastOneOf:
                 properties:
                   c:
@@ -168,7 +165,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: at least one of the fields in [c d] must be set
-                  rule: '[has(self.c),has(self.d)].filter(x,x==true).size() >= 1'
+                  rule: has(self.c)||has(self.d)
               typeWithOmitZeroExact:
                 properties:
                   a:
@@ -178,7 +175,7 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: exactly one of the fields in [a b] must be set
-                  rule: '[has(self.a),has(self.b)].filter(x,x==true).size() == 1'
+                  rule: (has(self.a)?1:0)+(has(self.b)?1:0) == 1
             type: object
         required:
         - spec


### PR DESCRIPTION
Followup to #1212

`AtMostOneOf`, `ExactlyOneOf`, and `AtLeastOneOf` currently emit a CEL rule of the form:

```cel
[has(self.a), has(self.b), ...].filter(x, x == true).size() <op> N
```

This pays for list construction and a comprehension over the list. Two equivalent but cheaper forms work just as well:

* `AtMostOneOf`/`ExactlyOneOf`: ternary-sum:
  ```cel
  (has(self.a)?1:0) + (has(self.b)?1:0) + ... <op> 1
  ```
  Constant-cost scalar arithmetic, no list, no iteration.

* `AtLeastOneOf`: short-circuit OR:
  ```cel
  has(self.a) || has(self.b) || ...
  ```
  Already a boolean, no count/compare, short-circuits as soon as any field is set.

User-visible behavior is unchanged: violation messages are emitted from the marker's static `Message` field, not from the rule expression itself.

I did some benchmarking with `github.com/google/cel-go/checker` to measure the estimated cost of both the old and the new CEL expressions with a couple number of items:
* estimated cost is from `checker.EstimateCost`: worst-case, what the apiserver budgets against the per-CRD limit at CRD-creation time
* runtime cost is from interpreter `ActualCost`: what counts against the per-call budget at admission

Runtime input states:
* `none`: no field set
* `one`: only first field set
* `all`: every field set
* `last`: only last field set

### `ExactlyOneOf` / `AtMostOneOf` (filter -> sum)

| N  | est.min  | est.max           | rt.none  | rt.one   | rt.all   |
|----|----------|-------------------|----------|----------|----------|
| 2  | 33 -> 6  | 57 -> 6 (−89%)    | 31 -> 6  | 44 -> 6  | 44 -> 6  |
| 3  | 38 -> 9  | 74 -> 9 (−88%)    | 35 -> 9  | 48 -> 9  | 48 -> 9  |
| 5  | 48 -> 15 | 108 -> 15 (−86%)  | 43 -> 15 | 56 -> 15 | 56 -> 15 |
| 10 | 73 -> 30 | 193 -> 30 (−84%)  | 63 -> 30 | 76 -> 30 | 76 -> 30 |

### `AtLeastOneOf` (filter -> `||`)

| N  | est.min  | est.max           | rt.none  | rt.one  | rt.last  |
|----|----------|-------------------|----------|---------|----------|
| 2  | 33 -> 2  | 57 -> 4 (−93%)    | 31 -> 4  | 44 -> 2 | 44 -> 4  |
| 3  | 38 -> 2  | 74 -> 6 (−92%)    | 35 -> 6  | 48 -> 2 | 48 -> 6  |
| 5  | 48 -> 2  | 108 -> 10 (−91%)  | 43 -> 10 | 56 -> 2 | 56 -> 10 |
| 10 | 73 -> 2  | 193 -> 20 (−90%)  | 63 -> 20 | 76 -> 2 | 76 -> 20 |

Note the `rt.one` column for `AtLeastOneOf` (cost `2` across all N): the `||` form short-circuits as soon as any field is found, so runtime cost is independent of how many fields the marker covers when any earlier one is set.

So these numbers show that:
* both estimated and runtime cost are always lower with the new expressions
* the maximum estimated cost, which as raised in #1212 can quickly balloon when nested deep in layers of unbounded arrays is significantly reduced by about 90% in average

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
