### PR TITLE
:seedling: refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/pkg/applyconfiguration/testdata/cronjob/api/v1/applyconfiguration/utils.go
+++ b/pkg/applyconfiguration/testdata/cronjob/api/v1/applyconfiguration/utils.go
@@ -13,7 +13,7 @@ import (
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no
 // apply configuration type exists for the given GroupVersionKind.
-func ForKind(kind schema.GroupVersionKind) interface{} {
+func ForKind(kind schema.GroupVersionKind) any {
 	switch kind {
 	// Group=testdata.kubebuilder.io, Version=v1
 	case v1.SchemeGroupVersion.WithKind("AssociativeType"):

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -407,7 +407,7 @@ type Nullable struct{}
 //
 //	// Object default
 //	// +kubebuilder:default={replicas: 1}
-//	Config map[string]interface{}
+//	Config map[string]any
 //
 // +controllertools:marker:generateHelp:category="CRD validation"
 type Default struct {
@@ -468,7 +468,7 @@ type Title struct {
 //
 //	// Object default (JSON format)
 //	// +default={"policy": "delete"}
-//	Config map[string]interface{}
+//	Config map[string]any
 //
 // +controllertools:marker:generateHelp:category="CRD validation"
 type KubernetesDefault struct {
@@ -531,7 +531,7 @@ type Example struct {
 // Example:
 //
 //	// +kubebuilder:pruning:PreserveUnknownFields
-//	RawConfig map[string]interface{}
+//	RawConfig map[string]any
 //
 // +controllertools:marker:generateHelp:category="CRD processing"
 type XPreserveUnknownFields struct{}

--- a/pkg/crd/parser_integration_test.go
+++ b/pkg/crd/parser_integration_test.go
@@ -273,7 +273,7 @@ var _ = Describe("CRD Generation From Parsing to CustomResourceDefinition", func
 			})
 		})
 
-		Context("InterfaceField API with any/interface{} types", func() {
+		Context("InterfaceField API with any types", func() {
 			BeforeEach(func() {
 				pkgPaths = []string{"./iface/..."}
 				expPkgLen = 1

--- a/pkg/crd/testdata/crd_test.go
+++ b/pkg/crd/testdata/crd_test.go
@@ -62,14 +62,14 @@ var _ = Describe("Enum CRD", func() {
 
 func enumObject(name, fieldValue string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": "testdata.kubebuilder.io/v1",
 			"kind":       "Enum",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      name,
 				"namespace": metav1.NamespaceDefault,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"field": fieldValue,
 			},
 		},


### PR DESCRIPTION
Replace `interface{}` with the equivalent `any` type alias available since Go 1.18.

Files changed:
- pkg/crd/markers/validation.go
- pkg/crd/testdata/crd_test.go
- pkg/crd/parser_integration_test.go
- pkg/applyconfiguration/testdata/cronjob/api/v1/applyconfiguration/utils.go