### PR TITLE
🐛 pkg/crd: reject pointer-receiver-only TextMarshaler types as map keys

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -383,19 +383,21 @@ func arrayToSchema(ctx *schemaContext, array *ast.ArrayType) *apiextensionsv1.JS
 	}
 }
 
-// mapToSchema creates a schema for items of the given map.  Key types must eventually resolve
-// to string (other types aren't allowed by JSON, and thus the kubernetes API standards).
+// mapToSchema creates a schema for items of the given map. Key types must eventually
+// resolve to string or implement encoding.TextMarshaler via a value receiver. Pointer-receiver
+// implementations are not accepted: map keys are not addressable, so encoding/json cannot call
+// a pointer-receiver MarshalText on them and will return an error at runtime.
 func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiextensionsv1.JSONSchemaProps {
 	keyType := ctx.pkg.TypesInfo.TypeOf(mapType.Key)
-	// check that we've got a type that actually corresponds to a string, or that
-	// implements encoding.TextMarshaler (in which case it serializes to a string,
-	// just like text-marshaler-implementing field types do).
+	// Accept string-kinded types, or types whose value receiver implements
+	// encoding.TextMarshaler (pointer-receiver-only types are rejected because map
+	// keys are not addressable and encoding/json cannot call pointer methods on them).
 	keyInfo := keyType
 	for keyInfo != nil {
 		switch typedKey := keyInfo.(type) {
 		case *types.Basic:
 			if typedKey.Info()&types.IsString == 0 {
-				if implements(keyType, textMarshaler) {
+				if types.Implements(keyType, textMarshaler) {
 					keyInfo = nil // stop iterating
 					break
 				}
@@ -406,7 +408,7 @@ func mapToSchema(ctx *schemaContext, mapType *ast.MapType) *apiextensionsv1.JSON
 		case *types.Named:
 			keyInfo = typedKey.Underlying()
 		default:
-			if implements(keyType, textMarshaler) {
+			if types.Implements(keyType, textMarshaler) {
 				keyInfo = nil // stop iterating
 				break
 			}

--- a/pkg/crd/schema_test.go
+++ b/pkg/crd/schema_test.go
@@ -26,7 +26,6 @@ import (
 	pkgstest "golang.org/x/tools/go/packages/packagestest"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
-	"sigs.k8s.io/controller-tools/pkg/loader"
 	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
@@ -71,106 +70,6 @@ func transform(t *testing.T, expr string) *apiextensionsv1.JSONSchemaProps {
 	result := typeToSchema(schemaContext, definedType)
 	failIfErrors(t, pkg.Errors)
 	return result
-}
-
-// transformPackage loads pkgContents as a fake package and returns the schema
-// produced for the type definition named typeName, together with the package so
-// callers can inspect (or assert) any errors raised during schema generation.
-// Unlike transform, it does not fail the test when schema generation errors,
-// which lets negative cases assert that an error was produced.
-func transformPackage(t *testing.T, pkgContents, typeName string) (*apiextensionsv1.JSONSchemaProps, *loader.Package) {
-	moduleName := "sigs.k8s.io/controller-tools/pkg/crd"
-	modules := []pkgstest.Module{
-		{
-			Name: moduleName,
-			Files: map[string]any{
-				"test.go": pkgContents,
-			},
-		},
-	}
-
-	pkgs, exported, err := testloader.LoadFakeRoots(pkgstest.Modules, modules, moduleName)
-	if exported != nil {
-		t.Cleanup(exported.Cleanup)
-	}
-
-	if err != nil {
-		t.Fatalf("unable to load fake package: %s", err)
-	}
-
-	if len(pkgs) != 1 {
-		t.Fatal("expected to parse only one package")
-	}
-
-	pkg := pkgs[0]
-	pkg.NeedTypesInfo()
-
-	schemaContext := newSchemaContext(pkg, nil, true, false).ForInfo(&markers.TypeInfo{})
-
-	var definedType ast.Expr
-	for _, decl := range pkg.Syntax[0].Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range genDecl.Specs {
-			typeSpec, ok := spec.(*ast.TypeSpec)
-			if ok && typeSpec.Name.Name == typeName {
-				definedType = typeSpec.Type
-			}
-		}
-	}
-	if definedType == nil {
-		t.Fatalf("could not find type %q in fake package", typeName)
-	}
-
-	return typeToSchema(schemaContext, definedType), pkg
-}
-
-const textMarshalerKeyPackage = `
-	package crd
-
-	// textKey implements encoding.TextMarshaler, so it serializes to a string
-	// and is a valid (JSON string) map key.
-	type textKey struct{}
-
-	func (textKey) MarshalText() ([]byte, error) { return nil, nil }
-
-	// nonStringKey is a struct that does not implement encoding.TextMarshaler.
-	type nonStringKey struct{}
-
-	type TextMarshalerKeyMap map[textKey]string
-	type NonStringKeyMap map[nonStringKey]string
-`
-
-// Test_Schema_MapOfTextMarshalerKey verifies that a map keyed by a type that
-// implements encoding.TextMarshaler is accepted (mirroring how such types are
-// accepted as struct fields) and produces an ordinary string-keyed object
-// schema with no key schema emitted.
-func Test_Schema_MapOfTextMarshalerKey(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	output, pkg := transformPackage(t, textMarshalerKeyPackage, "TextMarshalerKeyMap")
-	failIfErrors(t, pkg.Errors)
-	g.Expect(output).To(gomega.Equal(&apiextensionsv1.JSONSchemaProps{
-		Type: "object",
-		AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
-			Allows: true,
-			Schema: &apiextensionsv1.JSONSchemaProps{
-				Type: "string",
-			},
-		},
-	}))
-}
-
-// Test_Schema_MapOfNonStringKey verifies that a struct key that does not
-// implement encoding.TextMarshaler is still rejected.
-func Test_Schema_MapOfNonStringKey(t *testing.T) {
-	g := gomega.NewWithT(t)
-
-	_, pkg := transformPackage(t, textMarshalerKeyPackage, "NonStringKeyMap")
-	g.Expect(pkg.Errors).ToNot(gomega.BeEmpty())
-	g.Expect(pkg.Errors[0].Msg).To(gomega.ContainSubstring("map keys must be strings"))
 }
 
 func failIfErrors(t *testing.T, errs []packages.Error) {

--- a/pkg/crd/schema_textmarshaler_test.go
+++ b/pkg/crd/schema_textmarshaler_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	"go/ast"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	pkgstest "golang.org/x/tools/go/packages/packagestest"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	testloader "sigs.k8s.io/controller-tools/pkg/loader/testutils"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var _ = Describe("mapToSchema", func() {
+	Context("TextMarshaler map key validation", func() {
+		// cleanup holds the teardown function returned by the fake package loader.
+		// AfterEach calls it so temp directories are removed after every It block.
+		var cleanup func()
+
+		AfterEach(func() {
+			if cleanup != nil {
+				cleanup()
+				cleanup = nil
+			}
+		})
+
+		// schemaForType loads src as a fake package and returns the schema for the
+		// named type, together with the package so callers can inspect errors.
+		// It sets cleanup so AfterEach can release temp files after the It block ends.
+		schemaForType := func(src, typeName string) (*apiextensionsv1.JSONSchemaProps, *loader.Package) {
+			const mod = "sigs.k8s.io/controller-tools/pkg/crd"
+			pkgs, exported, err := testloader.LoadFakeRoots(pkgstest.Modules, []pkgstest.Module{{
+				Name:  mod,
+				Files: map[string]any{"test.go": src},
+			}}, mod)
+			if exported != nil {
+				cleanup = exported.Cleanup
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pkgs).To(HaveLen(1))
+
+			pkg := pkgs[0]
+			pkg.NeedTypesInfo()
+
+			schemaCtx := newSchemaContext(pkg, nil, true, false).ForInfo(&markers.TypeInfo{})
+
+			var definedType ast.Expr
+			for _, decl := range pkg.Syntax[0].Decls {
+				if gd, ok := decl.(*ast.GenDecl); ok {
+					for _, spec := range gd.Specs {
+						if ts, ok := spec.(*ast.TypeSpec); ok && ts.Name.Name == typeName {
+							definedType = ts.Type
+						}
+					}
+				}
+			}
+			Expect(definedType).NotTo(BeNil(), "type %q not found in fake package", typeName)
+			return typeToSchema(schemaCtx, definedType), pkg
+		}
+
+		// src defines three map types covering the three cases below.
+		const src = `
+package crd
+
+// valueKey implements encoding.TextMarshaler via a value receiver.
+// encoding/json can call MarshalText on map keys of this type because
+// the method is reachable without a pointer.
+type valueKey struct{}
+func (valueKey) MarshalText() ([]byte, error) { return nil, nil }
+
+// ptrKey implements encoding.TextMarshaler via a pointer receiver only.
+// Map keys are not addressable, so encoding/json cannot call *ptrKey.MarshalText
+// and will return an error at runtime — this type must be rejected.
+type ptrKey struct{}
+func (*ptrKey) MarshalText() ([]byte, error) { return nil, nil }
+
+// noMarshalKey is a plain struct with no TextMarshaler implementation.
+type noMarshalKey struct{}
+
+type ValueKeyMap    map[valueKey]string
+type PtrKeyMap      map[ptrKey]string
+type NoMarshalKeyMap map[noMarshalKey]string
+`
+
+		It("accepts a value-receiver TextMarshaler type as a map key", func() {
+			output, pkg := schemaForType(src, "ValueKeyMap")
+			Expect(pkg.Errors).To(BeEmpty())
+			Expect(output).To(Equal(&apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+					Allows: true,
+					Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+				},
+			}))
+		})
+
+		It("rejects a pointer-receiver-only TextMarshaler type as a map key", func() {
+			_, pkg := schemaForType(src, "PtrKeyMap")
+			Expect(pkg.Errors).NotTo(BeEmpty())
+			Expect(pkg.Errors[0].Msg).To(ContainSubstring("map keys must be strings"))
+		})
+
+		It("rejects a struct that does not implement TextMarshaler", func() {
+			_, pkg := schemaForType(src, "NoMarshalKeyMap")
+			Expect(pkg.Errors).NotTo(BeEmpty())
+			Expect(pkg.Errors[0].Msg).To(ContainSubstring("map keys must be strings"))
+		})
+	})
+})

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -297,9 +297,9 @@ type CronJobSpec struct {
 	// Maps of arrays of things-that-aren’t-strings are permitted
 	MapOfArraysOfFloats map[string][]bool `json:"mapOfArraysOfFloats,omitempty"`
 
-	// Maps keyed by a type that implements encoding.TextMarshaler are permitted,
-	// since such keys serialize to strings (just like TextMarshaler fields do).
-	MapOfTextMarshalerKeys map[URL3]string `json:"mapOfTextMarshalerKeys,omitempty"`
+	// Maps keyed by a type that implements encoding.TextMarshaler via a value receiver
+	// are permitted, since such keys serialize to strings when marshaled to JSON.
+	MapOfTextMarshalerKeys map[TextMarshalerKey]string `json:"mapOfTextMarshalerKeys,omitempty"`
 
 	// +kubebuilder:validation:Minimum=-0.5
 	// +kubebuilder:validation:Maximum=1.5
@@ -710,6 +710,15 @@ var _ encoding.TextMarshaler = (*URL4)(nil)
 func (u *URL4) MarshalText() (text []byte, err error) {
 	return (*url.URL)(u).MarshalBinary()
 }
+
+// TextMarshalerKey is a string-based type that implements [encoding.TextMarshaler]
+// via a value receiver, making it valid as a CRD map key.
+type TextMarshalerKey string
+
+var _ encoding.TextMarshaler = TextMarshalerKey("")
+
+// MarshalText implements [encoding.TextMarshaler].
+func (t TextMarshalerKey) MarshalText() ([]byte, error) { return []byte(t), nil }
 
 // +kubebuilder:validation:Type=integer
 // +kubebuilder:validation:Format=int64

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9472,8 +9472,8 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  Maps keyed by a type that implements encoding.TextMarshaler are permitted,
-                  since such keys serialize to strings (just like TextMarshaler fields do).
+                  Maps keyed by a type that implements encoding.TextMarshaler via a value receiver
+                  are permitted, since such keys serialize to strings when marshaled to JSON.
                 type: object
               minMaxProperties:
                 description: This tests that min/max properties work


### PR DESCRIPTION
encoding/json marshals map keys by value, not by pointer. Map keys are not addressable in Go's reflect model, so if a type implements MarshalText only via a pointer receiver, encoding/json returns an error at runtime for any map that uses it as a key.

PR #1419 introduced the TextMarshaler map key check using the implements() helper, which accepts both value and pointer receivers. This caused controller-gen to accept types that would fail at runtime. Fix both occurrences in mapToSchema to use types.Implements directly, which checks value receivers only.

The testdata example had the same problem: URL3 implements MarshalText only via a pointer receiver, so map[URL3]string would have failed at runtime. Replace it with a new TextMarshalerKey type that uses a value receiver and actually works. Add a Ginkgo test suite covering all three cases: accepted (value receiver), rejected (pointer receiver only), and rejected (no TextMarshaler at all).
