### PR TITLE
✨ add field level marker "kubebuilder:ignore" to exclude a field from generation

### DIFF
--- a/pkg/crd/gen_integration_test.go
+++ b/pkg/crd/gen_integration_test.go
@@ -153,6 +153,17 @@ var _ = Describe("CRD Generation proper defaulting", func() {
 		Expect(out.buf.String()).NotTo(ContainSubstring("preserveUnknownFields"))
 	})
 
+	It("should not add fields marked with kubebuilder:ignore to the CRD", func() {
+		By("calling Generate")
+		gen := &crd.Generator{
+			CRDVersions: []string{"v1"},
+		}
+		Expect(gen.Generate(ctx)).NotTo(HaveOccurred())
+
+		By("searching for the ignored field")
+		Expect(out.buf.String()).NotTo(ContainSubstring("ignoredString"))
+	})
+
 	It("should truncate CRD descriptions", func() {
 		By("calling Generate")
 		fifty := 50

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -35,6 +35,7 @@ const (
 	validationPrefix = "kubebuilder:validation:"
 
 	SchemalessName        = "kubebuilder:validation:Schemaless"
+	IgnoreName            = "kubebuilder:ignore"
 	ValidationItemsPrefix = validationPrefix + "items:"
 
 	ValidationExactlyOneOfPrefix = validationPrefix + "ExactlyOneOf"
@@ -152,6 +153,9 @@ var ValidationIshMarkers = []*definitionWithHelp{
 		WithHelp(Title{}.Help()),
 	must(markers.MakeAnyTypeDefinition("kubebuilder:title", markers.DescribesType, Title{})).
 		WithHelp(Title{}.Help()),
+
+	must(markers.MakeDefinition(IgnoreName, markers.DescribesField, Ignore{})).
+		WithHelp(Ignore{}.Help()),
 }
 
 func init() {
@@ -608,6 +612,19 @@ func (m Immutable) ApplyToSchema(_ *SchemaContext, schema *apiextensionsv1.JSONS
 	})
 	return nil
 }
+
+// Ignore excludes this field from the generated CRD schema entirely.
+//
+// Unlike marking a field optional, an ignored field is not just absent from
+// the value, it never appears in the schema's properties at all.
+//
+// Example:
+//
+//	// +kubebuilder:ignore
+//	Internal string
+//
+// +controllertools:marker:generateHelp:category="CRD processing"
+type Ignore struct{}
 
 func hasNumericType(schema *apiextensionsv1.JSONSchemaProps) bool {
 	return schema.Type == string(Integer) || schema.Type == string(Number)

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -169,6 +169,17 @@ func (Format) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (Ignore) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD processing",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "excludes this field from the generated CRD schema entirely.",
+			Details: "Unlike marking a field optional, an ignored field is not just absent from\nthe value, it never appears in the schema's properties at all.\n\nExample:\n\n\t// +kubebuilder:ignore\n\tInternal string",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (Immutable) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -525,6 +525,10 @@ func structToSchema(ctx *schemaContext, structType *ast.StructType) *apiextensio
 			continue
 		}
 
+		if field.Markers.Get(crdmarkers.IgnoreName) != nil {
+			continue
+		}
+
 		jsonTag, hasTag := field.Tag.Lookup("json")
 		if !hasTag {
 			// if the field doesn't have a JSON tag, it doesn't belong in output (and shouldn't exist in a serialized type)

--- a/pkg/crd/testdata/gen/foo_types.go
+++ b/pkg/crd/testdata/gen/foo_types.go
@@ -28,6 +28,11 @@ type FooSpec struct {
 	// +kubebuilder:default=fooDefaultString
 	// +kubebuilder:example=fooExampleString
 	DefaultedString string `json:"defaultedString"`
+
+	// This tests that fields marked with kubebuilder:ignore are excluded
+	// from the generated CRD schema entirely.
+	// +kubebuilder:ignore
+	IgnoredString string `json:"ignoredString,omitempty"`
 }
 type FooStatus struct{}
 


### PR DESCRIPTION
This PR was written with the assistance of generative AI

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
This change set adds a field level marker named "kubebuilder:ignore". As the name implies the field allows ignoring the field during the generation, regardless of whether the field has a `json` tag or no. 
