### PR TITLE
✨Support XValidation on type aliases to map/slice/pointer types

### DIFF
--- a/pkg/crd/schema.go
+++ b/pkg/crd/schema.go
@@ -304,10 +304,29 @@ func localNamedToSchema(ctx *schemaContext, ident *ast.Ident) *apiextensionsv1.J
 		ctx.pkg.AddError(loader.ErrFromNode(fmt.Errorf("unknown type %s", ident.Name), ident))
 		return &apiextensionsv1.JSONSchemaProps{}
 	}
-	// This reproduces the behavior we had pre gotypesalias=1 (needed if this
-	// project is compiled with default settings and Go >= 1.23).
+	// For user-defined type aliases (type X = Y, gotypesalias=1), the handling
+	// depends on the RHS type:
+	//   - Basic types (type X = string): unwrap to preserve existing behavior
+	//     (inline type/format needed for field-level markers like MinLength).
+	//   - Named types (type X = SomeStruct): unwrap to preserve existing behavior
+	//     (emits $ref to the underlying named type, needed for inline/embedded
+	//     struct aliases and the applyconfiguration generator).
+	//   - Complex types (type X = map[string]string, []string, etc.): the
+	//     existing switch would error out because these types have no Obj().
+	//     Instead, emit a $ref to the alias type so markers on the alias
+	//     declaration (e.g. +kubebuilder:validation:XValidation) are applied
+	//     when the flattener resolves the $ref via infoToSchema.
+	//   - Built-in aliases (any): unwrap, Pkg() is nil.
 	if aliasInfo, isAlias := typeInfo.(*types.Alias); isAlias {
-		typeInfo = aliasInfo.Rhs()
+		rhs := aliasInfo.Rhs()
+		_, rhsIsBasic := rhs.(*types.Basic)
+		_, rhsHasObj := rhs.(interface{ Obj() *types.TypeName })
+		if !rhsIsBasic && !rhsHasObj && aliasInfo.Obj().Pkg() != nil {
+			ctx.requestSchema("", ident.Name)
+			link := TypeRefLink("", ident.Name)
+			return &apiextensionsv1.JSONSchemaProps{Ref: &link}
+		}
+		typeInfo = rhs
 	}
 	switch typeInfo := typeInfo.(type) {
 	case *types.Basic:

--- a/pkg/crd/schema_test.go
+++ b/pkg/crd/schema_test.go
@@ -277,3 +277,155 @@ func (m *testapplyFirstMarker) ApplyToSchema(*crdmarkers.SchemaContext, *apiexte
 	m.callback()
 	return nil
 }
+
+// Test_Schema_TypeAlias_Map verifies that a type alias to a map type
+// (type X = map[string]string) produces a $ref to the alias instead of
+// erroring out. This is the fix for https://github.com/kubernetes-sigs/controller-tools/issues/1462.
+func Test_Schema_TypeAlias_Map(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	pkgContents := `
+package crd
+
+// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) > 0)",message="keys must be non-empty"
+type MapAlias = map[string]string
+`
+	pkg := loadTestPackage(t, pkgContents)
+
+	// Find the MapAlias identifier from the alias type declaration's AST.
+	// We need an *ast.Ident to trigger localNamedToSchema.
+	ident := findTypeIdent(t, pkg, "MapAlias")
+	// Use a no-op schemaRequester since we only test the immediate output.
+	ctx := newSchemaContext(pkg, &noopSchemaRequester{}, true, false).ForInfo(&markers.TypeInfo{})
+	result := localNamedToSchema(ctx, ident)
+	failIfErrors(t, pkg.Errors)
+
+	g.Expect(result.Ref).ToNot(gomega.BeNil(), "map type alias should produce a $ref")
+	g.Expect(*result.Ref).To(gomega.ContainSubstring("MapAlias"))
+}
+
+// Test_Schema_TypeAlias_Slice verifies that a type alias to a slice type
+// produces a $ref to the alias instead of erroring out.
+func Test_Schema_TypeAlias_Slice(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	pkgContents := `
+package crd
+
+type SliceAlias = []string
+`
+	pkg := loadTestPackage(t, pkgContents)
+	ident := findTypeIdent(t, pkg, "SliceAlias")
+	ctx := newSchemaContext(pkg, &noopSchemaRequester{}, true, false).ForInfo(&markers.TypeInfo{})
+	result := localNamedToSchema(ctx, ident)
+	failIfErrors(t, pkg.Errors)
+
+	g.Expect(result.Ref).ToNot(gomega.BeNil(), "slice type alias should produce a $ref")
+	g.Expect(*result.Ref).To(gomega.ContainSubstring("SliceAlias"))
+}
+
+// Test_Schema_TypeAlias_Basic verifies that a basic type alias
+// (type X = string) still produces an inline type with a $ref
+// (preserving existing behavior for field-level markers like MinLength).
+func Test_Schema_TypeAlias_Basic(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	pkgContents := `
+package crd
+
+type StringAlias = string
+`
+	pkg := loadTestPackage(t, pkgContents)
+	ident := findTypeIdent(t, pkg, "StringAlias")
+	ctx := newSchemaContext(pkg, &noopSchemaRequester{}, true, false).ForInfo(&markers.TypeInfo{})
+	result := localNamedToSchema(ctx, ident)
+	failIfErrors(t, pkg.Errors)
+
+	g.Expect(result.Type).To(gomega.Equal("string"), "basic type alias should preserve inline type")
+	g.Expect(result.Ref).ToNot(gomega.BeNil(), "basic type alias should also have a $ref")
+}
+
+// Test_Schema_TypeAlias_Struct verifies that a struct type alias
+// (type X = SomeStruct) still produces a $ref to the underlying named type
+// (preserving existing behavior for inline/embedded struct aliases).
+func Test_Schema_TypeAlias_Struct(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	pkgContents := `
+package crd
+
+type EmbeddedStruct struct {
+	Name string ` + "`json:\"name\"`" + `
+}
+
+type StructAlias = EmbeddedStruct
+`
+	pkg := loadTestPackage(t, pkgContents)
+	ident := findTypeIdent(t, pkg, "StructAlias")
+	ctx := newSchemaContext(pkg, &noopSchemaRequester{}, true, false).ForInfo(&markers.TypeInfo{})
+	result := localNamedToSchema(ctx, ident)
+	failIfErrors(t, pkg.Errors)
+
+	g.Expect(result.Ref).ToNot(gomega.BeNil(), "struct type alias should produce a $ref")
+	// The $ref should point to the underlying named type (EmbeddedStruct),
+	// not the alias name, preserving existing behavior for inline/embedded
+	// struct aliases and the applyconfiguration generator.
+	g.Expect(*result.Ref).To(gomega.ContainSubstring("EmbeddedStruct"))
+}
+
+// noopSchemaRequester is a schemaRequester that does nothing, for unit tests
+// that only check the immediate schema output without resolving references.
+type noopSchemaRequester struct{}
+
+func (noopSchemaRequester) NeedSchemaFor(typ TypeIdent) {}
+func (noopSchemaRequester) LookupType(pkg *loader.Package, name string) *markers.TypeInfo {
+	return nil
+}
+
+// loadTestPackage loads pkgContents as a fake package for unit testing.
+func loadTestPackage(t *testing.T, pkgContents string) *loader.Package {
+	moduleName := "sigs.k8s.io/controller-tools/pkg/crd"
+	modules := []pkgstest.Module{
+		{
+			Name: moduleName,
+			Files: map[string]any{
+				"test.go": pkgContents,
+			},
+		},
+	}
+
+	pkgs, exported, err := testloader.LoadFakeRoots(pkgstest.Modules, modules, moduleName)
+	if exported != nil {
+		t.Cleanup(exported.Cleanup)
+	}
+	if err != nil {
+		t.Fatalf("unable to load fake package: %s", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatal("expected to parse only one package")
+	}
+
+	pkg := pkgs[0]
+	pkg.NeedTypesInfo()
+	return pkg
+}
+
+// findTypeIdent returns an *ast.Ident for the type declaration with the given name.
+// This is used to test localNamedToSchema directly.
+func findTypeIdent(t *testing.T, pkg *loader.Package, typeName string) *ast.Ident {
+	t.Helper()
+	for _, decl := range pkg.Syntax[0].Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if ok && typeSpec.Name.Name == typeName {
+				return typeSpec.Name
+			}
+		}
+	}
+	t.Fatalf("could not find type %q in fake package", typeName)
+	return nil
+}

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -402,6 +402,14 @@ type CronJobSpec struct {
 	// This tests that validation on a string alias type itself is handled correctly.
 	StringAliasAlreadyValidated StringAliasWithValidation `json:"stringAliasAlreadyValidated,omitempty"`
 
+	// This tests that validation on a map type alias is handled correctly.
+	MapAliasField MapAliasWithValidation `json:"mapAliasField,omitempty"`
+
+	// This tests that a struct type alias resolves to the underlying named type.
+	// Note: markers on the alias declaration are not applied for struct aliases
+	// (they resolve to the underlying named type via $ref).
+	StructAliasField StructAlias `json:"structAliasField,omitempty"`
+
 	// These test that title works on both a type and field, with field taking precedence.
 	// +kubebuilder:title="title on field"
 	StringAliasWithAddedTitle StringAliasWithTitle `json:"stringAliasWithAddedTitle,omitempty"`
@@ -499,6 +507,14 @@ type StringAliasWithTitle = string
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=255
 type StringAliasWithValidation = string
+
+// MapAliasWithValidation is a map type alias with XValidation.
+// +kubebuilder:validation:XValidation:rule=`self.all(key, size(key) > 0)`,message="keys must be non-empty"
+type MapAliasWithValidation = map[string]string
+
+// StructAlias is a struct type alias with XValidation.
+// +kubebuilder:validation:XValidation:rule="self.name != ''",message="name must not be empty"
+type StructAlias = EmbeddedStruct
 
 type ContainsNestedMap struct {
 	InnerMap map[string]string `json:"innerMap,omitempty"`

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -9526,6 +9526,15 @@ spec:
                   type: string
                 minItems: 3
                 type: array
+              mapAliasField:
+                additionalProperties:
+                  type: string
+                description: This tests that validation on a map type alias is handled
+                  correctly.
+                type: object
+                x-kubernetes-validations:
+                - message: keys must be non-empty
+                  rule: self.all(key, size(key) > 0)
               mapOfArraysOfFloats:
                 additionalProperties:
                   items:
@@ -9752,6 +9761,17 @@ spec:
                 x-kubernetes-validations:
                 - messageExpression: self + ' has odd length, must be even'
                   rule: self.size() % 2 == 0
+              structAliasField:
+                description: |-
+                  This tests that a struct type alias resolves to the underlying named type.
+                  Note: markers on the alias declaration are not applied for struct aliases
+                  (they resolve to the underlying named type via $ref).
+                properties:
+                  fromEmbedded:
+                    description: FromEmbedded is a field from the embedded struct
+                      that was used through an alias type.
+                    type: string
+                type: object
               structWithSeveralFields:
                 description: A struct that can only be entirely replaced
                 properties:


### PR DESCRIPTION
### What does this PR do, and why do we need it?

Fixes https://github.com/kubernetes-sigs/controller-tools/issues/1462

`controller-gen` did not generate `x-kubernetes-validations` for type aliases to complex types (e.g. `type X = map[string]string`). The alias was unwrapped to the underlying type in `localNamedToSchema`, which hit the default case and produced an error:

```
unsupported type *types.Map for identifier X
```

### Changes

For user-defined type aliases (`type X = Y`) whose RHS is a non-basic, non-named type (map, slice, pointer, etc.), emit a `$ref` to the alias type instead of unwrapping it. The flattener then resolves the `$ref` via `infoToSchema`, which correctly applies markers on the alias declaration (including `+kubebuilder:validation:XValidation`).

Behavior for other alias types is preserved:
- **Basic type aliases** (`type X = string`): unwrap, emit inline type/format + `$ref` (preserves field-level markers like MinLength/MaxLength)
- **Named type aliases** (`type X = SomeStruct`): unwrap, emit `$ref` to the underlying named type (preserves inline/embedded struct alias behavior and applyconfiguration generator compatibility)
- **Built-in aliases** (`any`): unwrap (no `$ref`, since `any` is not a user-defined type)

### Example

```go
// +kubebuilder:validation:XValidation:rule=`self.all(key, size(key) > 0)`,message="keys must be non-empty"
type Labels = map[string]string

type MySpec struct {
    Labels Labels `json:"labels,omitempty"`
}
```

Now correctly generates:

```yaml
labels:
  additionalProperties:
    type: string
  type: object
  x-kubernetes-validations:
  - message: keys must be non-empty
    rule: self.all(key, size(key) > 0)
```