### PR TITLE
:bug: crd: support Kubernetes declarative validation bounds

### DIFF
--- a/pkg/applyconfiguration/testdata/cronjob/api/v1/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/applyconfiguration/testdata/cronjob/api/v1/testdata.kubebuilder.io_cronjobs.yaml
@@ -614,6 +614,7 @@ spec:
                               required:
                               - name
                               type: object
+                            maxItems: 4
                             type: array
                             x-kubernetes-list-map-keys:
                             - name
@@ -646,6 +647,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                maxItems: 1
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
@@ -678,6 +680,7 @@ spec:
                                       parallelism for a Job).
                                       If set, it must be a positive integer.
                                     format: int32
+                                    minimum: 1
                                     type: integer
                                 type: object
                             type: object
@@ -5115,12 +5118,15 @@ spec:
                                         The interval 0-999 is reserved for responders with *.k8s.io suffix.
                                         This field is required.
                                       format: int32
+                                      maximum: 100000
+                                      minimum: 0
                                       type: integer
                                   required:
                                   - name
                                   - priority
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                maxItems: 10
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -137,6 +137,15 @@ var FieldOnlyMarkers = []*definitionWithHelp{
 
 	must(markers.MakeDefinition("k8s:immutable", markers.DescribesField, Immutable{})).
 		WithHelp(Immutable{}.Help()),
+
+	// Kubernetes declarative validation aliases.  These bounds are especially
+	// important for keeping the estimated cost of CEL rules finite.
+	must(markers.MakeDefinition("k8s:maxItems", markers.DescribesField, MaxItems(0))).
+		WithHelp(MaxItems(0).Help()),
+	must(markers.MakeDefinition("k8s:minimum", markers.DescribesField, Minimum(0))).
+		WithHelp(Minimum(0).Help()),
+	must(markers.MakeDefinition("k8s:maximum", markers.DescribesField, Maximum(0))).
+		WithHelp(Maximum(0).Help()),
 }
 
 // ValidationIshMarkers are field-and-type markers that don't fall under the
@@ -207,6 +216,33 @@ type Minimum float64
 
 func (m Minimum) Value() float64 {
 	return float64(m)
+}
+
+func declarativeValidationMarkerValue(name, restFields string) string {
+	if strings.HasPrefix(name, "k8s:") {
+		if comment := strings.Index(restFields, " #"); comment >= 0 {
+			restFields = restFields[:comment]
+		}
+	}
+	return strings.TrimSpace(restFields)
+}
+
+func (m *Maximum) ParseMarker(_, name, restFields string) error {
+	value, err := strconv.ParseFloat(declarativeValidationMarkerValue(name, restFields), 64)
+	if err != nil {
+		return fmt.Errorf("invalid maximum value: %w", err)
+	}
+	*m = Maximum(value)
+	return nil
+}
+
+func (m *Minimum) ParseMarker(_, name, restFields string) error {
+	value, err := strconv.ParseFloat(declarativeValidationMarkerValue(name, restFields), 64)
+	if err != nil {
+		return fmt.Errorf("invalid minimum value: %w", err)
+	}
+	*m = Minimum(value)
+	return nil
 }
 
 // ExclusiveMinimum indicates that the minimum is "up to" but not including that value.
@@ -284,6 +320,15 @@ type Pattern string
 //
 // +controllertools:marker:generateHelp:category="CRD validation"
 type MaxItems int
+
+func (m *MaxItems) ParseMarker(_, name, restFields string) error {
+	value, err := strconv.Atoi(declarativeValidationMarkerValue(name, restFields))
+	if err != nil {
+		return fmt.Errorf("invalid maxItems value: %w", err)
+	}
+	*m = MaxItems(value)
+	return nil
+}
 
 // MinItems specifies the minimum length for this list.
 //

--- a/pkg/crd/testdata/declarativevalidation/types.go
+++ b/pkg/crd/testdata/declarativevalidation/types.go
@@ -1,0 +1,47 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=testdata.kubebuilder.io
+// +versionName=v1
+package declarativevalidation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// +kubebuilder:object:root=true
+type DeclarativeValidation struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec DeclarativeValidationSpec `json:"spec"`
+}
+
+// +kubebuilder:object:root=true
+type DeclarativeValidationList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []DeclarativeValidation `json:"items"`
+}
+
+type DeclarativeValidationSpec struct {
+	// +k8s:maxItems=2
+	Items []string `json:"items"`
+
+	// +k8s:minimum=-2
+	// +k8s:maximum=2 # Bounds the CEL validation cost.
+	Value int32 `json:"value"`
+}

--- a/pkg/crd/testdata/declarativevalidation_test.go
+++ b/pkg/crd/testdata/declarativevalidation_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cronjob
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("DeclarativeValidation CRD", func() {
+	newObj := func(name string, items []any, value int64) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "testdata.kubebuilder.io/v1",
+			"kind":       "DeclarativeValidation",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "default",
+			},
+			"spec": map[string]any{
+				"items": items,
+				"value": value,
+			},
+		}}
+	}
+
+	It("should accept values within the declarative validation bounds", func(ctx SpecContext) {
+		Expect(k8sClient.Create(ctx, newObj("valid-bounds", []any{"one", "two"}, 2))).To(Succeed())
+	})
+
+	It("should enforce k8s:maxItems", func(ctx SpecContext) {
+		err := k8sClient.Create(ctx, newObj("too-many-items", []any{"one", "two", "three"}, 0))
+		Expect(err).To(MatchError(ContainSubstring("must have at most 2 items")))
+	})
+
+	DescribeTable("should enforce numeric declarative validation bounds",
+		func(ctx SpecContext, name string, value int64, message string) {
+			err := k8sClient.Create(ctx, newObj(name, []any{}, value))
+			Expect(err).To(MatchError(ContainSubstring(message)))
+		},
+		Entry("minimum", "below-minimum", int64(-3), "greater than or equal to -2"),
+		Entry("maximum", "above-maximum", int64(3), "less than or equal to 2"),
+	)
+})

--- a/pkg/crd/testdata/suite_test.go
+++ b/pkg/crd/testdata/suite_test.go
@@ -38,6 +38,7 @@ func TestCRD(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{CRDInstallOptions: envtest.CRDInstallOptions{Paths: []string{
+		"testdata.kubebuilder.io_declarativevalidations.yaml",
 		"testdata.kubebuilder.io_emptyobjectdefaults.yaml",
 		"testdata.kubebuilder.io_enums.yaml",
 		"testdata.kubebuilder.io_immutabletypes.yaml",

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -694,6 +694,7 @@ spec:
                               required:
                               - name
                               type: object
+                            maxItems: 4
                             type: array
                             x-kubernetes-list-map-keys:
                             - name
@@ -726,6 +727,7 @@ spec:
                                   required:
                                   - key
                                   type: object
+                                maxItems: 1
                                 type: array
                                 x-kubernetes-list-type: atomic
                             type: object
@@ -758,6 +760,7 @@ spec:
                                       parallelism for a Job).
                                       If set, it must be a positive integer.
                                     format: int32
+                                    minimum: 1
                                     type: integer
                                 type: object
                             type: object
@@ -5195,12 +5198,15 @@ spec:
                                         The interval 0-999 is reserved for responders with *.k8s.io suffix.
                                         This field is required.
                                       format: int32
+                                      maximum: 100000
+                                      minimum: 0
                                       type: integer
                                   required:
                                   - name
                                   - priority
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                maxItems: 10
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/pkg/crd/testdata/testdata.kubebuilder.io_declarativevalidations.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_declarativevalidations.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
+  name: declarativevalidations.testdata.kubebuilder.io
+spec:
+  group: testdata.kubebuilder.io
+  names:
+    kind: DeclarativeValidation
+    listKind: DeclarativeValidationList
+    plural: declarativevalidations
+    singular: declarativevalidation
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              items:
+                items:
+                  type: string
+                maxItems: 2
+                type: array
+              value:
+                format: int32
+                maximum: 2
+                minimum: -2
+                type: integer
+            required:
+            - items
+            - value
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
This fixes an issue where `controller-gen` recognizes `+k8s:immutable` but silently drops the related bounds declared with:

- `+k8s:maxItems`
- `+k8s:minimum`
- `+k8s:maximum`

These bounds are used by the Kubernetes API server when estimating the cost of CEL validation rules. Dropping them can make an otherwise valid generated CRD exceed the CEL cost budget and be rejected, particularly when embedding Kubernetes types such as `batch/v1.JobSpec`.

This PR registers the three markers and maps them to the equivalent OpenAPI schema fields. It also supports the trailing comments used by Kubernetes declarative validation markers, for example:

```go
// +k8s:maximum=2 # Bounds the CEL validation cost.
```

The CRD golden fixtures have been updated to verify that these bounds are preserved in generated schemas.

Fixes #1473.
