### PR TITLE
:bug: Accept `encoding.TextMarshaler` types as CRD map keys

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -386,20 +386,31 @@ func arrayToSchema(ctx *schemaContext, array *ast.ArrayType) *apiextensionsv1.JS
 // mapToSchema creates a schema for items of the given map.  Key types must eventually resolve
 // to string (other types aren't allowed by JSON, and thus the kubernetes API standards).
 func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiextensionsv1.JSONSchemaProps {
-	keyInfo := ctx.pkg.TypesInfo.TypeOf(mapType.Key)
-	// check that we've got a type that actually corresponds to a string
+	keyType := ctx.pkg.TypesInfo.TypeOf(mapType.Key)
+	// check that we've got a type that actually corresponds to a string, or that
+	// implements encoding.TextMarshaler (in which case it serializes to a string,
+	// just like text-marshaler-implementing field types do).
+	keyInfo := keyType
 	for keyInfo != nil {
 		switch typedKey := keyInfo.(type) {
 		case *types.Basic:
 			if typedKey.Info()&types.IsString == 0 {
-				ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map keys must be strings, not %s", keyInfo.String()), mapType.Key))
+				if implements(keyType, textMarshaler) {
+					keyInfo = nil // stop iterating
+					break
+				}
+				ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map keys must be strings or implement encoding.TextMarshaler, not %s", keyInfo.String()), mapType.Key))
 				return &apiextensionsv1.JSONSchemaProps{}
 			}
 			keyInfo = nil // stop iterating
 		case *types.Named:
 			keyInfo = typedKey.Underlying()
 		default:
-			ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map keys must be strings, not %s", keyInfo.String()), mapType.Key))
+			if implements(keyType, textMarshaler) {
+				keyInfo = nil // stop iterating
+				break
+			}
+			ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("map keys must be strings or implement encoding.TextMarshaler, not %s", keyInfo.String()), mapType.Key))
 			return &apiextensionsv1.JSONSchemaProps{}
 		}
 	}

--- a/pkg/crd/schema_test.go
+++ b/pkg/crd/schema_test.go
@@ -26,6 +26,7 @@ import (
 	pkgstest "golang.org/x/tools/go/packages/packagestest"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
+	"sigs.k8s.io/controller-tools/pkg/loader"
 	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -70,6 +71,106 @@ func transform(t *testing.T, expr string) *apiextensionsv1.JSONSchemaProps {
 	result := typeToSchema(schemaContext, definedType)
 	failIfErrors(t, pkg.Errors)
 	return result
+}
+
+// transformPackage loads pkgContents as a fake package and returns the schema
+// produced for the type definition named typeName, together with the package so
+// callers can inspect (or assert) any errors raised during schema generation.
+// Unlike transform, it does not fail the test when schema generation errors,
+// which lets negative cases assert that an error was produced.
+func transformPackage(t *testing.T, pkgContents, typeName string) (*apiextensionsv1.JSONSchemaProps, *loader.Package) {
+	moduleName := "sigs.k8s.io/controller-tools/pkg/crd"
+	modules := []pkgstest.Module{
+		{
+			Name: moduleName,
+			Files: map[string]any{
+				"test.go": pkgContents,
+			},
+		},
+	}
+
+	pkgs, exported, err := testloader.LoadFakeRoots(pkgstest.Modules, modules, moduleName)
+	if exported != nil {
+		t.Cleanup(exported.Cleanup)
+	}
+
+	if err != nil {
+		t.Fatalf("unable to load fake package: %s", err)
+	}
+
+	if len(pkgs) != 1 {
+		t.Fatal("expected to parse only one package")
+	}
+
+	pkg := pkgs[0]
+	pkg.NeedTypesInfo()
+
+	schemaContext := newSchemaContext(pkg, nil, true, false).ForInfo(&markers.TypeInfo{})
+
+	var definedType ast.Expr
+	for _, decl := range pkg.Syntax[0].Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if ok && typeSpec.Name.Name == typeName {
+				definedType = typeSpec.Type
+			}
+		}
+	}
+	if definedType == nil {
+		t.Fatalf("could not find type %q in fake package", typeName)
+	}
+
+	return typeToSchema(schemaContext, definedType), pkg
+}
+
+const textMarshalerKeyPackage = `
+	package crd
+
+	// textKey implements encoding.TextMarshaler, so it serializes to a string
+	// and is a valid (JSON string) map key.
+	type textKey struct{}
+
+	func (textKey) MarshalText() ([]byte, error) { return nil, nil }
+
+	// nonStringKey is a struct that does not implement encoding.TextMarshaler.
+	type nonStringKey struct{}
+
+	type TextMarshalerKeyMap map[textKey]string
+	type NonStringKeyMap map[nonStringKey]string
+`
+
+// Test_Schema_MapOfTextMarshalerKey verifies that a map keyed by a type that
+// implements encoding.TextMarshaler is accepted (mirroring how such types are
+// accepted as struct fields) and produces an ordinary string-keyed object
+// schema with no key schema emitted.
+func Test_Schema_MapOfTextMarshalerKey(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	output, pkg := transformPackage(t, textMarshalerKeyPackage, "TextMarshalerKeyMap")
+	failIfErrors(t, pkg.Errors)
+	g.Expect(output).To(gomega.Equal(&apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+			Allows: true,
+			Schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "string",
+			},
+		},
+	}))
+}
+
+// Test_Schema_MapOfNonStringKey verifies that a struct key that does not
+// implement encoding.TextMarshaler is still rejected.
+func Test_Schema_MapOfNonStringKey(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	_, pkg := transformPackage(t, textMarshalerKeyPackage, "NonStringKeyMap")
+	g.Expect(pkg.Errors).ToNot(gomega.BeEmpty())
+	g.Expect(pkg.Errors[0].Msg).To(gomega.ContainSubstring("map keys must be strings"))
 }
 
 func failIfErrors(t *testing.T, errs []packages.Error) {

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -297,6 +297,10 @@ type CronJobSpec struct {
 	// Maps of arrays of things-that-aren’t-strings are permitted
 	MapOfArraysOfFloats map[string][]bool `json:"mapOfArraysOfFloats,omitempty"`
 
+	// Maps keyed by a type that implements encoding.TextMarshaler are permitted,
+	// since such keys serialize to strings (just like TextMarshaler fields do).
+	MapOfTextMarshalerKeys map[URL3]string `json:"mapOfTextMarshalerKeys,omitempty"`
+
 	// +kubebuilder:validation:Minimum=-0.5
 	// +kubebuilder:validation:Maximum=1.5
 	// +kubebuilder:validation:MultipleOf=0.5

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9468,6 +9468,13 @@ spec:
                   fields
                 type: object
                 x-kubernetes-map-type: granular
+              mapOfTextMarshalerKeys:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Maps keyed by a type that implements encoding.TextMarshaler are permitted,
+                  since such keys serialize to strings (just like TextMarshaler fields do).
+                type: object
               minMaxProperties:
                 description: This tests that min/max properties work
                 maxProperties: 2


### PR DESCRIPTION
`controller-gen` already emits `type: string` for any type implementing `encoding.TextMarshaler` when it is used as a struct field (`infoToSchema`), but `mapToSchema` rejected the identical type as a map key with a fatal `"map keys must be strings"` error. This is an internal inconsistency: the key type is never represented in the generated schema (a map is always `type: object` + `additionalProperties`, with no `propertyNames`), so the validation gate in mapToSchema was the only place the key type mattered.

This PR applies the same `implements(keyType, textMarshaler)` check used by the field path before erroring on a non-string key. The original named/struct key type is tested, not the unwrapped underlying, since the method set lives there. Non-string keys that do not implement `TextMarshaler` still error.

The change is output-neutral: generated YAML is byte-identical to the string-keyed case. It is also runtime-safe, since CRDs are stored as JSON and both `encoding/json` and `sigs.k8s.io/json` marshal map keys through `encoding.Text{Marshaler,Unmarshaler}`.

Closes #1420

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
