### PR TITLE
🌱fix: resolve misspell false positives and bump golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -33,6 +33,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # tag=v9.2.1
         with:
-          version: v2.12.1
+          version: v2.12.2
           args: --output.text.print-linter-name=true --output.text.colors=true --timeout 10m
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,8 @@ linters:
         - pkg: sigs.k8s.io/controller-runtime
           alias: ctrl
       no-unaliased: true
+    misspell:
+      mode: default
     revive:
       # By default, revive will enable only the linting rules that are named in the configuration file.
       # So, it's needed to explicitly enable all required rules here.

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -571,8 +571,8 @@ type XIntOrString struct{}
 // Schemaless objects are not introspected, so you must provide
 // any type and validation information yourself. One use for this
 // tag is for embedding fields that hold JSONSchema typed objects.
-// Because this field disables all type checking, it is recommended
-// to be used only as a last resort.
+// Because this field disables all type checking, it is recommended to
+// be used only as a last resort.
 //
 // Example:
 //

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -443,7 +443,7 @@ func (Schemaless) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "marks a field as being a schemaless object.",
-			Details: "Schemaless objects are not introspected, so you must provide\nany type and validation information yourself. One use for this\ntag is for embedding fields that hold JSONSchema typed objects.\nBecause this field disables all type checking, it is recommended\nto be used only as a last resort.\n\nExample:\n\n\t// +kubebuilder:validation:Schemaless\n\tJSONSchema apiextensionsv1.JSONSchemaProps",
+			Details: "Schemaless objects are not introspected, so you must provide\nany type and validation information yourself. One use for this\ntag is for embedding fields that hold JSONSchema typed objects.\nBecause this field disables all type checking, it is recommended to\nbe used only as a last resort.\n\nExample:\n\n\t// +kubebuilder:validation:Schemaless\n\tJSONSchema apiextensionsv1.JSONSchemaProps",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}

--- a/pkg/genall/output.go
+++ b/pkg/genall/output.go
@@ -130,10 +130,9 @@ func (o outputToStdout) Open(_ *loader.Package, _ string) (io.WriteCloser, error
 // OutputArtifacts outputs artifacts to different locations, depending on
 // whether they're package-associated or not.
 //
-// Non-package associated artifacts
-// are output to the Config directory, while package-associated ones are output
-// to their package's source files' directory, unless an alternate path is
-// specified in Code.
+// Non-package associated artifacts are output to the Config directory,
+// while package-associated ones are output to their package's source
+// files' directory, unless an alternate path is specified in Code.
 type OutputArtifacts struct {
 	// Config points to the directory to which to write configuration.
 	Config OutputToDirectory

--- a/pkg/genall/zz_generated.markerhelp.go
+++ b/pkg/genall/zz_generated.markerhelp.go
@@ -40,7 +40,7 @@ func (OutputArtifacts) Help() *markers.DefinitionHelp {
 		Category: "",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "outputs artifacts to different locations, depending on",
-			Details: "whether they're package-associated or not.\n\nNon-package associated artifacts\nare output to the Config directory, while package-associated ones are output\nto their package's source files' directory, unless an alternate path is\nspecified in Code.",
+			Details: "whether they're package-associated or not.\n\nNon-package associated artifacts are output to the Config directory,\nwhile package-associated ones are output to their package's source\nfiles' directory, unless an alternate path is specified in Code.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
 			"Config": {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->

## Summary                                                                                                                                                                                                                                
  - Fix misspell false positives caused by `\nto` in generated marker help files                                                                                                                                                            
    - Reflow Go doc comments in `pkg/genall/output.go` and `pkg/crd/markers/validation.go`                                                                                                                                                  
    - Regenerate `zz_generated.markerhelp.go` files via `go generate`                                                                                                                                                                       
  - Bump golangci-lint from v2.12.1 to v2.12.2                                                                                                                                                                                              
  - Add explicit `misspell.mode: default` config in `.golangci.yml`                                                                                                                                                                         
                                                                                                                                                                                                                                            
  ## Root Cause 

  ref: https://goreportcard.com/report/sigs.k8s.io/controller-tools#misspell
                                                                                                                                                                                                                            
  The `helpgen` tool converts Go doc comments to string literals using `%q`,                                                                                                                                                                
  turning newlines into `\n`. When a line starts with "to", the generated                                                                                                                                                                   
  source contains `\nto`, which misspell parses as the word "nto" and flags                                                                                                                                                                 
  as a misspelling of "not".