### PR TITLE
:sparkles: add ignore top level object and type metadata flag

### DIFF
--- a/pkg/crd/gen.go
+++ b/pkg/crd/gen.go
@@ -79,6 +79,10 @@ type Generator struct {
 	// GenerateEmbeddedObjectMeta specifies if any embedded ObjectMeta in the CRD should be generated
 	GenerateEmbeddedObjectMeta *bool `marker:",optional"`
 
+	// IgnoreTopLevelObjectAndTypeMeta specifies if the top level ObjectMeta and type metadata (kind and apiVersion)
+	// should be generated.
+	IgnoreTopLevelObjectAndTypeMeta *bool `marker:",optional"`
+
 	// HeaderFile specifies the header text (e.g. license) to prepend to generated files.
 	HeaderFile string `marker:",optional"`
 
@@ -131,7 +135,8 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		IgnoreUnexportedFields: g.IgnoreUnexportedFields != nil && *g.IgnoreUnexportedFields,
 		AllowDangerousTypes:    g.AllowDangerousTypes != nil && *g.AllowDangerousTypes,
 		// Indicates the parser on whether to register the ObjectMeta type or not
-		GenerateEmbeddedObjectMeta: g.GenerateEmbeddedObjectMeta != nil && *g.GenerateEmbeddedObjectMeta,
+		GenerateEmbeddedObjectMeta:      g.GenerateEmbeddedObjectMeta != nil && *g.GenerateEmbeddedObjectMeta,
+		IgnoreTopLevelObjectAndTypeMeta: g.IgnoreTopLevelObjectAndTypeMeta != nil && *g.IgnoreTopLevelObjectAndTypeMeta,
 	}
 
 	AddKnownTypes(parser)
@@ -182,8 +187,10 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		crdRaw := parser.CustomResourceDefinitions[groupKind]
 		addAttribution(&crdRaw)
 
-		// Prevent the top level metadata for the CRD to be generate regardless of the intention in the arguments
-		FixTopLevelMetadata(crdRaw)
+		if !parser.IgnoreTopLevelObjectAndTypeMeta {
+			// Prevent the top level metadata for the CRD to be generate regardless of the intention in the arguments
+			FixTopLevelMetadata(crdRaw)
+		}
 
 		versionedCRDs := make([]any, len(crdVersions))
 		for i, ver := range crdVersions {

--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -169,6 +169,23 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		By("comparing the two")
 		Expect(out.buf.String()).To(Equal(string(expectedFile)), cmp.Diff(out.buf.String(), string(expectedFile)))
 	})
+
+	It("should not generate top level type and object metadata", func() {
+		By("calling Generate")
+		yes := true
+		gen := &crd.Generator{
+			CRDVersions:                     []string{"v1"},
+			IgnoreTopLevelObjectAndTypeMeta: &yes,
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("loading the desired YAML")
+		expectedFile, err := os.ReadFile(filepath.Join(genDir, "bar.example.com_foos_no_toplevel_meta.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("comparing the two")
+		Expect(out.buf.String()).To(Equal(string(expectedFile)), cmp.Diff(out.buf.String(), string(expectedFile)))
+	})
 })
 
 type outputRule struct {

--- a/pkg/crd/parser.go
+++ b/pkg/crd/parser.go
@@ -92,6 +92,9 @@ type Parser struct {
 
 	// GenerateEmbeddedObjectMeta specifies if any embedded ObjectMeta should be generated
 	GenerateEmbeddedObjectMeta bool
+
+	// IgnoreTopLevelObjectAndTypeMeta specifies if the top level ObjectMeta and TypeMeta should be omitted
+	IgnoreTopLevelObjectAndTypeMeta bool
 }
 
 func (p *Parser) init() {
@@ -172,7 +175,7 @@ func (p *Parser) NeedSchemaFor(typ TypeIdent) {
 	// avoid tripping recursive schemata, like ManagedFields, by adding an empty WIP schema
 	p.Schemata[typ] = apiextensionsv1.JSONSchemaProps{}
 
-	schemaCtx := newSchemaContext(typ.Package, p, p.AllowDangerousTypes, p.IgnoreUnexportedFields)
+	schemaCtx := newSchemaContext(typ.Package, p, p.AllowDangerousTypes, p.IgnoreUnexportedFields, p.IgnoreTopLevelObjectAndTypeMeta)
 	ctxForInfo := schemaCtx.ForInfo(info)
 
 	pkgMarkers, err := markers.PackageMarkers(p.Collector, typ.Package)

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -71,19 +71,21 @@ type schemaContext struct {
 	schemaRequester schemaRequester
 	PackageMarkers  markers.MarkerValues
 
-	allowDangerousTypes    bool
-	ignoreUnexportedFields bool
+	allowDangerousTypes             bool
+	ignoreUnexportedFields          bool
+	ignoreTopLevelObjectAndTypeMeta bool
 }
 
 // newSchemaContext constructs a new schemaContext for the given package and schema requester.
 // It must have type info added before use via ForInfo.
-func newSchemaContext(pkg *loader.Package, req schemaRequester, allowDangerousTypes, ignoreUnexportedFields bool) *schemaContext {
+func newSchemaContext(pkg *loader.Package, req schemaRequester, allowDangerousTypes, ignoreUnexportedFields, ignoreTopLevelObjectAndTypeMeta bool) *schemaContext {
 	pkg.NeedTypesInfo()
 	return &schemaContext{
-		pkg:                    pkg,
-		schemaRequester:        req,
-		allowDangerousTypes:    allowDangerousTypes,
-		ignoreUnexportedFields: ignoreUnexportedFields,
+		pkg:                             pkg,
+		schemaRequester:                 req,
+		allowDangerousTypes:             allowDangerousTypes,
+		ignoreUnexportedFields:          ignoreUnexportedFields,
+		ignoreTopLevelObjectAndTypeMeta: ignoreTopLevelObjectAndTypeMeta,
 	}
 }
 
@@ -91,11 +93,12 @@ func newSchemaContext(pkg *loader.Package, req schemaRequester, allowDangerousTy
 // as this one, except with the given type information.
 func (c *schemaContext) ForInfo(info *markers.TypeInfo) *schemaContext {
 	return &schemaContext{
-		pkg:                    c.pkg,
-		info:                   info,
-		schemaRequester:        c.schemaRequester,
-		allowDangerousTypes:    c.allowDangerousTypes,
-		ignoreUnexportedFields: c.ignoreUnexportedFields,
+		pkg:                             c.pkg,
+		info:                            info,
+		schemaRequester:                 c.schemaRequester,
+		allowDangerousTypes:             c.allowDangerousTypes,
+		ignoreUnexportedFields:          c.ignoreUnexportedFields,
+		ignoreTopLevelObjectAndTypeMeta: c.ignoreTopLevelObjectAndTypeMeta,
 	}
 }
 
@@ -484,6 +487,14 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 		if len(jsonOpts) == 1 && jsonOpts[0] == "-" {
 			// skipped fields have the tag "-" (note that "-," means the field is named "-")
 			continue
+		}
+
+		//nolint:gocritic // we need here the switch on type, otherwise reflect package is needed
+		switch ft := field.RawField.Type.(type) {
+		case *ast.SelectorExpr:
+			if (ft.Sel.Name == "TypeMeta" || ft.Sel.Name == "ObjectMeta") && ctx.ignoreTopLevelObjectAndTypeMeta {
+				continue
+			}
 		}
 
 		inline := false

--- a/pkg/crd/schema_test.go
+++ b/pkg/crd/schema_test.go
@@ -64,7 +64,7 @@ func transform(t *testing.T, expr string) *apiextensionsv1.JSONSchemaProps {
 	pkg.NeedTypesInfo()
 	failIfErrors(t, pkg.Errors)
 
-	schemaContext := newSchemaContext(pkg, nil, true, false).ForInfo(&markers.TypeInfo{})
+	schemaContext := newSchemaContext(pkg, nil, true, false, false).ForInfo(&markers.TypeInfo{})
 	// yick: grab the only type definition
 	definedType := pkg.Syntax[0].Decls[0].(*ast.GenDecl).Specs[0].(*ast.TypeSpec).Type
 	result := typeToSchema(schemaContext, definedType)

--- a/pkg/crd/testdata/gen/bar.example.com_foos_no_toplevel_meta.yaml
+++ b/pkg/crd/testdata/gen/bar.example.com_foos_no_toplevel_meta.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  name: foos.bar.example.com
+spec:
+  group: bar.example.com
+  names:
+    kind: Foo
+    listKind: FooList
+    plural: foos
+    singular: foo
+  scope: Namespaced
+  versions:
+  - name: foo
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: Spec comments SHOULD appear in the CRD spec
+            properties:
+              defaultedString:
+                default: fooDefaultString
+                description: |-
+                  This tests that defaulted fields are stripped for v1beta1,
+                  but not for v1
+                example: fooExampleString
+                type: string
+            required:
+            - defaultedString
+            type: object
+          status:
+            description: Status comments SHOULD appear in the CRD spec
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/pkg/crd/zz_generated.markerhelp.go
+++ b/pkg/crd/zz_generated.markerhelp.go
@@ -52,6 +52,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "specifies if any embedded ObjectMeta in the CRD should be generated",
 				Details: "",
 			},
+			"IgnoreTopLevelObjectAndTypeMeta": {
+				Summary: "specifies if the top level ObjectMeta and type metadata (kind and apiVersion)",
+				Details: "should be generated.",
+			},
 			"HeaderFile": {
 				Summary: "specifies the header text (e.g. license) to prepend to generated files.",
 				Details: "",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

# What does this do, and why do we need it? 

as mentioned in #1431, this changeset adds an additional option/flag for the crd generator that can ignore those object and type meta fields when toggled. Reason: object and type meta are optional for the CRD definition because those fields are automatically assumed for any CRD, when not present. Please refer to the [issue](#1431) for more details and examples. 
