### PR TITLE
🌱 Add verify-generated check for golden files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ test-all:
 	$(MAKE) verify-modules
 	$(MAKE) verify-boilerplate
 	$(MAKE) verify-k8s-deps
+	$(MAKE) verify-generated
 	$(MAKE) test
 
 .PHONY: modules
@@ -116,6 +117,10 @@ verify-modules: modules ## Verify go modules are up to date
 .PHONY: verify-boilerplate
 verify-boilerplate:
 	./hack/verify-boilerplate.sh
+
+.PHONY: verify-generated
+verify-generated:
+	./hack/verify-generated.sh
 
 ## --------------------------------------
 ## Cleanup / Verification

--- a/hack/update-generated.sh
+++ b/hack/update-generated.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+for dir in $(find . -name go.mod -exec dirname {} \;); do
+  echo "go generate in $dir"
+  (cd "$dir" && go generate ./...)
+done

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+hack/update-generated.sh
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "ERROR: generated files are out of date. Run 'hack/update-generated.sh' to update." >&2
+  git status --short >&2
+  exit 1
+fi

--- a/test.sh
+++ b/test.sh
@@ -105,20 +105,6 @@ fetch_kb_tools
 # setup testing env
 setup_envs
 
-header_text "Running go generate"
-for dir in $(find . -name go.mod -exec dirname {} \;); do
-  header_text "go generate in $dir"
-  pushd "$dir" > /dev/null
-    go generate ./...
-  popd > /dev/null
-done
-
-if ! git diff --quiet --exit-code; then
-  header_text "go generate produced changes"
-  git diff
-  exit 1
-fi
-
 header_text "running golangci-lint"
 make lint
 


### PR DESCRIPTION
Extract the inline `go generate` + `git diff` check from `test.sh` into a dedicated `hack/verify-generated.sh` script (paired with `hack/update-generated.sh`), following the existing `verify-k8s-deps.sh` / `update-k8s-deps.sh` pattern.

The verify script provides a clear error message when generated files are out of date, telling developers exactly how to fix it: `Run 'hack/update-generated.sh' to update.`

The new `verify-generated` Makefile target is included in `test-all` so it runs automatically in CI for every PR.

This addresses the [review comment on PR #1455](https://github.com/kubernetes-sigs/controller-tools/pull/1455#discussion_r3650396865).