### PR TITLE
:bug: inject min boundaries for +k8s:required on strings, maps, and slices

### DIFF
--- a/pkg/applyconfiguration/testdata/cronjob/api/v1/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/applyconfiguration/testdata/cronjob/api/v1/testdata.kubebuilder.io_cronjobs.yaml
@@ -596,6 +596,7 @@ spec:
                                   description: |-
                                     name uniquely identifies this resource claim inside the group.
                                     This field is required. It must be a DNS_LABEL.
+                                  minLength: 1
                                   type: string
                                 resourceClaimName:
                                   description: |-
@@ -642,6 +643,7 @@ spec:
                                         All pods within the PodGroup must be colocated within the same domain instance.
                                         Different PodGroups can land on different domain instances even if they derive from the same PodGroupTemplate.
                                         Examples: "topology.kubernetes.io/rack"
+                                      minLength: 1
                                       type: string
                                   required:
                                   - key
@@ -5099,6 +5101,7 @@ spec:
                                         Domain names *.k8s.io and *.kubernetes.io are reserved.
                                         This field must be unique for each responder.
                                         This field is required.
+                                      minLength: 1
                                       type: string
                                     priority:
                                       description: |-

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -114,7 +114,7 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is required.")),
 	must(markers.MakeDefinition("optional", markers.DescribesField, struct{}{})).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional.")),
-	must(markers.MakeDefinition("k8s:required", markers.DescribesField, struct{}{})).
+	must(markers.MakeDefinition("k8s:required", markers.DescribesField, K8sRequired{})).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is required.")),
 	must(markers.MakeDefinition("k8s:optional", markers.DescribesField, struct{}{})).
 		WithHelp(markers.SimpleHelp("CRD validation", "specifies that this field is optional.")),
@@ -1185,5 +1185,35 @@ func (K8sEnum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSch
 
 	schema.Type = "string"
 	schema.Enum = enumValues
+	return nil
+}
+
+// K8sRequired specifies that this field is required.
+// When applied to a string, it also ensures that the string has a minimum length of 1.
+// When applied to a map, it also ensures that the map has at least 1 property.
+// When applied to a slice, it also ensures that the slice has at least 1 item.
+// These minimum constraints are only applied if they are not explicitly set.
+//
+// +controllertools:marker:generateHelp:category="CRD validation"
+type K8sRequired struct{}
+
+func (m K8sRequired) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSchemaProps) error {
+	switch schema.Type {
+	case "string":
+		if schema.MinLength == nil {
+			val := int64(1)
+			schema.MinLength = &val
+		}
+	case "array":
+		if schema.MinItems == nil {
+			val := int64(1)
+			schema.MinItems = &val
+		}
+	case "object":
+		if schema.AdditionalProperties != nil && schema.MinProperties == nil {
+			val := int64(1)
+			schema.MinProperties = &val
+		}
+	}
 	return nil
 }

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -1192,6 +1192,7 @@ func (K8sEnum) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.JSONSch
 // When applied to a string, it also ensures that the string has a minimum length of 1.
 // When applied to a map, it also ensures that the map has at least 1 property.
 // When applied to a slice, it also ensures that the slice has at least 1 item.
+// When applied to a struct, it also ensures that the struct has at least 1 field set.
 // These minimum constraints are only applied if they are not explicitly set.
 //
 // +controllertools:marker:generateHelp:category="CRD validation"
@@ -1210,7 +1211,13 @@ func (m K8sRequired) ApplyToSchema(ctx *SchemaContext, schema *apiextensionsv1.J
 			schema.MinItems = &val
 		}
 	case "object":
-		if schema.AdditionalProperties != nil && schema.MinProperties == nil {
+		if schema.MinProperties == nil {
+			val := int64(1)
+			schema.MinProperties = &val
+		}
+	default:
+		// If the schema is a reference to a type.
+		if schema.Ref != nil && schema.MinProperties == nil {
 			val := int64(1)
 			schema.MinProperties = &val
 		}

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -185,7 +185,7 @@ func (K8sRequired) Help() *markers.DefinitionHelp {
 		Category: "CRD validation",
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "specifies that this field is required.",
-			Details: "When applied to a string, it also ensures that the string has a minimum length of 1.\nWhen applied to a map, it also ensures that the map has at least 1 property.\nWhen applied to a slice, it also ensures that the slice has at least 1 item.\nThese minimum constraints are only applied if they are not explicitly set.",
+			Details: "When applied to a string, it also ensures that the string has a minimum length of 1.\nWhen applied to a map, it also ensures that the map has at least 1 property.\nWhen applied to a slice, it also ensures that the slice has at least 1 item.\nWhen applied to a struct, it also ensures that the struct has at least 1 field set.\nThese minimum constraints are only applied if they are not explicitly set.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -180,6 +180,17 @@ func (Immutable) Help() *markers.DefinitionHelp {
 	}
 }
 
+func (K8sRequired) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "specifies that this field is required.",
+			Details: "When applied to a string, it also ensures that the string has a minimum length of 1.\nWhen applied to a map, it also ensures that the map has at least 1 property.\nWhen applied to a slice, it also ensures that the slice has at least 1 item.\nThese minimum constraints are only applied if they are not explicitly set.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
 func (KubernetesDefault) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "CRD validation",

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -289,6 +289,33 @@ type CronJobSpec struct {
 	// +k8s:required
 	ExplicitlyRequiredK8s string `json:"explicitlyRequiredK8s,omitempty"`
 
+	// This tests explicitly required k8s fields on a pointer
+	// +k8s:required
+	ExplicitlyRequiredK8sPointer *string `json:"explicitlyRequiredK8sPointer,omitempty"`
+
+	// This tests explicitly required k8s fields on a slice
+	// +k8s:required
+	ExplicitlyRequiredK8sSlice []string `json:"explicitlyRequiredK8sSlice,omitempty"`
+
+	// This tests explicitly required k8s fields on a map
+	// +k8s:required
+	ExplicitlyRequiredK8sMap map[string]string `json:"explicitlyRequiredK8sMap,omitempty"`
+
+	// This tests explicitly required k8s fields with minLength already set
+	// +k8s:required
+	// +kubebuilder:validation:MinLength=5
+	ExplicitlyRequiredK8sWithMinLength string `json:"explicitlyRequiredK8sWithMinLength,omitempty"`
+
+	// This tests explicitly required k8s fields on a slice with minItems already set
+	// +k8s:required
+	// +kubebuilder:validation:MinItems=5
+	ExplicitlyRequiredK8sSliceWithMinItems []string `json:"explicitlyRequiredK8sSliceWithMinItems,omitempty"`
+
+	// This tests explicitly required k8s fields on a map with minProperties already set
+	// +k8s:required
+	// +kubebuilder:validation:MinProperties=5
+	ExplicitlyRequiredK8sMapWithMinProperties map[string]string `json:"explicitlyRequiredK8sMapWithMinProperties,omitempty"`
+
 	// This tests that min/max properties work
 	MinMaxProperties MinMaxObject `json:"minMaxProperties,omitempty"`
 

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -301,6 +301,14 @@ type CronJobSpec struct {
 	// +k8s:required
 	ExplicitlyRequiredK8sMap map[string]string `json:"explicitlyRequiredK8sMap,omitempty"`
 
+	// This tests explicitly required k8s fields on a struct
+	// +k8s:required
+	ExplicitlyRequiredK8sStruct NestedObject `json:"explicitlyRequiredK8sStruct,omitempty"`
+
+	// This tests explicitly required k8s fields on a pointer to struct
+	// +k8s:required
+	ExplicitlyRequiredK8sStructPointer *NestedObject `json:"explicitlyRequiredK8sStructPointer,omitempty"`
+
 	// This tests explicitly required k8s fields with minLength already set
 	// +k8s:required
 	// +kubebuilder:validation:MinLength=5

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -268,6 +268,31 @@ spec:
                   type: string
                 minItems: 5
                 type: array
+              explicitlyRequiredK8sStruct:
+                description: This tests explicitly required k8s fields on a struct
+                minProperties: 1
+                properties:
+                  bar:
+                    type: boolean
+                  foo:
+                    type: string
+                required:
+                - bar
+                - foo
+                type: object
+              explicitlyRequiredK8sStructPointer:
+                description: This tests explicitly required k8s fields on a pointer
+                  to struct
+                minProperties: 1
+                properties:
+                  bar:
+                    type: boolean
+                  foo:
+                    type: string
+                required:
+                - bar
+                - foo
+                type: object
               explicitlyRequiredK8sWithMinLength:
                 description: This tests explicitly required k8s fields with minLength
                   already set
@@ -712,6 +737,7 @@ spec:
                                   description: |-
                                     name uniquely identifies this resource claim inside the group.
                                     This field is required. It must be a DNS_LABEL.
+                                  minLength: 1
                                   type: string
                                 resourceClaimName:
                                   description: |-
@@ -758,6 +784,7 @@ spec:
                                         All pods within the PodGroup must be colocated within the same domain instance.
                                         Different PodGroups can land on different domain instances even if they derive from the same PodGroupTemplate.
                                         Examples: "topology.kubernetes.io/rack"
+                                      minLength: 1
                                       type: string
                                   required:
                                   - key
@@ -5215,6 +5242,7 @@ spec:
                                         Domain names *.k8s.io and *.kubernetes.io are reserved.
                                         This field must be unique for each responder.
                                         This field is required.
+                                      minLength: 1
                                       type: string
                                     priority:
                                       description: |-
@@ -10364,6 +10392,8 @@ spec:
             - explicitlyRequiredK8sPointer
             - explicitlyRequiredK8sSlice
             - explicitlyRequiredK8sSliceWithMinItems
+            - explicitlyRequiredK8sStruct
+            - explicitlyRequiredK8sStructPointer
             - explicitlyRequiredK8sWithMinLength
             - explicitlyRequiredKubebuilder
             - explicitlyRequiredKubernetes

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -236,6 +236,42 @@ spec:
                 type: string
               explicitlyRequiredK8s:
                 description: This tests explicitly required k8s fields
+                minLength: 1
+                type: string
+              explicitlyRequiredK8sMap:
+                additionalProperties:
+                  type: string
+                description: This tests explicitly required k8s fields on a map
+                minProperties: 1
+                type: object
+              explicitlyRequiredK8sMapWithMinProperties:
+                additionalProperties:
+                  type: string
+                description: This tests explicitly required k8s fields on a map with
+                  minProperties already set
+                minProperties: 5
+                type: object
+              explicitlyRequiredK8sPointer:
+                description: This tests explicitly required k8s fields on a pointer
+                minLength: 1
+                type: string
+              explicitlyRequiredK8sSlice:
+                description: This tests explicitly required k8s fields on a slice
+                items:
+                  type: string
+                minItems: 1
+                type: array
+              explicitlyRequiredK8sSliceWithMinItems:
+                description: This tests explicitly required k8s fields on a slice
+                  with minItems already set
+                items:
+                  type: string
+                minItems: 5
+                type: array
+              explicitlyRequiredK8sWithMinLength:
+                description: This tests explicitly required k8s fields with minLength
+                  already set
+                minLength: 5
                 type: string
               explicitlyRequiredKubebuilder:
                 description: This tests explicitly required kubebuilder fields
@@ -10323,6 +10359,12 @@ spec:
             - duplicateListMapKey
             - embeddedResource
             - explicitlyRequiredK8s
+            - explicitlyRequiredK8sMap
+            - explicitlyRequiredK8sMapWithMinProperties
+            - explicitlyRequiredK8sPointer
+            - explicitlyRequiredK8sSlice
+            - explicitlyRequiredK8sSliceWithMinItems
+            - explicitlyRequiredK8sWithMinLength
             - explicitlyRequiredKubebuilder
             - explicitlyRequiredKubernetes
             - float64WithValidations


### PR DESCRIPTION
**What does this do, and why do we need it?**

This PR updates the CRD generation logic for the `+k8s:required` marker to automatically apply minimum boundaries to strings, arrays, and objects.

Specifically, when a field is marked as required, this change will now automatically inject:
*   `minLength=1` for `string` types.
*   `minItems=1` for `array` (slice) types.
*   `minProperties=1` for `object` (map) types.
 
This aligns with the implementation of +k8s:required of validation-gen of kubernetes. https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/api/validate/required.go

There is  no clean way to model required int in CRD as of now. We will handle it separately.

There are no prod usage outside of k/k for +k8s:required. It is fine to change now then later.  CRs are ratcheted,  It is safe to change it. https://grep.app/search?q=%2Bk8s%3Arequired+
